### PR TITLE
Set Sphinx to use v1.7.9

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,6 @@ name: enterprise_gateway_docs
 dependencies:
 - python=3.5
 - sphinx_rtd_theme
-- sphinx
+- sphinx=1.7.9
 - pip:
     - recommonmark

--- a/requirements.yml
+++ b/requirements.yml
@@ -18,7 +18,7 @@ dependencies:
     - yarn-api-client>=0.2.3
   # Documentation Requirements
   - sphinx_rtd_theme
-  - sphinx
+  - sphinx=1.7.9
   - recommonmark
   # Test Requirements
   - nose


### PR DESCRIPTION
Documentation builds were failing after Sphinx was bumped up to 1.8.0. Was unable to recreate the error locally. This PR will test to see if reverting to 1.7.9 resolves the issue.  