### PR TITLE
get the assigned host ip for pod

### DIFF
--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -19,6 +19,7 @@ class ContainerProcessProxy(RemoteProcessProxy):
     def __init__(self, kernel_manager, proxy_config):
         super(ContainerProcessProxy, self).__init__(kernel_manager, proxy_config)
         self.container_name = ''
+        self.assigned_node_ip = None
         self._determine_kernel_images(proxy_config)
 
     def _determine_kernel_images(self, proxy_config):
@@ -123,6 +124,15 @@ class ContainerProcessProxy(RemoteProcessProxy):
                     self.pgid = 0
             else:
                 self.detect_launch_failure()
+
+    def get_process_info(self):
+        process_info = super(ContainerProcessProxy, self).get_process_info()
+        process_info.update({'assigned_node_ip': self.assigned_node_ip,})
+        return process_info
+
+    def load_process_info(self, process_info):
+        super(ContainerProcessProxy, self).load_process_info(process_info)
+        self.assigned_node_ip = process_info['assigned_node_ip']
 
     @abc.abstractmethod
     def get_initial_states(self):

--- a/enterprise_gateway/services/processproxies/docker_swarm.py
+++ b/enterprise_gateway/services/processproxies/docker_swarm.py
@@ -167,7 +167,7 @@ class DockerProcessProxy(ContainerProcessProxy):
                         self.log.warning("Docker network '{}' could not be located in container attributes - "
                                          "using assigned_ip '{}'.".format(docker_network, self.assigned_ip))
 
-                    self.assigned_host = self.assigned_ip
+                    self.assigned_host = self.container_name
 
         if iteration:  # only log if iteration is not None (otherwise poll() is too noisy)
             self.log.debug("{}: Waiting to connect to docker container. "

--- a/enterprise_gateway/services/processproxies/k8s.py
+++ b/enterprise_gateway/services/processproxies/k8s.py
@@ -57,7 +57,8 @@ class KubernetesProcessProxy(ContainerProcessProxy):
                 if pod_status == 'Running' and self.assigned_host == '':
                     # Pod is running, capture IP
                     self.assigned_ip = pod_info.status.pod_ip
-                    self.assigned_host = pod_info.status.host_ip
+                    self.assigned_host = pod_info.status.pod_ip
+                    self.assigned_node_ip = pod_info.status.host_ip
 
         if iteration:  # only log if iteration is not None (otherwise poll() is too noisy)
             self.log.debug("{}: Waiting to connect to k8s pod in namespace '{}'. "

--- a/enterprise_gateway/services/processproxies/k8s.py
+++ b/enterprise_gateway/services/processproxies/k8s.py
@@ -57,7 +57,7 @@ class KubernetesProcessProxy(ContainerProcessProxy):
                 if pod_status == 'Running' and self.assigned_host == '':
                     # Pod is running, capture IP
                     self.assigned_ip = pod_info.status.pod_ip
-                    self.assigned_host = pod_info.status.pod_ip
+                    self.assigned_host = pod_info.status.host_ip
 
         if iteration:  # only log if iteration is not None (otherwise poll() is too noisy)
             self.log.debug("{}: Waiting to connect to k8s pod in namespace '{}'. "

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -568,6 +568,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         self.start_time = None
         self.assigned_ip = None
         self.assigned_host = ''
+        self.assigned_node_ip = None
         self.comm_ip = None
         self.comm_port = 0
         self.tunneled_connect_info = None    # Contains the destination connection info when tunneling in use
@@ -960,6 +961,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         process_info = super(RemoteProcessProxy, self).get_process_info()
         process_info.update({'assigned_ip': self.assigned_ip,
                              'assigned_host': self.assigned_host,
+                             'assigned_node_ip': self.assigned_node_ip,
                              'comm_ip': self.comm_ip,
                              'comm_port': self.comm_port,
                              'tunneled_connect_info': self.tunneled_connect_info})
@@ -969,6 +971,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         super(RemoteProcessProxy, self).load_process_info(process_info)
         self.assigned_ip = process_info['assigned_ip']
         self.assigned_host = process_info['assigned_host']
+        self.assigned_node_ip = process_info['assigned_node_ip']
         self.comm_ip = process_info['comm_ip']
         self.comm_port = process_info['comm_port']
         if 'tunneled_connect_info' in process_info and process_info['tunneled_connect_info'] is not None:

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -568,7 +568,6 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         self.start_time = None
         self.assigned_ip = None
         self.assigned_host = ''
-        self.assigned_node_ip = None
         self.comm_ip = None
         self.comm_port = 0
         self.tunneled_connect_info = None    # Contains the destination connection info when tunneling in use
@@ -961,7 +960,6 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         process_info = super(RemoteProcessProxy, self).get_process_info()
         process_info.update({'assigned_ip': self.assigned_ip,
                              'assigned_host': self.assigned_host,
-                             'assigned_node_ip': self.assigned_node_ip,
                              'comm_ip': self.comm_ip,
                              'comm_port': self.comm_port,
                              'tunneled_connect_info': self.tunneled_connect_info})
@@ -971,7 +969,6 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         super(RemoteProcessProxy, self).load_process_info(process_info)
         self.assigned_ip = process_info['assigned_ip']
         self.assigned_host = process_info['assigned_host']
-        self.assigned_node_ip = process_info['assigned_node_ip']
         self.comm_ip = process_info['comm_ip']
         self.comm_port = process_info['comm_port']
         if 'tunneled_connect_info' in process_info and process_info['tunneled_connect_info'] is not None:


### PR DESCRIPTION
We should use host_ip to get the assigned host ip for pod in k8s,not the same pod_ip, if my understanding is correct