### PR TITLE
Initial changes for kernel session persistence.

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -32,6 +32,7 @@ from tornado.log import enable_pretty_logging, LogFormatter
 from notebook.notebookapp import random_ports
 from ._version import __version__
 from .services.sessions.sessionmanager import SessionManager
+from .services.sessions.kernelsessionmanager import KernelSessionManager
 from .services.kernels.remotemanager import RemoteMappingKernelManager
 from .services.kernelspecs.remotekernelspec import RemoteKernelSpecManager
 
@@ -387,6 +388,14 @@ class KernelGatewayApp(JupyterApp):
             log=self.log,
             kernel_manager=self.kernel_manager
         )
+
+        self.kernel_session_manager = KernelSessionManager(
+            log=self.log,
+            kernel_manager=self.kernel_manager
+        )
+        # Attempt to start persisted sessions
+        self.kernel_session_manager.start_sessions()
+
         self.contents_manager = None
 
         if self.prespawn_count:

--- a/kernel_gateway/services/kernels/remotemanager.py
+++ b/kernel_gateway/services/kernels/remotemanager.py
@@ -5,6 +5,8 @@
 import os
 from ipython_genutils.importstring import import_item
 from .manager import SeedingMappingKernelManager, KernelGatewayIOLoopKernelManager
+from tornado import gen
+from ipython_genutils.py3compat import (bytes_to_str, str_to_bytes)
 
 
 class RemoteMappingKernelManager(SeedingMappingKernelManager):
@@ -12,81 +14,118 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
 
     This class is responsible for managing remote kernels. 
     """
-    remote_process_proxy_class = None
+    process_proxy_class = None
 
     def _kernel_manager_class_default(self):
         return 'kernel_gateway.services.kernels.remotemanager.RemoteKernelManager'
 
-    def start_kernel(self, *args, **kwargs):
+    @gen.coroutine
+    def start_kernel(self, kernel_id=None, *args, **kwargs):
         self.log.debug("RemoteMappingKernelManager.start_kernel: {}".format(kwargs['kernel_name']))
-        if kwargs['kernel_name'] is not None:
+        if kwargs['kernel_name']:
             kernel_spec = self.kernel_spec_manager.get_kernel_spec(kwargs['kernel_name'])
-            if self.remote_process_proxy_class is not None:
-                # Detect remote type changes (when changing kernels) and reset remote
+            if self.process_proxy_class:
+                # Detect process proxy type changes (when changing kernels) and reset remote
                 # process proxy class if necessary.  Note, we need to keep the kernel_manager_class
                 # pointing at this RemoteKernelManager.  If a local kernel is desired, this multi-kernel
                 # manager will do the right thing.
                 #
-                if self.remote_process_proxy_class != kernel_spec.remote_process_proxy_class:
-                    self.log.debug("Detected remote_process_proxy_class change from %s to %s",
-                                   self.remote_process_proxy_class, kernel_spec.remote_process_proxy_class)
-                    self.remote_process_proxy_class = kernel_spec.remote_process_proxy_class
+                if self.process_proxy_class != kernel_spec.process_proxy_class:
+                    self.log.debug("Detected process_proxy_class change from %s to %s",
+                                   self.process_proxy_class, kernel_spec.process_proxy_class)
+                    self.process_proxy_class = kernel_spec.process_proxy_class
                     self.log.debug("Kernel manager class is {}".format(self.kernel_manager_class))
             else:
-                self.remote_process_proxy_class = kernel_spec.remote_process_proxy_class
-        return super(RemoteMappingKernelManager, self).start_kernel(*args, **kwargs)
+                self.process_proxy_class = kernel_spec.process_proxy_class
+        kernel_id = yield gen.maybe_future(super(RemoteMappingKernelManager, self).start_kernel(*args, **kwargs))
+        self.parent.kernel_session_manager.create_session(kernel_id, **kwargs)
+        raise gen.Return(kernel_id)
+
+    def remove_kernel(self, kernel_id):
+        super(RemoteMappingKernelManager, self).remove_kernel(kernel_id)
+        self.parent.kernel_session_manager.delete_session(kernel_id)
+
+    def start_kernel_from_session(self, kernel_id, kernel_name, connection_info, process_info, launch_args):
+        # Create a KernelManger instance and load connection and process info, then confirm the kernel is still
+        # alive.
+        constructor_kwargs = {}
+        if self.kernel_spec_manager:
+            constructor_kwargs['kernel_spec_manager'] = self.kernel_spec_manager
+
+        # Construct a kernel manager...
+        km = self.kernel_manager_factory(connection_file=os.path.join(
+            self.connection_dir, "kernel-%s.json" % kernel_id),
+            parent=self, log=self.log, kernel_name=kernel_name,
+            **constructor_kwargs)
+
+        km.load_connection_info(connection_info)
+        km.write_connection_file()
+
+        km._launch_args = launch_args
+
+        # Construct a process-proxy
+        if km.kernel_spec.process_proxy_class:
+            process_proxy_class = import_item(km.kernel_spec.process_proxy_class)
+            kw = {'env': {}}
+            km.process_proxy = process_proxy_class(km, **kw)
+            km.process_proxy.load_process_info(process_info)
+
+            # Confirm we can even poll the process.  If not, remove the persisted session.
+            if km.process_proxy.poll() is False:
+                return False
+
+        km.kernel = km.process_proxy
+        km.start_restarter()
+        km._connect_control_socket()
+        self._kernels[kernel_id] = km
+        self._kernel_connections[kernel_id] = 0
+        self.start_watching_activity(kernel_id)
+        self.add_restart_callback(kernel_id,
+            lambda: self._handle_kernel_died(kernel_id),
+            'dead',
+        )
+        self.initialize_culler()
+        return True
 
 
 class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
     """Extends the KernelGatewayIOLoopKernelManager used by the RemoteMappingKernelManager.
 
     This class is responsible for detecting that a remote kernel is desired, then launching the 
