### PR TITLE
Update process proxy constructor when loading persisted sessions

### DIFF
--- a/kernel_gateway/services/kernels/remotemanager.py
+++ b/kernel_gateway/services/kernels/remotemanager.py
@@ -52,7 +52,7 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
         if km.kernel_spec.process_proxy_class:
             process_proxy_class = import_item(km.kernel_spec.process_proxy_class)
             kw = {'env': {}}
-            km.process_proxy = process_proxy_class(km, km.kernel_spec.process_proxy_connection_file_mode, **kw)
+            km.process_proxy = process_proxy_class(km)
             km.process_proxy.load_process_info(process_info)
 
             # Confirm we can even poll the process.  If not, remove the persisted session.


### PR DESCRIPTION
When removing push and pull connection modes, the constructor for process proxy instances changed since the connection file mode is no longer necessary.  I failed to catch the constructor used when loading persisted kernel sessions.  My testing failed to encounter this because I perform graceful shutdowns of kernels and elyra - probably need to change my ways in that respect.  Thanks for catching this @ckadner!

Closes #108