### PR TITLE
[Issue #45] Make sure connection file is still produced when pull mode is enabled.

### DIFF
--- a/etc/kernels/spark_2.1_python_yarn_cluster/scripts/launch_ipykernel.py
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/scripts/launch_ipykernel.py
@@ -1,4 +1,4 @@
-import sys
+import os.path
 import socket
 import json
 import uuid
@@ -9,14 +9,18 @@ from IPython import embed_kernel
 from pyspark.sql import SparkSession
 
 
-def return_connection_info(connection_file, ip, reponse_addr):
+def return_connection_info(connection_file, ip, response_addr):
     response_parts = response_addr.split(":")
+    if len(response_parts) != 2:
+        print("Invalid format for response address '{}'.  Assuming 'pull' mode...".format(response_addr))
+        return
+
     response_ip = response_parts[0]
-    response_port = int(response_parts[1])
-
-    key = str_to_bytes(str(uuid.uuid4()))
-
-    write_connection_file(fname=connection_file, ip=ip, key=key)
+    try:
+        response_port = int(response_parts[1])
+    except ValueError:
+        print("Invalid port component found in response address '{}'.  Assuming 'pull' mode...".format(response_addr))
+        return
 
     with open(connection_file) as fp:
         cf_json = json.load(fp)
@@ -28,6 +32,7 @@ def return_connection_info(connection_file, ip, reponse_addr):
         s.send(json.dumps(cf_json).encode(encoding='utf-8'))
     finally:
         s.close()
+
 
 if __name__ == "__main__":
     """
@@ -54,8 +59,14 @@ if __name__ == "__main__":
 
     ip = "0.0.0.0"
 
-    if response_addr:
-        return_connection_info(connection_file, ip, response_addr)
+    # If the connection file doesn't exist, then we're using 'pull' or 'socket' mode - otherwise 'push' mode.
+    # If 'pull' or 'socket', create the file, then return it to server (if response address provided, i.e., 'socket')
+    if not os.path.isfile(connection_file):
+        key = str_to_bytes(str(uuid.uuid4()))
+        write_connection_file(fname=connection_file, ip=ip, key=key)
+
+        if response_addr:
+            return_connection_info(connection_file, ip, response_addr)
 
     # launch the IPython kernel instance
     embed_kernel(connection_file=connection_file, ip=ip)


### PR DESCRIPTION
Other changes.
1. Added checks that if the connection file already exists, then we'll assume 'push' mode.
2. Added some validation of the response address parameter since users may forget to remove that parameter from the LAUNCH_OPTS variable.  In such cases, they will encounter ERROR__NO__KERNEL_RESPONSE_ADDRESS as the response-address parameter value.  If we find that the response address cannot be split into two pieces on ':' or if the port portion of that split is not an int(), then assume 'pull' mode has been specified and just return.