### PR TITLE
Add Scala kernel files for YARN Cluster mode (Toree)

### DIFF
--- a/etc/kernels/spark_2.1_scala_yarn_cluster/bin/run.sh
+++ b/etc/kernels/spark_2.1_scala_yarn_cluster/bin/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+echo
+echo "Starting Scala kernel for Spark 2.1 in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
+
+if [ -z "${SPARK_HOME}" ]; then
+  echo "SPARK_HOME must be set to the location of a Spark distribution!"
+  exit 1
+fi
+
+PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
+TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
+
+# The SPARK_OPTS values during installation are stored in __TOREE_SPARK_OPTS__. This allows values to be specified during
+# install, but also during runtime. The runtime options take precedence over the install options.
+if [ "${SPARK_OPTS}" = "" ]; then
+   SPARK_OPTS=${__TOREE_SPARK_OPTS__}
+fi
+
+if [ "${TOREE_OPTS}" = "" ]; then
+   TOREE_OPTS=${__TOREE_OPTS__}
+fi
+
+eval exec \
+     "${SPARK_HOME}/bin/spark-submit" \
+     "${SPARK_OPTS}" \
+     --class org.apache.toree.Main \
+     "${TOREE_ASSEMBLY}" \
+     "${TOREE_OPTS}" \
+     "$@"

--- a/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
@@ -1,0 +1,16 @@
+{
+  "language": "scala",
+  "display_name": "Spark 2.1 - Scala (YARN Cluster Mode)",
+  "remote_process_proxy_class": "kernel_gateway.services.kernels.processproxy.YarnProcessProxy",
+  "env": {
+    "SPARK_HOME": "/usr/iop/current/spark2-client",
+    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}",
+    "__TOREE_OPTS__": "",
+    "DEFAULT_INTERPRETER": "Scala"
+  },
+  "argv": [
+    "/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/bin/run.sh",
+    "--profile",
+    "{connection_file}"
+  ]
+}


### PR DESCRIPTION
### Proposed Changes:

Adding 2 new files under `etc/kernels/spark_2.1_scala_yarn_cluster/`
- `kernel.json` (kernel spec)
- `bin/run.sh` (calls `spark-submit` with class `org.apache.toree.Main`)

### Notes:

1. Requires [Apache Toree](http://toree.apache.org/docs/current/user/installation/) to be installed. The `kernel.json` and `run.sh` files are meant to replace the `kernel.json` and `run.sh` files created by the *Apache Toree* installer.

2. The kernel files assume user impersonation to be mandatory (`--proxy-user ...`) to not open up security holes. Developers who want to test without Kerberos in place, would have to remove the ` --proxy-user ${KERNEL_USERNAME...}` from the `__TOREE_SPARK_OPTS__` in `kernel.json`.

### Future Considerations:

We may want to remove the duplicated and stale `SPARK_HOME` and `SPARK_OPTS` environment variables from our kernel files (Scala, Python, R). Instead **either** ... 

- **(a)** the kernel manager could populate those environment variables when launching the kernel process. The values would be read from a configuration file, or JKG startup params, or have been exported into the environment that starts the JKG process ...

    -- or --

- **(b)** the `run.sh` files could `source` a common `conf/kernel-env.sh` script that exports those variables into the environment of the kernel process 