### PR TITLE
Remove write_connection_file when loading from persisted sessions.

### DIFF
--- a/kernel_gateway/services/kernels/remotemanager.py
+++ b/kernel_gateway/services/kernels/remotemanager.py
@@ -42,8 +42,8 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
             parent=self, log=self.log, kernel_name=kernel_name,
             **constructor_kwargs)
 
+        # Load connection info into member vars - no need to write out connection file
         km.load_connection_info(connection_info)
-        km.write_connection_file()
 
         km._launch_args = launch_args
 


### PR DESCRIPTION
Since loopback mode could yield connection files owned by non-elyra
users (e.g., yarn), writing the connection file when recovering those
sessions can result in permission issues (Issue #74).  Since we don't
need to write the connection file at all, we should remove the call
altogether - because the connection file isn't used following a kernel's
initial startup.