### PR TITLE
Fix for syntax error in launch_IRkernel script

### DIFF
--- a/etc/kernels/spark_2.1_R_yarn_cluster/scripts/launch_IRkernel.R
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/scripts/launch_IRkernel.R
@@ -71,7 +71,7 @@ if (!file.exists(argv$connection_file)){
 
     system(python_cmd)
 
-    if (length(argv$response_address){
+    if (length(argv$response_address)){
       return_connection_info(argv$connection_file, local_ip, argv$response_address)
     }
 }


### PR DESCRIPTION
Missing a closing parenthesis... 