### PR TITLE
Ensure dist directory exists prior to kernelspecs creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ help:
 
 build:
 env: ## Make a dev environment
-	conda create -y -n $(ENV) -c conda-forge --file requirements.txt \
+	-conda create -y -n $(ENV) -c conda-forge --file requirements.txt \
 		--file requirements-test.txt
-	source activate $(ENV) && \
+	$(SA) $(ENV) && \
 		pip install -r requirements-doc.txt && \
 		pip install -e .
 


### PR DESCRIPTION
Testing on build machine found that just running `make kernelspecs` prior to `make bdist` caused issues because the `dist` directory was not present.   This change creates that directory if it doesn't already exist.

Also used echo suppression on a couple of the actions.