### PR TITLE
Create a separate kernelspecs tar for each resource manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 env: ## Make a dev environment
 	-conda env create --file requirements.yml --name $(ENV)
 
-activate: ## eval `make activate`
+activate: ## Activate the virtualenv (default: enterprise-gateway-dev)
 	@echo "$(SA) $(ENV)"
 
 clean: ## Make a clean source tree
@@ -44,7 +44,8 @@ dev: ## Make a server in jupyter_websocket mode
 docs: ## Make HTML documentation
 	$(SA) $(ENV) && make -C docs html
 
-kernelspecs: ## Create an archive with sample kernelspecs
+kernelspecs:  kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker ## Create archives with sample kernelspecs
+kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker: 
 	make VERSION=$(VERSION) -C  etc $@
 
 install: ## Make a conda env with dist/*.whl and dist/*.tar.gz installed
@@ -89,36 +90,16 @@ release: POST_SDIST=upload
 release: bdist sdist ## Make a wheel + source release on PyPI
 
 # Here for doc purposes
-docker-images:  ## Build docker images
-enterprise-gateway-demo:  ## Build elyra/enterprise-gateway-demo:dev docker image
-yarn-spark:  ## Build elyra/yarn-spark:2.3.1 docker image
-nb2kg:  ## Build elyra/nb2kg:dev docker image
-enterprise-gateway: ## Build elyra/enterprise-gateway:dev docker image
+docker-images:  ## Build docker images (includes kernel-based images)
 kernel-images: ## Build kernel-based docker images
-kernel-py: ## Build elyra/kernel-py:dev docker image
-kernel-r: ## Build elyra/kernel-r:dev docker image
-kernel-spark-r: ## Build elyra/kernel-spark-r:dev docker image
-kernel-scala: ## Build elyra/kernel-scala:dev docker image
-kernel-tf-py: ## Build elyra/kernel-tf-py:dev docker image
-kernel-tf-gpu-py: ## Build elyra/kernel-tf-gpu-py:dev docker image
 
 # Actual working targets...
 docker-images enterprise-gateway-demo yarn-spark nb2kg kernel-images enterprise-gateway kernel-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py:
 	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) -C etc $@
 
 # Here for doc purposes
-clean-images: ## Remove docker images
-clean-enterprise-gateway-demo: ## Remove elyra/enterprise-gateway-demo:dev docker image
-clean-nb2kg: ## Remove elyra/nb2kg:dev docker image
-clean-yarn-spark: ## Remove elyra/yarn-spark:2.3.1 docker image
-clean-enterprise-gateway: ## Remove elyra/enterprise-gateway:dev docker image
-clean-kernel-images: ## Remove kernel-based docker images
-clean-kernel-py: ## Remove elyra/kernel-py:dev docker image
-clean-kernel-r: ## Remove elyra/kernel-r:dev docker image
-clean-kernel-spark-r: ## Remove elyra/kernel-spark-r:dev docker image
-clean-kernel-scala: ## Remove elyra/kernel-scala:dev docker image
-clean-kernel-tf-py: ## Remove elyra/kernel-tf-py:dev docker image
-clean-kernel-tf-gpu-py: ## Remove elyra/kernel-tf-gpu-py:dev docker image
+clean-images: ## Remove docker images (includes kernel-based images)
+clean-kernel-images: ## Remove kernel-based images
 
 clean-images clean-enterprise-gateway-demo clean-nb2kg clean-yarn-spark clean-kernel-images clean-enterprise-gateway clean-kernel-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala clean-kernel-tf-py clean-kernel-tf-gpu-py:
 	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) -C etc $@

--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -26,44 +26,24 @@ Enterprise Gateway's build environment is centered around `make` and the corresp
 Entering `make` with no parameters yields the following:
 
 ```
-activate                       eval `make activate`
-clean-enterprise-gateway-demo  Remove elyra/enterprise-gateway-demo:dev docker image
-clean-enterprise-gateway       Remove elyra/enterprise-gateway:dev docker image
-clean-images                   Remove docker images
-clean-kernel-images            Remove kernel-based docker images
-clean-kernel-py                Remove elyra/kernel-py:dev docker image
-clean-kernel-r                 Remove elyra/kernel-r:dev docker image
-clean-kernel-scala             Remove elyra/kernel-scala:dev docker image
-clean-kernel-spark-r           Remove elyra/kernel-spark-r:dev docker image
-clean-kernel-tf-gpu-py         Remove elyra/kernel-tf-gpu-py:dev docker image
-clean-kernel-tf-py             Remove elyra/kernel-tf-py:dev docker image
-clean-nb2kg                    Remove elyra/nb2kg:dev docker image
-clean-yarn-spark               Remove elyra/yarn-spark:2.1.0 docker image
+activate                       Activate the virtualenv (default: enterprise-gateway-dev)
+clean-images                   Remove docker images (includes kernel-based images)
+clean-kernel-images            Remove kernel-based images
 clean                          Make a clean source tree
 dev                            Make a server in jupyter_websocket mode
 dist                           Make source, binary and kernelspecs distribution to dist folder
-docker-images                  Build docker images
+docker-images                  Build docker images (includes kernel-based images)
 docs                           Make HTML documentation
-enterprise-gateway-demo        Build elyra/enterprise-gateway-demo:dev docker image
-enterprise-gateway             Build elyra/enterprise-gateway:dev docker image
 env                            Make a dev environment
 install                        Make a conda env with dist/*.whl and dist/*.tar.gz installed
-itest-docker                   Run integration tests (optionally) against docker container
-itest-yarn                     Run integration tests (optionally) against docker demo (YARN) container 
+itest-docker                   Run integration tests (optionally) against docker swarm
+itest-yarn                     Run integration tests (optionally) against docker demo (YARN) container
 kernel-images                  Build kernel-based docker images
-kernel-py                      Build elyra/kernel-py:dev docker image
-kernel-r                       Build elyra/kernel-r:dev docker image
-kernel-scala                   Build elyra/kernel-scala:dev docker image
-kernel-spark-r                 Build elyra/kernel-spark-r:dev docker image
-kernel-tf-gpu-py               Build elyra/kernel-tf-gpu-py:dev docker image
-kernel-tf-py                   Build elyra/kernel-tf-py:dev docker image
-kernelspecs                    Create an archive with sample kernelspecs
-nb2kg                          Build elyra/nb2kg:dev docker image
+kernelspecs                    Create archives with sample kernelspecs
 nuke                           Make clean + remove conda env
 publish-images                 Push docker images to docker hub
 release                        Make a wheel + source release on PyPI
 test                           Run unit tests
-yarn-spark                     Build elyra/yarn-spark:2.1.0 docker image
 ```
 Some of the more useful commands are listed below.
 

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -2,15 +2,12 @@
 # Distributed under the terms of the Modified BSD License.
 
 .PHONY: help clean clean-images clean-enterprise-gateway clean-enterprise-gateway-demo clean-nb2kg clean-yarn-spark \
