### PR TITLE
Add support for gateway communication port

### DIFF
--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -1,9 +1,9 @@
 import os
-import socket
 import tempfile
 import json
 import uuid
 import argparse
+from socket import *
 from ipython_genutils.py3compat import str_to_bytes
 from jupyter_client.connect import write_connection_file
 from IPython import embed_kernel
@@ -66,7 +66,17 @@ sqlCtx = WaitingForSparkSessionToBeInitialized(global_variable_name='sqlCtx')
 thread_to_initialize_spark_session = Thread(target=initialize_spark_session)
 
 
-def return_connection_info(connection_file, ip, response_addr):
+def prepare_gateway_socket():
+    sock = socket(AF_INET, SOCK_STREAM)
+    sock.bind(('0.0.0.0', 0))
+    print("Signal socket bound to host: {}, port: {}".format(sock.getsockname()[0], sock.getsockname()[1]))
+    sock.listen(1)
+    sock.settimeout(5)
+    return sock
+
+
+def return_connection_info(connection_file, ip, response_addr, disable_gateway_socket):
+    gateway_sock = None
     response_parts = response_addr.split(":")
     if len(response_parts) != 2:
         print("Invalid format for response address '{}'.  Assuming 'pull' mode...".format(response_addr))
@@ -82,17 +92,25 @@ def return_connection_info(connection_file, ip, response_addr):
     with open(connection_file) as fp:
         cf_json = json.load(fp)
         fp.close()
-        # add process and process group ids into connection info.
-        pid = os.getpid()
-        cf_json['pid'] = str(pid)
-        cf_json['pgid'] = str(os.getpgid(pid))
 
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    # add process and process group ids into connection info.
+    pid = os.getpid()
+    cf_json['pid'] = str(pid)
+    cf_json['pgid'] = str(os.getpgid(pid))
+
+    # prepare socket address for handling signals
+    if not disable_gateway_socket:
+        gateway_sock = prepare_gateway_socket()
+        cf_json['comm_port'] = gateway_sock.getsockname()[1]
+
+    s = socket(AF_INET, SOCK_STREAM)
     try:
         s.connect((response_ip, response_port))
         s.send(json.dumps(cf_json).encode(encoding='utf-8'))
     finally:
         s.close()
+
+    return gateway_sock
 
 
 def determine_connection_file(conn_file):
@@ -106,6 +124,39 @@ def determine_connection_file(conn_file):
 
     return conn_file
 
+
+def get_gateway_request(sock):
+    conn = None
+    data = ''
+    request_info = None
+    try:
+        conn, addr = sock.accept()
+        while True:
+            buffer = conn.recv(1024).decode('utf-8')
+            if not buffer:  # send is complete
+                request_info = json.loads(data)
+                break
+            data = data + buffer  # append what we received until we get no more...
+    except Exception as e:
+        if type(e) is not timeout:
+            raise e
+    finally:
+        if conn:
+            conn.close()
+
+    return request_info
+
+
+def gateway_listener(sock):
+    while True:
+        request = get_gateway_request(sock)
+        if request:
+            if request.get('signum'):
+                signum = int(request.get('signum'))
+                os.kill(os.getpid(), signum)
+            # else: unexpected request, just ignore
+            #    print("Unexpected request from gateway: {}".format(request))
+
 if __name__ == "__main__":
     """
         Usage: spark-submit launch_ipykernel [connection_file] [--RemoteProcessProxy.response-address <response_addr>]
@@ -113,10 +164,16 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument('connection_file', help='Connection file to write connection info')
-    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?', metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
+    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
+                        metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
+    parser.add_argument('--RemoteProcessProxy.disable-gateway-socket', dest='disable_gateway_socket',
+                        action='store_true', help='Disable use of gateway socket for extended communications',
+                        default=False)
+
     arguments = vars(parser.parse_args())
     connection_file = arguments['connection_file']
     response_addr = arguments['response_address']
+    disable_gateway_socket = arguments['disable_gateway_socket']
     ip = "0.0.0.0"
 
     # If the connection file doesn't exist, then create it.
@@ -126,7 +183,10 @@ if __name__ == "__main__":
         write_connection_file(fname=connection_file, ip=ip, key=key)
 
         if response_addr:
-            return_connection_info(connection_file, ip, response_addr)
+            gateway_socket = return_connection_info(connection_file, ip, response_addr, disable_gateway_socket)
+            if gateway_socket:  # socket in use, start gateway listener thread
+                gateway_listener_thread = Thread(target=gateway_listener, args=(gateway_socket,))
+                gateway_listener_thread.start()
 
     # start to initialize the Spark session in the background
     thread_to_initialize_spark_session.start()


### PR DESCRIPTION
Because signals cannot be used between processes of differing user-ids (of the gateway server and kernel process), we need a different mechanism for communicating to the kernel that it needs to interrupt its current cell.  

This change alters Enterprise Gateway to look for the return of a `comm_port` value upon return of the connection information from the kernel launcher.  If present, that port (along with the `ip` corresponding to the kernel's assigned host) will be used as a `gateway communication port`.  Currently, the port listener within the launcher understands one request.  If the json payload contains a `signum` key, then its value is the corresponding signal number the launcher will send to the kernel (which is essentially itself).  Likewise, if the `comm_port` has been returned, the Enterprise Gateway will attempt to send corresponding signal values via the gateway communication port.  If an exception occurs, the current fallback mechanism will be attempted, although this will not succeed if the processes are running under different user-ids.

The ipython kernel launcher has been updated accordingly.  This logic is enabled by default but can be disabled by invoking the launcher with `--RemoteProcessProxy.disable-gateway-socket`.  When enabled,the launcher builds the connection information, then creates the gateway socket for listening and returns the port in the `comm_port` key value of the connection info response.  It then starts a thread to listen on the socket, while the primary thread completes the launch of the kernel.  If the listening thread receives data, it checks is there's a `signum` key and uses that value to signal itself - which is sent to the primary thread.   If there's no `signum` key, the request is ignored (until new requests are needed).

This `gateway communication port` will be tunneled if ssh tunneling is enabled.  As a result, some refactoring of the recently added tunneling code has occurred, along with fixing the detection of whether or not ssh tunneling is enabled.