### PR TITLE
Add support to YARN endpoints protected by SPNEGO

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -30,7 +30,7 @@ A snapshot of this help appears below for ease of reference on the web.
 ```
 Jupyter Enterprise Gateway
 
-Provisions Jupyter kernels and proxies HTTP/Websocket traffic to them.
+Provisions remote Jupyter kernels and proxies HTTP/Websocket traffic to them.
 
 Options
 -------
@@ -92,7 +92,7 @@ Parameters are set from command-line arguments of the form:
 are allowed, e.g.:: `--C.a='range(3)'` For setting C.a=[0,1,2].
 
 EnterpriseGatewayApp options
-----------------
+----------------------------
 --EnterpriseGatewayApp.allow_credentials=<Unicode>
     Default: u''
     Sets the Access-Control-Allow-Credentials header. (KG_ALLOW_CREDENTIALS env
@@ -136,6 +136,10 @@ EnterpriseGatewayApp options
     Default: None
     The full path to a certificate authority certificate for SSL/TLS client
     authentication. (KG_CLIENT_CA env var)
+--EnterpriseGatewayApp.conductor_endpoint=<Unicode>
+    Default: None
+    The http url for accessing the Conductor REST API. (EG_CONDUCTOR_ENDPOINT
+    env var)
 --EnterpriseGatewayApp.config_file=<Unicode>
     Default: u''
     Full path of a config file.
@@ -145,6 +149,10 @@ EnterpriseGatewayApp options
 --EnterpriseGatewayApp.default_kernel_name=<Unicode>
     Default: u''
     Default kernel name when spawning a kernel (KG_DEFAULT_KERNEL_NAME env var)
+--EnterpriseGatewayApp.env_process_whitelist=<List>
+    Default: []
+    Environment variables allowed to be inherited from the spawning process by
+    the kernel
 --EnterpriseGatewayApp.expose_headers=<Unicode>
     Default: u''
     Sets the Access-Control-Expose-Headers header. (KG_EXPOSE_HEADERS env var)
@@ -162,6 +170,14 @@ EnterpriseGatewayApp options
 --EnterpriseGatewayApp.ip=<Unicode>
     Default: '127.0.0.1'
     IP address on which to listen (KG_IP env var)
+--EnterpriseGatewayApp.kernel_manager_class=<Type>
+    Default: 'enterprise_gateway.services.kernels.remotemanager.RemoteMapp...
+    The kernel manager class to use. Should be a subclass of
+    `notebook.services.kernels.MappingKernelManager`.
+--EnterpriseGatewayApp.kernel_spec_manager_class=<Type>
+    Default: 'enterprise_gateway.services.kernelspecs.remotekernelspec.Rem...
+    The kernel spec manager class to use. Should be a subclass of
+    `jupyter_client.kernelspec.KernelSpecManager`.
 --EnterpriseGatewayApp.keyfile=<Unicode>
     Default: None
     The full path to a private key file for usage with SSL/TLS. (KG_KEYFILE env
@@ -196,9 +212,8 @@ EnterpriseGatewayApp options
     Specifies the lower and upper port numbers from which ports are created.
     The bounded values are separated by '..' (e.g., 33245..34245 specifies a
     range of 1000 ports to be randomly selected). A range of zero (e.g.,
-    33245..33245 or 0..0) disables port-range enforcement. If the specified
-    range overlaps with TCP's well-known port range of (0, 1024], then a
-    RuntimeError will be thrown. (EG_PORT_RANGE env var)
+    33245..33245 or 0..0) disables port-range enforcement.  (EG_PORT_RANGE env
+    var)
 --EnterpriseGatewayApp.port_retries=<Integer>
     Default: 50
     Number of ports to try if the specified port is not available
@@ -216,6 +231,10 @@ EnterpriseGatewayApp options
     Default: None
     Runs the notebook (.ipynb) at the given URI on every kernel launched. No
     seed by default. (KG_SEED_URI env var)
+--EnterpriseGatewayApp.trust_xheaders=<CBool>
+    Default: False
+    Use x-* header values for overriding the remote-ip, useful when application
+    is behing a proxy. (KG_TRUST_XHEADERS env var)
 --EnterpriseGatewayApp.unauthorized_users=<Set>
     Default: set(['root'])
     Comma-separated list of user names (e.g., ['root','admin']) against which
@@ -226,6 +245,10 @@ EnterpriseGatewayApp options
     Default: 'http://localhost:8088/ws/v1/cluster'
     The http url for accessing the YARN Resource Manager. (EG_YARN_ENDPOINT env
     var)
+--EnterpriseGatewayApp.yarn_endpoint_security_enabled=<Bool>
+    Default: False
+    Is YARN Kerberos/SPNEGO Security enabled (True/False).
+    (EG_YARN_ENDPOINT_SECURITY_ENABLED env var)
 
 NotebookHTTPPersonality options
 -------------------------------
@@ -240,7 +263,7 @@ NotebookHTTPPersonality options
     'kernel_gateway.notebook_http.cell.parser' and
     'kernel_gateway.notebook_http.swagger.parser'. (KG_CELL_PARSER env var)
 --NotebookHTTPPersonality.comment_prefix=<Dict>
-    Default: {'scala': '//', None: '#'}
+    Default: {None: '#', 'scala': '//'}
     Maps kernel language to code comment syntax
 --NotebookHTTPPersonality.static_path=<Unicode>
     Default: None

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -64,11 +64,20 @@ class EnterpriseGatewayApp(KernelGatewayApp):
     yarn_endpoint_env = 'EG_YARN_ENDPOINT'
     yarn_endpoint_default_value = 'http://localhost:8088/ws/v1/cluster'
     yarn_endpoint = Unicode(yarn_endpoint_default_value, config=True,
-        help="""The http url for accessing the Yarn Resource Manager. (EG_YARN_ENDPOINT env var)""")
+        help="""The http url for accessing the YARN Resource Manager. (EG_YARN_ENDPOINT env var)""")
 
     @default('yarn_endpoint')
     def yarn_endpoint_default(self):
         return os.getenv(self.yarn_endpoint_env, self.yarn_endpoint_default_value)
+
+    yarn_endpoint_security_enabled_env = 'EG_YARN_ENDPOINT_SECURITY_ENABLED'
+    yarn_endpoint_security_enabled_default_value = False
+    yarn_endpoint_security_enabled = Bool(yarn_endpoint_security_enabled_default_value, config=True,
+        help="""Is YARN Kerberos/SPNEGO Security enabled (True/False). (EG_YARN_ENDPOINT_SECURITY_ENABLED env var)""")
+
+    @default('yarn_endpoint_security_enabled')
+    def yarn_endpoint_security_enabled_default(self):
+        return bool(os.getenv(self.yarn_endpoint_security_enabled_env, self.yarn_endpoint_security_enabled_default_value))
 
     # Conductor endpoint
     conductor_endpoint_env = 'EG_CONDUCTOR_ENDPOINT'

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -44,7 +44,6 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
             self.resource_mgr = ResourceManager(address=yarn_master, kerberos_enabled=self.yarn_endpoint_security_enabled)
         else:
             self.resource_mgr = ResourceManager(address=yarn_master)
-        self.resource_mgr.logger.setLevel('DEBUG')
 
     def launch_process(self, kernel_cmd, **kw):
         """ Launches the Yarn process.  Prior to invocation, connection files will be distributed to each applicable

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -33,9 +33,18 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
     def __init__(self, kernel_manager, proxy_config):
         super(YarnClusterProcessProxy, self).__init__(kernel_manager, proxy_config)
         self.application_id = None
-        self.yarn_endpoint = proxy_config.get('yarn_endpoint', kernel_manager.parent.parent.yarn_endpoint)
+        self.yarn_endpoint \
+            = proxy_config.get('yarn_endpoint',
+                               kernel_manager.parent.parent.yarn_endpoint)
+        self.yarn_endpoint_security_enabled \
+            = proxy_config.get('yarn_endpoint_security_enabled',
+                               kernel_manager.parent.parent.yarn_endpoint_security_enabled)
         yarn_master = urlparse(self.yarn_endpoint).hostname
-        self.resource_mgr = ResourceManager(address=yarn_master)
+        if self.yarn_endpoint_security_enabled is True:
+            self.resource_mgr = ResourceManager(address=yarn_master, kerberos_enabled=self.yarn_endpoint_security_enabled)
+        else:
+            self.resource_mgr = ResourceManager(address=yarn_master)
+        self.resource_mgr.logger.setLevel('DEBUG')
 
     def launch_process(self, kernel_cmd, **kw):
         """ Launches the Yarn process.  Prior to invocation, connection files will be distributed to each applicable
@@ -254,8 +263,6 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         except Exception as e:
             self.log.warning("Query for kernel ID '{}' failed with exception: {} - '{}'.  Continuing...".
                              format(kernel_id, type(e), e))
-        finally:
-            self.resource_mgr.http_conn.close()
 
         if type(data) is dict and type(data.get("apps")) is dict and 'app' in data.get("apps"):
             for app in data['apps']['app']:
@@ -276,8 +283,6 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         except Exception as e:
             self.log.warning("Query for application ID '{}' failed with exception: '{}'.  Continuing...".
                            format(app_id, e))
-        finally:
-            self.resource_mgr.http_conn.close()
         if type(data) is dict and 'app' in data:
             return data['app']
         return None
@@ -289,35 +294,26 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         :return: 
         """
         response = None
-        url = '%s/apps/%s/state' % (self.yarn_endpoint, app_id)
-        cmd = ['curl', '-X', 'GET', url]
         try:
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
-            output, stderr = process.communicate()
-            response = json.loads(output.decode('utf-8')).get('state') if output else None
+            response = self.resource_mgr.cluster_application_state(application_id=app_id)
         except Exception as e:
-            self.log.warning("Query for application state with cmd '{}' failed with exception: '{}'.  Continuing...".
-                           format(cmd, e))
-        return response
+            self.log.warning("Query for application '{}' state failed with exception: '{}'.  Continuing...".
+                             format(app_id, e))
+
+        return response.data['state']
 
     def kill_app_by_id(self, app_id):
         """Kill an application. If the app's state is FINISHED or FAILED, it won't be changed to KILLED.
-        TODO: extend the yarn_api_client to support cluster_application_kill with PUT, e.g.:
-            YarnProcessProxy.resource_mgr.cluster_application_kill(application_id=app_id)
 
-        :param app_id 
+        :param app_id
         :return: The JSON response of killing the application.
         """
+
         response = None
-        header = "Content-Type: application/json"
-        data = '{"state": "KILLED"}'
-        url = '%s/apps/%s/state' % (self.yarn_endpoint, app_id)
-        cmd = ['curl', '-X', 'PUT', '-H', header, '-d', data, url]
         try:
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
-            output, stderr = process.communicate()
-            response = json.loads(output.decode('utf-8')) if output else None
+            response = self.resource_mgr.cluster_application_kill(application_id=app_id)
         except Exception as e:
-            self.log.warning("Termination of application with cmd '{}' failed with exception: '{}'.  Continuing...".
-                           format(cmd, e))
+            self.log.warning("Termination of application '{}' failed with exception: '{}'.  Continuing...".
+                             format(app_id, e))
+
         return response

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,6 +1,6 @@
 FROM kubespark/spark-driver-py:v2.2.0-kubernetes-0.5.0
 
-RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev curl
+RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev curl krb5-dev
 
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp

--- a/etc/docker/yarn-spark/Dockerfile
+++ b/etc/docker/yarn-spark/Dockerfile
@@ -5,6 +5,8 @@ ENV ANACONDA_HOME=/opt/anaconda2
 ENV PATH=$ANACONDA_HOME/bin:$PATH
 ENV PYSPARK_PYTHON=$ANACONDA_HOME/bin/python
 
+RUN yum install -y gcc krb5-devel; yum clean all
+
 COPY yarn-site.xml.template /usr/local/hadoop/etc/hadoop/
 
 # Install system logging and insert into bootstrap.sh - helps in troubleshooting ssh

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ Jupyter Notebooks to share resources across an Apache Spark cluster.
         'tornado>=4.2.0',
         'requests>=2.7,<3.0',
         'paramiko>=2.1.2',
-        'yarn-api-client<0.3.0',
+        'yarn-api-client>=0.3.0',
         'pexpect>=4.2.0',
         'pycrypto>=2.6.1',
         'pyzmq>=17.0.0',


### PR DESCRIPTION
Update to the YARN client API package that has now
enabled SPENEGO support and properly expose a parameter
for the user to enable/disable support for SPENEGO in
Enterprise Gateway. Also update the docker images with
kerberos library dependencies.

Closes #459