### PR TITLE
[Issue #27] Add IPython kernel files (YARN Cluster mode)

### DIFF
--- a/etc/kernels/spark_2.1_python_yarn_cluster/bin/run.sh
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/bin/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo
+echo "Starting IPython kernel for Spark 2.1 in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
+
+if [ -z "${SPARK_HOME}" ]; then
+  echo "SPARK_HOME must be set to the location of a Spark distribution!"
+  exit 1
+fi
+
+PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+
+eval exec \
+     "${SPARK_HOME}/bin/spark-submit" \
+     "${SPARK_OPTS}" \
+     "${PROG_HOME}/scripts/launch_ipykernel.py" \
+     "$@"

--- a/etc/kernels/spark_2.1_python_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/kernel.json
@@ -1,0 +1,13 @@
+{
+  "language": "python",
+  "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
+  "remote_process_proxy_class": "kernel_gateway.services.kernels.processproxy.YarnProcessProxy",
+  "env": {
+    "SPARK_HOME": "/usr/iop/current/spark2-client",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}"
+  },
+  "argv": [
+    "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_cluster/bin/run.sh",
+    "{connection_file}"
+  ]
+}

--- a/etc/kernels/spark_2.1_python_yarn_cluster/scripts/launch_ipykernel.py
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/scripts/launch_ipykernel.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import sys
+from IPython import embed_kernel
+from pyspark.sql import SparkSession
+
+if __name__ == "__main__":
+    """
+        Usage: spark-submit launch_ipykernel [connection_file]
+    """
+    # create a Spark session
+    spark = SparkSession.builder.getOrCreate()
+
+    # setup Spark session variables
+    sc = spark.sparkContext
+    sql = spark.sql
+
+    # setup Spark legacy variables for compatibility
+    sqlContext = spark._wrapped
+    sqlCtx = sqlContext
+
+    # we may have a connection file
+    connection_file = sys.argv[1] if len(sys.argv) > 1 else ""
+
+    # prevent kernel from using the loop-back IP (127.0.0.1)
+    ip = "0.0.0.0"
+
+    # launch the IPython kernel instance
+    embed_kernel(connection_file=connection_file, ip=ip)
+
+    # stop the SparkContext after the kernel is stopped/killed
+    spark.stop()


### PR DESCRIPTION
Adding 3 new files under etc/kernels/spark_2.1_python_yarn_cluster/

- `kernel.json` (kernel spec)
- `run.sh` (calls spark-submit with launch_ipykernel.py)
- `launch_ipykernel.py` (Spark application that starts IPython kernel on YARN worker node)

The IPython kernel will create the specified connection file on the YARN worker node after determining available local ports.  _**Note**, @liukun1016 is preparing a separate PR to make sure that those communication ports are used._

**Note:** the kernel files assume user impersonation to be mandatory (`--proxy-user ...`) to not open up security holes. Developers who want to test without Kerberos in place, would have to remove the ` --proxy-user ${KERNEL_USERNAME...}` from the `SPARK_OPTS` in `kernel.json`.

We may want to consider adding a kernel install script, i.e. `dev/install-kernels.sh` which would copy the kernel files to the local Jupyter kernel directory. That script would also allow to take parameters to, for example, fill in the SPARK_HOME variable into the `kernel.json` files, or any other currently hard-coded values.

I will create another PR to add the kernel files for the Scala kernel.