### PR TITLE
Move process-proxy into metadata in kernel.json

### DIFF
--- a/docs/source/getting-started-client-mode.md
+++ b/docs/source/getting-started-client-mode.md
@@ -52,8 +52,10 @@ After that, you should have a kernel.json that looks similar to the one below:
 {
   "language": "python",
   "display_name": "Spark - Python (YARN Client Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -86,8 +88,10 @@ Please see below how a kernel.json would look like for integrating with Spark St
 {
   "language": "python",
   "display_name": "Spark - Python (YARN Client Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/docs/source/getting-started-cluster-mode.md
+++ b/docs/source/getting-started-cluster-mode.md
@@ -43,8 +43,10 @@ After that, you should have a kernel.json that looks similar to the one below:
 {
   "language": "python",
   "display_name": "Spark - Python (YARN Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/docs/source/getting-started-docker.md
+++ b/docs/source/getting-started-docker.md
@@ -48,7 +48,7 @@ Items worth noting:
 
 ### DockerSwarmProcessProxy
 To indicate that a given kernel should be launched as a Docker Swarm service into a swarm clustr, the
-kernel.json file must include a `process_proxy` stanza indicating a `class_name:`  of 
+kernel.json file's `metadata` stanza  must include a `process_proxy` stanza indicating a `class_name:`  of 
 `DockerSwarmProcessProxy`. This ensures the appropriate lifecycle management will take place relative
 to a Docker Swarm environment.
 
@@ -61,12 +61,14 @@ rest of the parameters used to launch the kernel by way of an environment variab
 
 ```json
 {
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:VERSION"
+      }
     }
-  }
+  },
 }
 ```
 As always, kernels are launched by virtue of the `argv:` stanza in their respective kernel.json
@@ -94,10 +96,12 @@ Running containers in Docker Swarm versus traditional Docker are different enoug
 separate process proxy implementations.  As a result, the kernel.json file could reference the `DockerProcessProxy` class and, accordingly, a traditional docker container (as opposed to a swarm _service_) will be created.  The rest of the kernel.json file, image name, argv stanza, etc. is identical.
 ```json
 {
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:VERSION"
+      }
     }
   },
   "argv": [

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -401,7 +401,7 @@ variables as noted in the `env:` section above.
 
 ### KubernetesProcessProxy
 To indicate that a given kernel should be launched into a Kubernetes configuration, the
-kernel.json file must include a `process_proxy` stanza indicating a `class_name:`  of 
+kernel.json file's `metadata` stanza must include a `process_proxy` stanza indicating a `class_name:`  of 
 `KubernetesProcessProxy`. This ensures the appropriate lifecycle management will take place relative
 to a Kubernetes environment.
 
@@ -414,10 +414,12 @@ rest of the parameters used to launch the kernel by way of an environment variab
 
 ```json
 {
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:VERSION"
+      }
     }
   }
 }

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -48,16 +48,18 @@ specification, otherwise known as the *kernel spec*.  Enterprise Gateway introdu
 named `RemoteKernelSpec`.  
 
 The `RemoteKernelSpec` class provides support for a new (and optional) stanza within the kernelspec file.  This 
-stanza is named `process_proxy` and identifies the class that provides the kernel's process abstraction (while 
-allowing for future extensions).
+stanza is located in the `metadata` stanza and is named `process_proxy`.  This stanza identifies 
+the class that provides the kernel's process abstraction (while allowing for future extensions).
 
 Here's an example of a kernel specification that uses the `DistributedProcessProxy` class for its abstraction:
 ```json
 {
   "language": "scala",
   "display_name": "Spark - Scala (YARN Client Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
@@ -332,12 +334,14 @@ In such situations, one might find the following `process-proxy` stanza:
 
 ```json
 {
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy",
-    "config": {
-      "remote_hosts": "priv_host1,priv_host2",
-      "port_range": "40000..41000",
-      "authorized_users": "bob,alice"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy",
+      "config": {
+        "remote_hosts": "priv_host1,priv_host2",
+        "port_range": "40000..41000",
+        "authorized_users": "bob,alice"
+      }
     }
   }
 }
