### PR TITLE
Skip restarts of non-connected kernels when triggered from restarter.

### DIFF
--- a/elyra/services/kernels/remotemanager.py
+++ b/elyra/services/kernels/remotemanager.py
@@ -126,9 +126,10 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
 
     def restart_kernel(self, now=False, **kw):
         kernel_id = os.path.basename(self.connection_file).replace('kernel-', '').replace('.json', '')
-        # Check if this is a remote process proxy. If so, check its connection count. If no connections, shutdown
-        # else perform the restart.
-        if isinstance(self.process_proxy,RemoteProcessProxy):
+        # Check if this is a remote process proxy and if now = True. If so, check its connection count. If no
+        # connections, shutdown else perform the restart.  Note: auto-restart sets now=True, but handlers use
+        # the default value (False).
+        if isinstance(self.process_proxy,RemoteProcessProxy) and now:
             if self.parent._kernel_connections.get(kernel_id, 0) == 0:
                 self.log.warning("Remote kernel ({}) will not be automatically restarted since there are no "
                                  "clients connected at this time.".format(kernel_id))


### PR DESCRIPTION
The previous attempt to address issue #118 broke restarts triggered
from the notebook client because the notebook actually closes the
websocket after triggering the restart - causing the connection count
to go to zero.  As a result, it is not sufficient to base this change
on a zero connection count.

Instead, we will use the `now` parameter value.  Its default is `False`
and `True` is only used when called from the restarter (i.e., when
auto-restart is the trigger).

Fixes #118