### PR TITLE
Ignore additional interrupt attempts after receiving the first.

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -529,6 +529,8 @@ class KernelGatewayApp(JupyterApp):
             self.io_loop.start()
         except KeyboardInterrupt:
             self.log.info("Interrupted...")
+            # Ignore further interrupts (ctrl-c)
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
         finally:
             self.shutdown()
 


### PR DESCRIPTION
This PR addresses issue #55.

When Elyra is started in the foreground, entering control-c from the
keyboard will interrupt the IO loop and trigger the graceful shutdown
of the service - which includes attempts to shutdown any active kernels.

However, if a second interrupt (control-c) is issued during the shutdown,
that interrupt will terminate the graceful shutdown activities taking
place.  

This change explicitly ignores additional interrupt signals,
thereby permitting the original shutdown sequence to complete.