@@ -382,8 +386,10 @@ file illustrating these parameters...
 {
   "language": "python",
   "display_name": "Spark - Python (YARN Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/enterprise_gateway/itests/kernels/authorization_test/kernel.json
+++ b/enterprise_gateway/itests/kernels/authorization_test/kernel.json
@@ -1,11 +1,13 @@
 {
   "display_name": "Authorization Testing",
   "language": "python",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy",
-    "config": {
-      "authorized_users": "bob,alice,bad_guy",
-      "unauthorized_users": "bad_guy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy",
+      "config": {
+        "authorized_users": "bob,alice,bad_guy",
+        "unauthorized_users": "bad_guy"
+      }
     }
   },
   "env": {

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -18,8 +18,9 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-# Default logging level of yarn-api produces too much noise - raise to warning only.
+# Default logging level of yarn-api and underlying connectionpool produce too much noise - raise to warning only.
 logging.getLogger('yarn_api_client.resource_manager').setLevel(os.getenv('EG_YARN_LOG_LEVEL', logging.WARNING))
+logging.getLogger('urllib3.connectionpool').setLevel(os.environ.get('EG_YARN_LOG_LEVEL', logging.WARNING))
 
 local_ip = localinterfaces.public_ips()[0]
 poll_interval = float(os.getenv('EG_POLL_INTERVAL', '0.5'))

--- a/etc/kernelspecs/R_docker/kernel.json
+++ b/etc/kernelspecs/R_docker/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "R",
   "display_name": "R on Docker",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-r:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-r:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/R_kubernetes/kernel.json
+++ b/etc/kernelspecs/R_kubernetes/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "R",
   "display_name": "R on Kubernetes",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-r:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-r:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/python_distributed/kernel.json
+++ b/etc/kernelspecs/python_distributed/kernel.json
@@ -1,18 +1,20 @@
 {
- "display_name": "Python 2 (distributed)", 
- "language": "python", 
- "process_proxy": {
-   "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
- },
- "argv": [
-   "python",
-   "/usr/local/share/jupyter/kernels/python_distributed/scripts/launch_ipykernel.py",
-   "{connection_file}",
-   "--RemoteProcessProxy.response-address",
-   "{response_address}",
-   "--RemoteProcessProxy.port-range",
-   "{port_range}",
-   "--RemoteProcessProxy.spark-context-initialization-mode",
-   "none"
- ]
+  "display_name": "Python 2 (distributed)", 
+  "language": "python", 
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
+  },
+  "argv": [
+    "python",
+    "/usr/local/share/jupyter/kernels/python_distributed/scripts/launch_ipykernel.py",
+    "{connection_file}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}",
+    "--RemoteProcessProxy.spark-context-initialization-mode",
+    "none"
+  ]
 }

--- a/etc/kernelspecs/python_docker/kernel.json
+++ b/etc/kernelspecs/python_docker/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "python",
   "display_name": "Python on Docker",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/python_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_kubernetes/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "python",
   "display_name": "Python on Kubernetes",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_docker/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "python",
   "display_name": "Python on Docker with Tensorflow",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-tf-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-tf-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_gpu_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_docker/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "python",
   "display_name": "Python on Docker with Tensorflow with GPUs",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-tf-gpu-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-tf-gpu-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "python",
   "display_name": "Python on Kubernetes with Tensorflow with GPUs",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-tf-gpu-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-tf-gpu-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_kubernetes/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "python",
   "display_name": "Python on Kubernetes with Tensorflow",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-tf-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-tf-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/scala_docker/kernel.json
+++ b/etc/kernelspecs/scala_docker/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "scala",
   "display_name": "Scala on Docker",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-scala:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-scala:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/scala_kubernetes/kernel.json
@@ -1,10 +1,12 @@
 {
   "language": "scala",
   "display_name": "Scala on Kubernetes",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-scala:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-scala:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/spark_R_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_conductor_cluster/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "R",
   "display_name": "Spark R (Spark Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",

--- a/etc/kernelspecs/spark_R_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_R_kubernetes/kernel.json
@@ -1,11 +1,13 @@
 {
   "language": "R",
   "display_name": "Spark - R (Kubernetes Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-spark-r:VERSION",
-      "executor_image_name": "elyra/kernel-spark-r:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-spark-r:VERSION",
+        "executor_image_name": "elyra/kernel-spark-r:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "R",
   "display_name": "Spark - R (YARN Client Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "R",
   "display_name": "Spark - R (YARN Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "python",
   "display_name": "Spark Python (Spark Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
+    }
   },
   "env": { 
     "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",

--- a/etc/kernelspecs/spark_python_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_python_kubernetes/kernel.json
@@ -1,11 +1,13 @@
 {
   "language": "python",
   "display_name": "Spark - Python (Kubernetes Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-py:VERSION",
-      "executor_image_name": "elyra/kernel-py:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:VERSION",
+        "executor_image_name": "elyra/kernel-py:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "python",
   "display_name": "Spark - Python (YARN Client Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "python",
   "display_name": "Spark - Python (YARN Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/spark_scala_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_conductor_cluster/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "scala",
   "display_name": "Spark Scala (Spark Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID}",

--- a/etc/kernelspecs/spark_scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_scala_kubernetes/kernel.json
@@ -1,11 +1,13 @@
 {
   "language": "scala",
   "display_name": "Spark - Scala (Kubernetes Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
-    "config": {
-      "image_name": "elyra/kernel-scala:VERSION",
-      "executor_image_name": "elyra/kernel-scala:VERSION"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-scala:VERSION",
+        "executor_image_name": "elyra/kernel-scala:VERSION"
+      }
     }
   },
   "env": {

--- a/etc/kernelspecs/spark_scala_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_client/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "scala",
   "display_name": "Spark - Scala (YARN Client Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -1,8 +1,10 @@
 {
   "language": "scala",
   "display_name": "Spark - Scala (YARN Cluster Mode)",
-  "process_proxy": {
-    "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
+    }
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",


### PR DESCRIPTION
Enterprise Gateway now expects the process_proxy stanza (and any
sub-stanzas) to be located within the metadata stanza of the kernel.json
file.  `RemoteKernelSpec` still exists to detect malformed kernel.json
files and logs a warning message in such cases.  It also moves the
process_proxy dictionary into the metadata dictionary so downstream
code does not need to worry about the changes.  It does nothing to fix
the offending kernel.json file.

After some period, we will remove the `RemoteKernelSpec` class altogether
since its obsolete with these changes (and properly configured kernel.json
files).  If malformed kernel.jsons are encounterd after that removal,
they will behave as if no process_proxy stanza existed as unrecognized
entries are ignored.

Also found that urllib3.connectionpool is logging on every poll() when
YARN cluster kernels are running, so I added entry to promote its log
level to warning.  This can be altered via EG_YARN_LOG_LEVEL.

Fixes #474