### PR TITLE
Add IRkernel files for R support

### DIFF
--- a/etc/kernels/spark_2.1_R_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/kernel.json
@@ -1,0 +1,13 @@
+{
+  "language": "R",
+  "display_name": "Spark 2.1 - R (YARN Cluster Mode)",
+  "remote_process_proxy_class": "kernel_gateway.services.kernels.processproxy.YarnProcessProxy",
+  "env": {
+    "SPARK_HOME": "/usr/iop/current/spark2-client",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --proxy-user ${KERNEL_USERNAME:-ERROR__NO__KERNEL_USERNAME}"
+  },
+  "argv": [
+    "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_cluster/run.sh",
+    "{connection_file}"
+  ]
+}

--- a/etc/kernels/spark_2.1_R_yarn_cluster/launch_IRkernel.R
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/launch_IRkernel.R
@@ -1,0 +1,26 @@
+library(IRkernel)
+library(SparkR)
+
+# Take in command line arguments (connection file)
+args <- commandArgs(trailingOnly = TRUE)
+
+# Make sure SparkR package is loaded at the last this is necessary
+# to avoid the need to fully qualify package namspace (using ::)
+old <- getOption("defaultPackages")
+options(defaultPackages = c(old, "SparkR"))
+
+# Initialize a new spark Session
+# Default to without Hive support for backward compatibility.
+spark <- SparkR::sparkR.session(enableHiveSupport = FALSE)
+assign("spark", spark, envir = .GlobalEnv)
+
+# Initialize spark context and sql context
+sc <- SparkR:::callJStatic("org.apache.spark.sql.api.r.SQLUtils", "getJavaSparkContext", spark)
+sqlContext <<- SparkR::sparkRSQL.init(sc);
+assign("sc", sc, envir = .GlobalEnv)
+
+# Pass in kernel connection file to R kernel
+IRkernel::main(args[1])
+
+# Stop the context and exit
+sparkR.session.stop()

--- a/etc/kernels/spark_2.1_R_yarn_cluster/run.sh
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ -z "${SPARK_HOME}" ]; then
+  echo "SPARK_HOME must be set to the location of a Spark distribution!"
+  exit 1
+fi
+
+echo
+echo "Starting IRkernel for Spark 2.1 in Yarn Cluster mode as user ${KERNEL_USERNAME:-UNSPECIFIED}"
+echo
+
+PROG_HOME="$(cd "`dirname "$0"`"/; pwd)"
+
+eval exec \
+     "${SPARK_HOME}/bin/spark-submit" \
+     "${SPARK_OPTS}" \
+     "${PROG_HOME}/launch_IRkernel.R" \
+     "$@"


### PR DESCRIPTION
3 files under etc/kernels/spark_2.1_R_yarn_cluster/

kernel.json - kernelspec file for JKG
launch_IRkernel.R - Starts a new spark session(2.x) as well as an older spark context and sql context . Takes in a connection file as a command line argument
run.sh - Runs spark submit passing in launch_IRkernel.R with its arguments