### PR TITLE
Regression issue - restore working code in StandAloneProcessProxy

### DIFF
--- a/kernel_gateway/services/kernels/processproxy.py
+++ b/kernel_gateway/services/kernels/processproxy.py
@@ -187,6 +187,11 @@ class StandaloneProcessProxy(BaseProcessProxyABC):
 
         self.ip = self.determine_next_host()
 
+        # write out connection file - which has the remote IP - prior to copy...
+        self.kernel_manager.ip = gethostbyname(self.ip)  # convert to ip if host is provided
+        self.kernel_manager.cleanup_connection_file()
+        self.kernel_manager.write_connection_file()
+
         cmd = self.build_startup_command(kernel_cmd, **kw)
         self.log.debug('Invoking cmd: {}'.format(cmd))
         result_pid = 'bad_pid'  # purposely initialize to bad int value


### PR DESCRIPTION
The previous changes to add support for pulling connection files
introduced a bug in the StandAloneProcessProxy in order to properly
test pulls.  That change broke the previous push model (which is what
we want in that particular proxy) by not setting up the remote IP
correctly (left at 0.0.0.0).  This change restores the code to working
order.