### PR TITLE
Add the Enterprise Gateway version stamp to the startup message.

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -262,8 +262,8 @@ class EnterpriseGatewayApp(KernelGatewayApp):
         # its start() logic and just call that of JKG's superclass.
         super(KernelGatewayApp, self).start()
 
-        self.log.info('Jupyter Enterprise Gateway at http{}://{}:{}'.format(
-            's' if self.keyfile else '', self.ip, self.port
+        self.log.info('Jupyter Enterprise Gateway {} is available at http{}://{}:{}'.format(
+            EnterpriseGatewayApp.version, 's' if self.keyfile else '', self.ip, self.port
         ))
         # If impersonation is enabled, issue a warning message if the gateway user is not in unauthorized_users.
         if self.impersonation_enabled:


### PR DESCRIPTION
This will help us during times of support.  It would be nice to capture all the components, but we can ask for a `pip freeze` for those.

Before:
```
[I 2018-10-10 12:53:16.677 EnterpriseGatewayApp] Jupyter Enterprise Gateway at http://0.0.0.0:8888
```

After:
```
[I 2018-10-10 12:53:16.677 EnterpriseGatewayApp] Jupyter Enterprise Gateway 1.1.0 is available at http://0.0.0.0:8888
```