### PR TITLE
add pid/pgid to python cluster launcher

### DIFF
--- a/etc/kernels/spark_2.1_python_yarn_cluster/scripts/launch_ipykernel.py
+++ b/etc/kernels/spark_2.1_python_yarn_cluster/scripts/launch_ipykernel.py
@@ -82,6 +82,10 @@ def return_connection_info(connection_file, ip, response_addr):
     with open(connection_file) as fp:
         cf_json = json.load(fp)
         fp.close()
+        # add process and process group ids into connection info.
+        pid = os.getpid()
+        cf_json['pid'] = str(pid)
+        cf_json['pgid'] = str(os.getpgid(pid))
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:


### PR DESCRIPTION
Failed to copy python launcher from client to cluster when addressing #134.  (This will not occur once #132 is implemented.)