-    clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher
+    clean-kernel-images clean-py clean-tf-py clean-tf-gpu-py clean-r clean-spark-r clean-scala toree-launcher \
+    kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker 
 
 SA:=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
-
-KERNELSPECS_FILE:=../dist/jupyter_enterprise_gateway_kernelspecs-$(VERSION).tar.gz
-KERNELSPECS_FILES:=$(shell find kernel-launchers kernelspecs -type f -name '*')
-TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -type f -name '*')
 
 # Docker attributes - hub organization and tag.  Modify accordingly
 HUB_ORG:=elyra
@@ -30,9 +27,20 @@ clean: ## Make a clean source tree
 # Kernelspec build section *************************************************
 #
 
-kernelspecs: $(KERNELSPECS_FILE) ## Make a tar.gz file consisting of kernelspec files
+KERNELSPECS := kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker
+kernelspecs: $(KERNELSPECS)
 
-$(KERNELSPECS_FILE): $(KERNELSPECS_FILES) kernel-launchers/scala/lib  
+FILE_kernelspecs_all:=../dist/jupyter_enterprise_gateway_kernelspecs-$(VERSION).tar.gz
+FILE_kernelspecs_yarn:=../dist/jupyter_enterprise_gateway_kernelspecs_yarn-$(VERSION).tar.gz
+FILE_kernelspecs_conductor:=../dist/jupyter_enterprise_gateway_kernelspecs_conductor-$(VERSION).tar.gz
+FILE_kernelspecs_kubernetes:=../dist/jupyter_enterprise_gateway_kernelspecs_kubernetes-$(VERSION).tar.gz
+FILE_kernelspecs_docker:=../dist/jupyter_enterprise_gateway_kernelspecs_docker-$(VERSION).tar.gz
+
+FILES_kernelspecs_all:=$(shell find kernel-launchers kernelspecs -type f -name '*')
+
+TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -type f -name '*')
+
+../build/kernelspecs: kernel-launchers/scala/lib  $(FILES_kernelspecs_all) 
 	@mkdir -p ../build/kernelspecs
     # Seed the build tree with initial files
 	cp -r kernelspecs ../build
@@ -41,13 +49,25 @@ $(KERNELSPECS_FILE): $(KERNELSPECS_FILES) kernel-launchers/scala/lib
 	@echo ../build/kernelspecs/{spark_,}R_* | xargs -t -n 1 cp -r kernel-launchers/R/scripts
 	@echo ../build/kernelspecs/{spark_,}scala_* | xargs -t -n 1 cp -r kernel-launchers/scala/lib
 	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_kubernetes | xargs -t -n 1 cp -r kernel-launchers/kubernetes/*
-	# Fixme - deal with spark-based docker containers...
+    # Fixme - deal with spark-based docker containers...
 	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_docker | xargs -t -n 1 cp -r kernel-launchers/docker/*
     # Perform the copy again to enable local, per-kernel, overrides
 	cp -r kernelspecs ../build
 	@mkdir -p ../dist
-	rm -f $(KERNELSPECS_FILE)
-	@( cd ../build/kernelspecs; tar -pvczf "../$(KERNELSPECS_FILE)" * )
+
+PATTERN_kernelspecs_all := *
+PATTERN_kernelspecs_yarn := *_yarn_*
+PATTERN_kernelspecs_conductor := *_conductor_*
+PATTERN_kernelspecs_kubernetes := *_kubernetes
+PATTERN_kernelspecs_docker := *_docker
+
+define BUILD_KERNELSPEC
+$1: $$(FILE_$1)
+$$(FILE_$1): ../build/kernelspecs
+	rm -f $$(FILE_$1)
+	@( cd ../build/kernelspecs; tar -pvczf "../$$(FILE_$1)" $$(PATTERN_$1) )
+endef
+$(foreach kernelspec,$(KERNELSPECS),$(eval $(call BUILD_KERNELSPEC,$(kernelspec))))
 
 kernel-launchers/scala/lib: $(TOREE_LAUNCHER_FILES)
 	-rm -rf kernel-launchers/scala/lib


### PR DESCRIPTION
The following targets are supported: kernelspecs_all, kernelspecs_yarn,
kernelspecs_conductor, kernelspecs_kubernetes, and kernelspecs_docker.

Also cleaned up the targets that get output when typing `make` and updated
the corresponding documentation.

Fixes #413