### PR TITLE
Remove push and pull connection file modes

### DIFF
--- a/etc/kernels/spark_2.1_R_yarn_client/kernel.json
+++ b/etc/kernels/spark_2.1_R_yarn_client/kernel.json
@@ -2,8 +2,7 @@
   "language": "R",
   "display_name": "Spark 2.1 - R (YARN Client Mode)",
   "process_proxy": {
-    "class_name": "kernel_gateway.services.kernels.processproxy.DistributedProcessProxy",
-    "connection_file_mode": "socket"
+    "class_name": "kernel_gateway.services.kernels.processproxy.DistributedProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -12,6 +11,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_client/bin/run.sh",
-    "{connection_file}"
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}"
   ]
 }

--- a/etc/kernels/spark_2.1_R_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/kernel.json
@@ -2,8 +2,7 @@
   "language": "R",
   "display_name": "Spark 2.1 - R (YARN Cluster Mode)",
   "process_proxy": {
-    "class_name": "kernel_gateway.services.kernels.processproxy.YarnClusterProcessProxy",
-    "connection_file_mode": "socket"
+    "class_name": "kernel_gateway.services.kernels.processproxy.YarnClusterProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -12,6 +11,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_R_yarn_cluster/bin/run.sh",
-    "{connection_file}"
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}"
   ]
 }

--- a/etc/kernels/spark_2.1_python_yarn_client/kernel.json
+++ b/etc/kernels/spark_2.1_python_yarn_client/kernel.json
@@ -2,8 +2,7 @@
   "language": "python",
   "display_name": "Spark 2.1 - Python (YARN Client Mode)",
   "process_proxy": {
-    "class_name": "kernel_gateway.services.kernels.processproxy.DistributedProcessProxy",
-    "connection_file_mode": "socket"
+    "class_name": "kernel_gateway.services.kernels.processproxy.DistributedProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -12,6 +11,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_client/bin/run.sh",
-    "{connection_file}"
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}"
   ]
 }

--- a/etc/kernels/spark_2.1_python_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/kernel.json
@@ -2,8 +2,7 @@
   "language": "python",
   "display_name": "Spark 2.1 - Python (YARN Cluster Mode)",
   "process_proxy": {
-    "class_name": "kernel_gateway.services.kernels.processproxy.YarnClusterProcessProxy",
-    "connection_file_mode": "socket"
+    "class_name": "kernel_gateway.services.kernels.processproxy.YarnClusterProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -12,6 +11,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_python_yarn_cluster/bin/run.sh",
-    "{connection_file}"
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}"
   ]
 }

--- a/etc/kernels/spark_2.1_scala_yarn_client/kernel.json
+++ b/etc/kernels/spark_2.1_scala_yarn_client/kernel.json
@@ -2,8 +2,7 @@
   "language": "scala",
   "display_name": "Spark 2.1 - Scala (YARN Client Mode)",
   "process_proxy": {
-    "class_name": "kernel_gateway.services.kernels.processproxy.DistributedProcessProxy",
-    "connection_file_mode": "socket"
+    "class_name": "kernel_gateway.services.kernels.processproxy.DistributedProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -15,6 +14,8 @@
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_client/bin/run.sh",
     "--profile",
-    "{connection_file}"
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}"
   ]
 }

--- a/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
@@ -2,8 +2,7 @@
   "language": "scala",
   "display_name": "Spark 2.1 - Scala (YARN Cluster Mode)",
   "process_proxy": {
-    "class_name": "kernel_gateway.services.kernels.processproxy.YarnClusterProcessProxy",
-    "connection_file_mode": "socket"
+    "class_name": "kernel_gateway.services.kernels.processproxy.YarnClusterProcessProxy"
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -15,6 +14,8 @@
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_2.1_scala_yarn_cluster/bin/run.sh",
     "--profile",
-    "{connection_file}"
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}"
   ]
 }

--- a/kernel_gateway/services/kernelspecs/remotekernelspec.py
+++ b/kernel_gateway/services/kernelspecs/remotekernelspec.py
@@ -15,20 +15,15 @@ class RemoteKernelSpec(KernelSpec):
     """RemoteKernelSpec is a subclass to identify and process attributes relative to remote kernel support.
     
     """
-
     def __init__(self, resource_dir, **kernel_dict):
         super(RemoteKernelSpec, self).__init__(resource_dir, **kernel_dict)
         # defaults...
         self.process_proxy_class = 'kernel_gateway.services.kernels.processproxy.LocalProcessProxy'
-        self.process_proxy_connection_file_mode = None
 
         if 'process_proxy' in kernel_dict and kernel_dict['process_proxy']:
             self.process_proxy_class = kernel_dict['process_proxy']['class_name']
-            if kernel_dict['process_proxy']['connection_file_mode']:
-                self.process_proxy_connection_file_mode = kernel_dict['process_proxy']['connection_file_mode'].lower()
 
     def to_dict(self):
         d = super(RemoteKernelSpec, self).to_dict()
-        d.update({'process_proxy': {'class_name': self.process_proxy_class,
-                                    'connection_file_mode': self.process_proxy_connection_file_mode}})
+        d.update({'process_proxy': {'class_name': self.process_proxy_class}})
         return d


### PR DESCRIPTION
Removed/refactored code and kernel.json references to connection file modes for `push` and `pull`.  This simplifies the user and support experiences.

Added formal definition of response-address argument to kernel.json files since we only support socket mode.

Updated Elyra.md to reflect recent changes.

Closes #91