### PR TITLE
Tolerate missing env when starting kernels

### DIFF
--- a/kernel_gateway/services/kernels/pool.py
+++ b/kernel_gateway/services/kernels/pool.py
@@ -28,7 +28,7 @@ class KernelPool(object):
         # Make sure we've got a int
         if not prespawn_count:
             prespawn_count = 0
-        env = dict(os.environ)
+        env = dict(os.environ.copy())
         env['KERNEL_USERNAME'] = prespawn_username
         for _ in range(prespawn_count):
             self.kernel_manager.start_seeded_kernel(env=env)

--- a/kernel_gateway/services/sessions/kernelsessionmanager.py
+++ b/kernel_gateway/services/sessions/kernelsessionmanager.py
@@ -11,7 +11,6 @@ import json
 import threading
 kernels_lock = threading.Lock()
 
-
 class KernelSessionManager(LoggingConfigurable):
     """
         KernelSessionManager is used to manage kernel sessions.  It loads the complete set of persisted kernel
@@ -27,7 +26,7 @@ class KernelSessionManager(LoggingConfigurable):
         super(KernelSessionManager, self).__init__(**kwargs)
         self.kernel_manager = kernel_manager
         self._sessions = dict()
-        self.kernel_session_file = os.path.join(self.get_sessions_loc(), 'kernels.json')
+        self.kernel_session_file = os.path.join(self._get_sessions_loc(), 'kernels.json')
         self._load_sessions()
 
     def create_session(self, kernel_id, **kwargs):
@@ -38,7 +37,7 @@ class KernelSessionManager(LoggingConfigurable):
         # Compose the kernel_session entry
         kernel_session = dict()
         kernel_session['kernel_id'] = kernel_id
-        kernel_session['username'] = kwargs['env']['KERNEL_USERNAME']
+        kernel_session['username'] = self._get_kernel_username(kwargs.get('env',{}))
         kernel_session['kernel_name'] = km.kernel_name
 
         # Build the inner dictionaries: connection_info, process_proxy and add to kernel_session
@@ -124,8 +123,12 @@ class KernelSessionManager(LoggingConfigurable):
             fp.close()
 
     @staticmethod
-    def get_sessions_loc():
+    def _get_sessions_loc():
         path = os.path.join(jupyter_data_dir(), 'sessions')
         if not os.path.exists(path):
             os.makedirs(path, 0o755)
         return path
+
+    @staticmethod
+    def _get_kernel_username(env_dict):
+        return env_dict.get('KERNEL_USERNAME', 'unspecified')


### PR DESCRIPTION
Elyra currently assumes an environment variable (env) exists in the set
of arguments to starting a kernel. However, when starting a kernel
directly via the REST API, env is does not exist. This change establishes
an env if one does not exist and adds `KERNEL_ID` so that remote kernels
can be launched.

The session persistence stores the value of `KERNEL_USERNAME` and had been
assuming its existence.  This change also tolerates that value not being
present.

Updated the pool code to use a copy of the environment since that is a
better practice.

Closes #87