-    appropriate class (previously pulled from the kernel spec).  The remote process 'proxy' is
+    appropriate class (previously pulled from the kernel spec).  The process 'proxy' is
     returned - upon which methods of poll(), wait(), send_signal(), and kill() can be called.
     """
-    remote_process = None
-#    conflicting_port = int(os.getenv('ELYRA_TEST_CONFLICTING_PORT', '0'))
+    process_proxy = None
 
     def start_kernel(self, **kw):
-        if self.kernel_spec.remote_process_proxy_class is not None:
-            self.log.debug("Instantiating remote kernel proxy: {}".format(self.kernel_spec.display_name))
-            remote_process_class = import_item(self.kernel_spec.remote_process_proxy_class)
-            self.remote_process = remote_process_class(self, **kw)
+        if self.kernel_spec.process_proxy_class:
+            self.log.debug("Instantiating kernel '{}' with process proxy: {}".
+                           format(self.kernel_spec.display_name, self.kernel_spec.process_proxy_class))
+            process_proxy_class = import_item(self.kernel_spec.process_proxy_class)
+            self.process_proxy = process_proxy_class(self, **kw)
             self.ip = '0.0.0.0'  # use the zero-ip from the start, can prevent having to write out connection file again
 
         return super(RemoteKernelManager, self).start_kernel(**kw)
 
-    def format_kernel_cmd(self, extra_arguments=None):
-        """Override for remote kernels so that we can have the kernel command built with a reference to the connection
-           file (potentially) relative to the destination system, not this local system.  
-        """
-        if self.kernel_spec.remote_process_proxy_class is not None:
-            local_connection_file = self.connection_file
-            self.connection_file = self.remote_process.get_connection_filename()
-            cmd = super(RemoteKernelManager, self).format_kernel_cmd(extra_arguments)
-            self.log.debug("Formatted remote kernel cmd is: '{}'".format(cmd))
-            self.connection_file = local_connection_file
-            return cmd
-
-        return super(RemoteKernelManager, self).format_kernel_cmd(extra_arguments)
-
     def _launch_kernel(self, kernel_cmd, **kw):
-        if self.kernel_spec.remote_process_proxy_class is not None:
-            self.log.debug("Launching remote kernel: {}".format(self.kernel_spec.display_name))
-            return self.remote_process.launch_process(kernel_cmd, **kw)
+        if self.kernel_spec.process_proxy_class:
+            self.log.debug("Launching kernel: {}".format(self.kernel_spec.display_name))
+            return self.process_proxy.launch_process(kernel_cmd, **kw)
 
         return super(RemoteKernelManager, self)._launch_kernel(kernel_cmd, **kw)
 
     def restart_kernel(self, now=False, **kw):
-        self.reset_connections()
         super(RemoteKernelManager, self).restart_kernel(now, **kw)
+        # Refresh persisted state.
+        kernel_id = os.path.basename(self.connection_file).replace('kernel-', '').replace('.json', '')
+        self.log.debug("RemoteKernelManager.restart_kernel: refreshing session for: {}".format(kernel_id))
+        self.parent.parent.kernel_session_manager.refresh_session(kernel_id)
 
     def signal_kernel(self, signum):
         """Need to override base method because it tries to send a signal to the (local)
            process group - so we bypass that code this way.
         """
         self.log.debug("RemoteKernelManager.signal_kernel({})".format(signum))
-
         if self.has_kernel:
             self.kernel.send_signal(signum)
         else:
@@ -94,42 +133,25 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
 
     def cleanup(self, connection_file=True):
         """Clean up resources when the kernel is shut down"""
-        if self.kernel_spec.remote_process_proxy_class is not None:
+        if self.kernel_spec.process_proxy_class:
             if self.has_kernel:
                 self.kernel.cleanup()
-
         return super(RemoteKernelManager, self).cleanup(connection_file)
 
+    def get_connection_info(self, session=False):
+        info = super(RemoteKernelManager, self).get_connection_info(session)
+        # Convert bytes to string for persistence.  Will reverse operation in load_connection_info
+        info['key'] = bytes_to_str(info['key'])
+        return info
+
+    def load_connection_info(self, info):
+        # get the key back to bytes...
+        info['key'] = str_to_bytes(info['key'])
+        return super(RemoteKernelManager, self).load_connection_info(info)
+
     def write_connection_file(self):
+        # Override purely for debug purposes
         self.log.debug(
             "RemoteKernelManager: Writing connection file with ip={}, control={}, hb={}, iopub={}, stdin={}, shell={}"
             .format(self.ip, self.control_port, self.hb_port, self.iopub_port, self.stdin_port, self.shell_port))
         return super(RemoteKernelManager, self).write_connection_file()
-
-    def reset_connections(self):
-        """Need to override and temporarily reset the ip to a local ip to avoid the check about non-local ip usage.
-           The ip will be overwritten with an appropriate ip address when _launch_kernel is called and the process
-           proxy is created.  In addition, since we have a higher propensity for port conflicts, assume that's the
-           case for restart and reset the ports - which requires a rebuild of the connection file.
-        """
-        self.ip = '0.0.0.0'
-        self.stdin_port = 0
-        self.iopub_port = 0
-        self.shell_port = 0
-        self.hb_port = 0
-        self.control_port = 0
-        self.cleanup_connection_file()
-#        self.conflicting_port = 0  - To be removed - FIXME
-#
-#    def testPortConflict(self):
-#        if self.conflicting_port > 0:
-#            self.control_port = self.conflicting_port
-#            self.stdin_port = self.conflicting_port + 1
-#            self.iopub_port = self.conflicting_port + 2
-#            self.shell_port = self.conflicting_port + 3
-#            self.hb_port = self.conflicting_port + 4
-#
-#    def start_kernel(self, **kw):
-#        self.testPortConflict()  - To be removed - FIXME
-#        super(RemoteKernelManager, self).start_kernel(**kw)
-#

--- a/kernel_gateway/services/kernelspecs/remotekernelspec.py
+++ b/kernel_gateway/services/kernelspecs/remotekernelspec.py
@@ -15,15 +15,17 @@ class RemoteKernelSpec(KernelSpec):
     """RemoteKernelSpec is a subclass to identify and process attributes relative to remote kernel support.
     
     """
-    remote_process_proxy_class = None
+    process_proxy_class = None
 
     def __init__(self, resource_dir, **kernel_dict):
         super(RemoteKernelSpec, self).__init__(resource_dir, **kernel_dict)
         if 'remote_process_proxy_class' in kernel_dict and kernel_dict['remote_process_proxy_class'] is not None:
-            self.remote_process_proxy_class = kernel_dict['remote_process_proxy_class']
+            self.process_proxy_class = kernel_dict['remote_process_proxy_class']
+        else: # ensure all kernelspecs have a process proxy entry
+            self.process_proxy_class = 'kernel_gateway.services.kernels.processproxy.LocalProcessProxy'
 
     def to_dict(self):
         d = super(RemoteKernelSpec, self).to_dict()
-        d.update({'remote_process_proxy_class': self.remote_process_proxy_class})
+        d.update({'remote_process_proxy_class': self.process_proxy_class})
         print("kernel_dict: %r" % d)
         return d

--- a/kernel_gateway/services/sessions/kernelsessionmanager.py
+++ b/kernel_gateway/services/sessions/kernelsessionmanager.py
@@ -1,0 +1,131 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Session manager that keeps all its metadata in memory."""
+
+import os
+from traitlets.config.configurable import LoggingConfigurable
+from jupyter_core.paths import jupyter_data_dir
+import json
+
+
+import threading
+kernels_lock = threading.Lock()
+
+
+class KernelSessionManager(LoggingConfigurable):
+    """
+        KernelSessionManager is used to manage kernel sessions.  It loads the complete set of persisted kernel
+        sessions during construction.  Following construction the parent object calls start_sessions to allow
+        Elyra to validate that all loaded sessions are still valid.  Those that it cannot 'revive' are marked
+        for deletion and the in-memory dictionary is updated - and the entire collection is written to store
+        (file or database).
+        
+        As kernels are created and destroyed, the KernelSessionManager is called upon to keep kernel session
+        state consistent.
+    """
+    def __init__(self, kernel_manager, **kwargs):
+        super(KernelSessionManager, self).__init__(**kwargs)
+        self.kernel_manager = kernel_manager
+        self._sessions = dict()
+        self.kernel_session_file = os.path.join(self.get_sessions_loc(), 'kernels.json')
+        self._load_sessions()
+
+    def create_session(self, kernel_id, **kwargs):
+        # Persists information about the kernel session within the designated repository.
+
+        km = self.kernel_manager.get_kernel(kernel_id)
+
+        # Compose the kernel_session entry
+        kernel_session = dict()
+        kernel_session['kernel_id'] = kernel_id
+        kernel_session['username'] = kwargs['env']['KERNEL_USERNAME']
+        kernel_session['kernel_name'] = km.kernel_name
+
+        # Build the inner dictionaries: connection_info, process_proxy and add to kernel_session
+        kernel_session['connection_info'] = km.get_connection_info()
+        kernel_session['launch_args'] = kwargs.copy()
+        kernel_session['process_info'] = km.process_proxy.get_process_info() if km.process_proxy else {}
+        self._save_session(kernel_id, kernel_session)
+
+    def refresh_session(self, kernel_id, **kwargs):
+        # Persists information about the kernel session within the designated repository.
+
+        km = self.kernel_manager.get_kernel(kernel_id)
+
+        # Compose the kernel_session entry
+        kernel_session = self._sessions[kernel_id]
+
+        # Build the inner dictionaries: connection_info, process_proxy and add to kernel_session
+        kernel_session['connection_info'] = km.get_connection_info()
+        kernel_session['process_info'] = km.process_proxy.get_process_info() if km.process_proxy else {}
+        self._save_session(kernel_id, kernel_session)
+
+    def _save_session(self, kernel_id, kernel_session):
+        # Write/commit the addition, update dictionary
+        kernels_lock.acquire()
+        try:
+            self._sessions[kernel_id] = kernel_session
+            self._commit_sessions()  # persist changes
+        finally:
+            kernels_lock.release()
+
+    def _load_sessions(self):
+        # Read directory/table and initialize _sessions member.  Must be called from constructor.
+        if os.path.exists(self.kernel_session_file):
+            self.log.debug("Loading saved sessions from {}".format(self.kernel_session_file))
+            with open(self.kernel_session_file) as fp:
+                self._sessions = json.load(fp)
+                fp.close()
+
+    def start_sessions(self):
+        # Track which sessions didn't restart...
+        sessions_to_remove = []
+        for kernel_id, kernel_session in self._sessions.items():
+            if not self._start_session(kernel_session):
+                sessions_to_remove.append(kernel_id)
+
+        self._delete_sessions(sessions_to_remove)
+
+    def _start_session(self, kernel_session):
+        # Attempt to start kernel from persisted state.  if started, record kernel_session in dictionary
+        # else delete session
+        kernel_id = kernel_session['kernel_id']
+        kernel_started = self.kernel_manager.start_kernel_from_session(kernel_id=kernel_id,
+                                                                kernel_name=kernel_session['kernel_name'],
+                                                                connection_info=kernel_session['connection_info'],
+                                                                process_info=kernel_session['process_info'],
+                                                                launch_args=kernel_session['launch_args'])
+        if not kernel_started:
+            return False
+
+        self.log.info("Started persisted kernel session for id: %s" % kernel_id)
+        return True
+
+    def delete_session(self, kernel_id):
+        # Removes saved session from dictionary and persisted store
+        self._delete_sessions([kernel_id])
+        self.log.info("Deleted persisted kernel session for id: %s" % kernel_id)
+
+    def _delete_sessions(self, kernel_ids):
+        # Remove unstarted sessions and rewrite
+        kernels_lock.acquire()
+        try:
+            for kernel_id in kernel_ids:
+                self._sessions.pop(kernel_id, None)
+
+            self._commit_sessions()  # persist changes
+        finally:
+            kernels_lock.release()
+
+    def _commit_sessions(self):
+        # Commits the sessions dictionary to persistent store.  Caller is responsible for single-threading call.
+        with open(self.kernel_session_file, 'w') as fp:
+            json.dump(self._sessions, fp)
+            fp.close()
+
+    @staticmethod
+    def get_sessions_loc():
+        path = os.path.join(jupyter_data_dir(), 'sessions')
+        if not os.path.exists(path):
+            os.makedirs(path, 0o755)
+        return path


### PR DESCRIPTION
1. All kernels use a process proxy (created `LocalProcessProxy`). This enables kernel session persistence for all kernel types.
2. All process proxy instances can get/load internal state (to/from json).
3. Kernel manager saves kernel-session after kernel starts and deletes kernel-session on
shutdown.  KernelSessionManager loads persisted sessions at startup and attempts to reconnect to each. Internal kernel restarts trigger refresh of persisted sessions.
4. `KERNEL_LAUNCH_TIMEOUT` is honored by YarnProcessProxy - default is `ELYRA_KERNEL_LAUNCH_TIMEOUT` (30). Override allows per-user launch timeouts.
5. Same path to connection file used on all nodes to simplify configurations and code (requires directory structure on worker nodes).
6. Loopback file copy is detected - else can render a zero-length file.
7. Some logging cleanup (particularly via poll methods) and general refactoring due to session persistence occurred (e.g., a process proxy that was local could now be remote on restart or vice versa).