### PR TITLE
Set EG to use yarn-api-client dependency <0.3.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -15,7 +15,7 @@ dependencies:
   - pyzmq>=17.0.0
   - pip
   - pip:
-    - yarn-api-client>=0.2.3
+    - yarn-api-client<0.3.0
   # Documentation Requirements
   - sphinx_rtd_theme
   - sphinx=1.7.9

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ Jupyter Notebooks to share resources across an Apache Spark cluster.
         'tornado>=4.2.0',
         'requests>=2.7,<3.0',
         'paramiko>=2.1.2',
-        'yarn-api-client>=0.2.3',
+        'yarn-api-client<0.3.0',
         'pexpect>=4.2.0',
         'pycrypto>=2.6.1',
         'pyzmq>=17.0.0',


### PR DESCRIPTION
kerberos issues with the new release of yarn-api-client