### PR TITLE
[Issue #44] Detect older versions of notebook that do not contain culling feature.

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -384,6 +384,11 @@ class KernelGatewayApp(JupyterApp):
             **kwargs
         )
 
+        # Detect older version of notebook
+        func = getattr(self.kernel_manager, 'initialize_culler', None)
+        if not func:
+            self.log.warning("Older version of Notebook detected - idle kernels will not be culled.  Culling requires Notebook >= 5.1.0.")
+
         self.session_manager = SessionManager(
             log=self.log,
             kernel_manager=self.kernel_manager

--- a/kernel_gateway/services/kernels/remotemanager.py
+++ b/kernel_gateway/services/kernels/remotemanager.py
@@ -68,7 +68,10 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
             lambda: self._handle_kernel_died(kernel_id),
             'dead',
         )
-        self.initialize_culler()
+        # Only initialize culling if available.  Warning message will be issued in gatewayapp at startup.
+        func = getattr(self, 'initialize_culler', None)
+        if func:
+            func()
         return True
 
 


### PR DESCRIPTION
If older versions of notebook (< 5.1.0) installed, the idle kernel
culling functionality is not present.  This can lead to a failure to
start Elyra in cases where Elyra was shutdown with active kernels.  In
those cases, Elyra's restart will try to activate those kernels and, if
they can be activated, the idle kernel culler initialization is called.
This call then produces an AttributeError exception if an older version
of notebook is present.

This change was tested by installing a pre-culling version of notebook.
In such cases, Elyra startup will produce a similar sequence of messages.
This example also shows messages produced when persisted kernel sessions
have been revived:
```
[W 2017-06-30 07:46:28.312 KernelGatewayApp] Config option `cull_idle_timeout` not recognized by `RemoteMappingKernelManager`.
[W 2017-06-30 07:46:28.312 KernelGatewayApp] Config option `cull_interval` not recognized by `RemoteMappingKernelManager`.
[W 2017-06-30 07:46:28.312 KernelGatewayApp] Older version of Notebook detected - idle kernels will not be culled.  Culling requires Notebook >= 5.1.0.
[D 2017-06-30 07:46:28.313 KernelGatewayApp] Loading saved sessions from /var/lib/elyra/sessions/kernels.json
[D 2017-06-30 07:46:28.326 KernelGatewayApp] RemoteKernelManager: Writing connection file with ip=172.16.190.111, control=35894, hb=52273, iopub=60800, stdin=35425, shell=51351
[D 2017-06-30 07:46:28.610 KernelGatewayApp] Found kernel spark_2.1_scala_sa in /usr/local/share/jupyter/kernels
[D 2017-06-30 07:46:28.610 KernelGatewayApp] Found kernel apache_toree_scala in /usr/local/share/jupyter/kernels
[D 2017-06-30 07:46:28.610 KernelGatewayApp] Found kernel spark_2.1_scala_yarn in /usr/local/share/jupyter/kernels
[D 2017-06-30 07:46:28.610 KernelGatewayApp] Found kernel spark_2.1_python_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2017-06-30 07:46:28.611 KernelGatewayApp] Native kernel (python2) available from /opt/anaconda2/lib/python2.7/site-packages/ipykernel/resources
[D 2017-06-30 07:46:28.632 KernelGatewayApp] BaseProcessProxy env: {'KERNEL_ID': u'60ec72f2-b584-4906-b0de-2d1ca48e69f5'}
[D 2017-06-30 07:46:28.645 KernelGatewayApp] Connecting to: tcp://172.16.190.111:35894
[D 2017-06-30 07:46:28.647 KernelGatewayApp] Connecting to: tcp://172.16.190.111:60800
[I 2017-06-30 07:46:28.648 KernelGatewayApp] Started persisted kernel session for id: 60ec72f2-b584-4906-b0de-2d1ca48e69f5
[I 2017-06-30 07:46:28.656 KernelGatewayApp] Jupyter Kernel Gateway at http://0.0.0.0:8888
```