### PR TITLE
Remove --response-address parameter from kernel.json LAUNCH_OPTS

### DIFF
--- a/etc/kernels/spark_2.1_R_yarn_client/kernel.json
+++ b/etc/kernels/spark_2.1_R_yarn_client/kernel.json
@@ -8,7 +8,7 @@
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
-    "LAUNCH_OPTS": "--response-address ${KERNEL_RESPONSE_ADDRESS:-ERROR__NO__KERNEL_RESPONSE_ADDRESS}"
+    "LAUNCH_OPTS": ""
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_client/bin/run.sh",

--- a/etc/kernels/spark_2.1_R_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/kernel.json
@@ -8,7 +8,7 @@
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
-    "LAUNCH_OPTS": "--response-address ${KERNEL_RESPONSE_ADDRESS:-ERROR__NO__KERNEL_RESPONSE_ADDRESS}"
+    "LAUNCH_OPTS": ""
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_cluster/bin/run.sh",

--- a/etc/kernels/spark_2.1_python_yarn_client/kernel.json
+++ b/etc/kernels/spark_2.1_python_yarn_client/kernel.json
@@ -8,7 +8,7 @@
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
-    "LAUNCH_OPTS": "--response-address ${KERNEL_RESPONSE_ADDRESS:-ERROR__NO__KERNEL_RESPONSE_ADDRESS}"
+    "LAUNCH_OPTS": ""
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_client/bin/run.sh",

--- a/etc/kernels/spark_2.1_python_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/kernel.json
@@ -8,7 +8,7 @@
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
-    "LAUNCH_OPTS": "--response-address ${KERNEL_RESPONSE_ADDRESS:-ERROR__NO__KERNEL_RESPONSE_ADDRESS}"
+    "LAUNCH_OPTS": ""
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_cluster/bin/run.sh",

--- a/etc/kernels/spark_2.1_scala_yarn_client/kernel.json
+++ b/etc/kernels/spark_2.1_scala_yarn_client/kernel.json
@@ -9,7 +9,7 @@
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",
     "__TOREE_OPTS__": "",
-    "LAUNCH_OPTS": "--response-address ${KERNEL_RESPONSE_ADDRESS:-ERROR__NO__KERNEL_RESPONSE_ADDRESS}",
+    "LAUNCH_OPTS": "",
     "DEFAULT_INTERPRETER": "Scala"
   },
   "argv": [

--- a/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
@@ -9,7 +9,7 @@
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
     "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
     "__TOREE_OPTS__": "",
-    "LAUNCH_OPTS": "--response-address ${KERNEL_RESPONSE_ADDRESS:-ERROR__NO__KERNEL_RESPONSE_ADDRESS}",
+    "LAUNCH_OPTS": "",
     "DEFAULT_INTERPRETER": "Scala"
   },
   "argv": [


### PR DESCRIPTION
This change removes the --response-address parameter from the `LAUNCH_OPTS` env variable specified in the kernel.json.  Instead, whenever `socket` mode is used, Elyra will modify the kernel run command to include the parameter.

The `LAUNCH_OPTS` variable will remain in the kernel.json file but will default to the empty string, since this will still allow users to influence their launcher if necessary.

This change is a precursor to Issues #80, #90 and #91.

Closes #78