### PR TITLE
Disable Yarn AM wait timeout for Scala kernels in cluster mode

### DIFF
--- a/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
+++ b/etc/kernels/spark_2.1_scala_yarn_cluster/kernel.json
@@ -6,7 +6,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
+    "__TOREE_SPARK_OPTS__": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d",
     "__TOREE_OPTS__": "",
     "LAUNCH_OPTS": "",
     "DEFAULT_INTERPRETER": "Scala"


### PR DESCRIPTION
We need to set the `spark.yarn.am.waitTime` to "infinity" in order to not
have Spark's Yarn ApplicationMaster fail the kernel if the user takes
longer than 100 seconds to trigger Spark session initialization.

Closes #105, #110