### PR TITLE
[Issue #27] Support iPython kernel with YARN cluster mode

### DIFF
--- a/kernel_gateway/services/kernels/processproxy.py
+++ b/kernel_gateway/services/kernels/processproxy.py
@@ -447,8 +447,7 @@ class YarnProcessProxy(BaseProcessProxyABC):
             self.handle_timeout(time_interval, kernel_launch_timeout)
 
             if self.get_application_id(True):
-                if app_state != 'RUNNING':
-                    app_state = YarnProcessProxy.query_app_state_by_id(self.application_id)
+                app_state = YarnProcessProxy.query_app_state_by_id(self.application_id)
                 if host == '':
                     app = YarnProcessProxy.query_app_by_id(self.application_id)
                     if app and app.get('amHostHttpAddress'):


### PR DESCRIPTION
Adding the support for iPython kernel with YARN cluster mode, by pulling connection file from the running kernel host.

Other major refactoring: a separate method for handling timeout during kernel launch.