### PR TITLE
Update IRkernel to version that fixes shutdown issue

### DIFF
--- a/docs/source/getting-started-kernels.md
+++ b/docs/source/getting-started-kernels.md
@@ -94,12 +94,12 @@ conda install --yes --quiet -c r r-essentials r-irkernel
 Rscript -e 'install.packages("argparser", repos="https://cran.rstudio.com")'
 
 
-# Create an R-script to run and install packages
+# Create an R-script to run and install packages and update IRkernel
 cat <<'EOF' > install_packages.R
 install.packages(c('repr', 'IRdisplay', 'evaluate', 'git2r', 'crayon', 'pbdZMQ',
                    'devtools', 'uuid', 'digest', 'RCurl', 'curl', 'argparser'),
                    repos='http://cran.rstudio.com/')
-devtools::install_github('IRkernel/IRkernel')
+devtools::install_github('IRkernel/IRkernel@0.8.14')
 IRkernel::installspec(user = FALSE)
 EOF
 

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -3,9 +3,13 @@
 # https://github.com/jupyter/docker-stacks/issues/679 - r-notebook kernel crashes because of png support
 FROM jupyter/r-notebook:8a1b90cbcba5
 
-# Additional package needed by launcher
+# Additional package needed by launcher, update IRkernel to fix kernel shutdown.
 RUN conda install --quiet --yes \
     'r-argparser=0.4*' && \
+     Rscript --slave --no-save --no-restore-history \
+        -e "options(unzip = 'internal')" \
+        -e "Sys.setenv(TAR = '/bin/tar')" \
+        -e "devtools::install_github('IRkernel/IRkernel@0.8.14')" && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /usr/share/doc/R/html && \
         -e "install.packages(pkgs=c('argparser','jsonlite','uuid','stringr','repr','IRdisplay','evaluate', 'crayon', 'pbdZMQ', 'digest', 'base64enc', 'versions'), \
         lib='/usr/lib/R/library', repos=c('http://cran.cnr.berkeley.edu/'))" \
         -e "versions::install.versions('devtools', '1.13.6', lib='/usr/lib/R/library')" \
-        -e "devtools::install_github('IRkernel/IRkernel')"
+        -e "devtools::install_github('IRkernel/IRkernel@0.8.14')"
 
 # Install OOTB kernelspecs
 ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/

--- a/etc/docker/yarn-spark/Dockerfile
+++ b/etc/docker/yarn-spark/Dockerfile
@@ -37,8 +37,12 @@ RUN cd /tmp && \
 	rm -f /tmp/toree-0.2.0.tar.gz
 
 # Install Anaconda R binaries, argparser and kernelspecs dir
-RUN conda install --yes --quiet -c r r-essentials r-irkernel && \
-	Rscript -e 'install.packages("argparser", repos="https://cran.rstudio.com")' 
+RUN conda install --yes --quiet -c r r-essentials r-irkernel r-devtools && \
+	Rscript --slave --no-save --no-restore-history \
+        -e 'install.packages("argparser", repos="https://cran.rstudio.com")' \
+        -e "options(unzip = 'internal')" \
+        -e "Sys.setenv(TAR = '/bin/tar')" \
+        -e "devtools::install_github('IRkernel/IRkernel@0.8.14')"
 
 # Create service user 'elyra'. Pin uid/gid to 1111.
 # Grant sudo privs to elyra. Unlock passwd (for ssh).


### PR DESCRIPTION
Use `devtools::install_github('IRkernel/IRkernel@0.8.14')` to update
IRkernel so that shutdowns are more graceful (and don't lead to
fallback (i.e., `kill`) measures).

Fixes #481