### PR TITLE
Do not auto restart remote kernels without connected clients

### DIFF
--- a/kernel_gateway/services/kernels/processproxy.py
+++ b/kernel_gateway/services/kernels/processproxy.py
@@ -17,7 +17,10 @@ from socket import *
 from jupyter_client import launch_kernel, localinterfaces
 from yarn_api_client.resource_manager import ResourceManager
 from datetime import datetime
-from urlparse import urlparse
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 # Default logging level of paramiko produces too much noise - raise to warning only.
 logging.getLogger('paramiko').setLevel(os.getenv('ELYRA_SSH_LOG_LEVEL', logging.WARNING))

--- a/kernel_gateway/services/sessions/kernelsessionmanager.py
+++ b/kernel_gateway/services/sessions/kernelsessionmanager.py
@@ -58,6 +58,7 @@ class KernelSessionManager(LoggingConfigurable):
     def refresh_session(self, kernel_id, **kwargs):
         # Persists information about the kernel session within the designated repository.
         if self.enable_persistence:
+            self.log.debug("Refreshing kernel session for id: {}".format(kernel_id))
             km = self.kernel_manager.get_kernel(kernel_id)
 
             # Compose the kernel_session entry


### PR DESCRIPTION
Intercept kernel restarts and check if the kernel's process proxy is an instance of `RemoteProcessProxy`.  If so, check its number of open connections.  If zero, use the parent mapping kernel manager instance to shutdown the kernel rather than restart it.  This will allow admins to terminate resource-managed (e.g., yarn) applications of disconnected kernels rather than having to wait the entire culling period for the resource to be.

**Note: These changes will need to be reapplied once PR #120 has been merged.**

Closes #118