### PR TITLE
Make kernel session persistence optional

### DIFF
--- a/kernel_gateway/gatewayapp.py
+++ b/kernel_gateway/gatewayapp.py
@@ -396,7 +396,9 @@ class KernelGatewayApp(JupyterApp):
 
         self.kernel_session_manager = KernelSessionManager(
             log=self.log,
-            kernel_manager=self.kernel_manager
+            kernel_manager=self.kernel_manager,
+            config=self.config, # required to get command-line options visible
+            **kwargs
         )
         # Attempt to start persisted sessions
         self.kernel_session_manager.start_sessions()


### PR DESCRIPTION
Added boolean command-line flag `--KernelSessionManager.enable_persistence` that, when equal True, enables the kernel session persistence code.  Default is False (no persistence).

Changes look more prevalent than they are due to indentation under the check if persistence is enabled.

Closes #114