### PR TITLE
Make default remote_user value the empty string instead of None

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -65,7 +65,7 @@ class EnterpriseGatewayApp(KernelGatewayApp):
 
     @default('remote_user')
     def remote_user_default(self):
-        return os.getenv(self.remote_user_env)
+        return os.getenv(self.remote_user_env, '')
 
     # Yarn endpoint
     yarn_endpoint_env = 'EG_YARN_ENDPOINT'


### PR DESCRIPTION
The previous change for Issue #148 and PR #158 caused test failures with the following message:
>`traitlets.traitlets.TraitError: The 'remote_user' trait of an EnterpriseGatewayApp instance must be a unicode string, but a value of None <class 'NoneType'> was specified.`

This change addresses that issue by ensuring that `remote_user` has a non-None default value ('' the empty string).