### PR TITLE
Allow enterprise gateway to ignore the SIGHUP signal

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -265,6 +265,8 @@ class EnterpriseGatewayApp(KernelGatewayApp):
                                  format(gateway_user))
 
         self.io_loop = ioloop.IOLoop.current()
+        
+        signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
         signal.signal(signal.SIGTERM, self._signal_stop)
 


### PR DESCRIPTION
We noticed that on python 3.x python would not ignore the SIGHUP by default. We made the similar change in kernel gateway, you can see the discussion here 
https://github.com/jupyter/kernel_gateway/pull/304