### PR TITLE
ELYRA-124 - Lazy eval for SparkR session

### DIFF
--- a/etc/kernels/spark_2.1_R_yarn_client/scripts/launch_IRkernel.R
+++ b/etc/kernels/spark_2.1_R_yarn_client/scripts/launch_IRkernel.R
@@ -5,8 +5,7 @@ r_libs_user <- Sys.getenv("R_LIBS_USER")
 
 sparkConfigList <- list(
 spark.executorEnv.R_LIBS_USER=r_libs_user,
-spark.rdd.compress="true",
-spark.serializer.objectStreamReset="100")
+spark.rdd.compress="true")
 
 # Initializes the Spark session/context and SQL context
 initialize_spark_session <- function() {

--- a/etc/kernels/spark_2.1_R_yarn_cluster/scripts/launch_IRkernel.R
+++ b/etc/kernels/spark_2.1_R_yarn_cluster/scripts/launch_IRkernel.R
@@ -5,8 +5,7 @@ r_libs_user <- Sys.getenv("R_LIBS_USER")
 
 sparkConfigList <- list(
 spark.executorEnv.R_LIBS_USER=r_libs_user,
-spark.rdd.compress="true",
-spark.serializer.objectStreamReset="100")
+spark.rdd.compress="true")
 
 # Initializes the Spark session/context and SQL context
 initialize_spark_session <- function() {


### PR DESCRIPTION
Merging changes from Christian. Including a few of the spark config options in the sparkConfigList. 
Removed redundant "spark.serializer.objectStreamReset" default is set to 100 already.