### PR TITLE
Add only appropriate launcher files to kernel images

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -96,8 +96,8 @@ clean-kernel-images: clean-kernel-py clean-kernel-spark-py clean-kernel-tf-py cl
 DEPENDS_nb2kg:
 DEPENDS_yarn-spark:
 DEPENDS_enterprise-gateway-demo: yarn-spark
-DEPENDS_enterprise-gateway: $(KERNELSPECS_FILE)
-DEPENDS_kernel-py DEPENDS_kernel-spark-py DEPENDS_kernel-r DEPENDS_kernel-spark-r DEPENDS_kernel-scala DEPENDS_kernel-tf-py DEPENDS_kernel-tf-gpu-py: $(KERNELSPECS_FILE)
+DEPENDS_enterprise-gateway: $(FILE_kernelspecs_all)
+DEPENDS_kernel-py DEPENDS_kernel-spark-py DEPENDS_kernel-r DEPENDS_kernel-spark-r DEPENDS_kernel-scala DEPENDS_kernel-tf-py DEPENDS_kernel-tf-gpu-py: $(FILE_kernelspecs_kubernetes) $(FILE_kernelspecs_docker)
 
 # Extra targets for each docker image...
 TARGETS_nb2kg:
@@ -111,20 +111,28 @@ FILES_nb2kg :=
 FILES_yarn-spark :=
 FILES_enterprise-gateway-demo := ../dist/jupyter_enterprise_gateway_kernelspecs-* ../dist/jupyter_enterprise_gateway*.whl
 FILES_enterprise-gateway := ../dist/jupyter_enterprise_gateway_kernelspecs-* ../dist/jupyter_enterprise_gateway*.whl
-FILES_kernel-py := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}* kernel-launchers/python/bootstrap/*
-FILES_kernel-spark-py := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}*
-FILES_kernel-tf-py := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}* kernel-launchers/python/bootstrap/*
-FILES_kernel-tf-gpu-py := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}* kernel-launchers/python/bootstrap/*
-FILES_kernel-r := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}* kernel-launchers/R/bootstrap/*
-FILES_kernel-spark-r := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}*
-FILES_kernel-scala := ../dist/jupyter_enterprise_gateway_kernelspecs_{d,k}* kernel-launchers/scala/bootstrap/*
+FILES_kernel-py := kernel-launchers/python/bootstrap/*
+FILES_kernel-spark-py := 
+FILES_kernel-tf-py := kernel-launchers/python/bootstrap/*
+FILES_kernel-tf-gpu-py := kernel-launchers/python/bootstrap/*
+FILES_kernel-r := kernel-launchers/R/bootstrap/*
+FILES_kernel-spark-r := 
+FILES_kernel-scala := kernel-launchers/scala/bootstrap/*
 
-# Publish each publish image on $(PUBLISHED_IMAGES) to DockerHub.  Switch 'eval' to 'info' to see what is produced.
-define PUBLISH_IMAGE
-publish-$1:
-	@docker push $(HUB_ORG)/$1:$(TAG)
-endef
-$(foreach image,$(PUBLISHED_IMAGES),$(eval $(call PUBLISH_IMAGE,$(image))))
+# Trim out only the kernelspec files needed in each of the kernel images. Note that because kernel-based
+# images only require the launcher (and supporting files) and launchers are consistent across kernel types,
+# we can use the base kernelspecs.
+LAUNCHER_FILES_nb2kg :=
+LAUNCHER_FILES_yarn-spark :=
+LAUNCHER_FILES_enterprise-gateway-demo := 
+LAUNCHER_FILES_enterprise-gateway := kernel-launchers/scala
+LAUNCHER_FILES_kernel-py := kernel-launchers/python
+LAUNCHER_FILES_kernel-spark-py := kernel-launchers/python
+LAUNCHER_FILES_kernel-tf-py := kernel-launchers/python
+LAUNCHER_FILES_kernel-tf-gpu-py := kernel-launchers/python
+LAUNCHER_FILES_kernel-r := kernel-launchers/R
+LAUNCHER_FILES_kernel-spark-r := kernel-launchers/R
+LAUNCHER_FILES_kernel-scala := kernel-launchers/scala
 
 # Generate image creation targets for each entry in $(DOCKER_IMAGES).  Switch 'eval' to 'info' to see what is produced.
 define BUILD_IMAGE
@@ -132,13 +140,13 @@ $1: ../.image-$1
 ../.image-$1: docker/$1/* DEPENDS_$1
 	@make clean-$1 TARGETS_$1
 	@mkdir -p ../build/docker/$1
-	cp -r docker/$1/* $$(FILES_$1) ../build/docker/$1
+	@cp -r docker/$1/* $$(FILES_$1) ../build/docker/$1
+	@(if [[ ! -z "$$(LAUNCHER_FILES_$1)" ]]; then mkdir -p ../build/docker/$1/kernel-launchers; cp -r $$(LAUNCHER_FILES_$1) ../build/docker/$1/kernel-launchers; rm -rf ../build/docker/$1/kernel-launchers/*/bootstrap; fi;)
 	@(cd ../build/docker/$1; docker build --build-arg HUB_ORG=${HUB_ORG} --build-arg VERSION=${VERSION} -t $(HUB_ORG)/$1:$(TAG) .)
 	@touch ../.image-$1
 	@-docker images $(HUB_ORG)/$1:$(TAG)
 endef
 $(foreach image,$(DOCKER_IMAGES),$(eval $(call BUILD_IMAGE,$(image))))
-
 
 # Generate clean-xxx targets for each entry in $(DOCKER_IMAGES).  Switch 'eval' to 'info' to see what is produced.
 define CLEAN_IMAGE
@@ -147,4 +155,11 @@ clean-$1:
 	@-docker rmi -f $(HUB_ORG)/$1:$(TAG)
 endef
 $(foreach image,$(DOCKER_IMAGES),$(eval $(call CLEAN_IMAGE,$(image))))
+
+# Publish each publish image on $(PUBLISHED_IMAGES) to DockerHub.  Switch 'eval' to 'info' to see what is produced.
+define PUBLISH_IMAGE
+publish-$1:
+	@docker push $(HUB_ORG)/$1:$(TAG)
+endef
+$(foreach image,$(PUBLISHED_IMAGES),$(eval $(call PUBLISH_IMAGE,$(image))))
 

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -9,6 +9,7 @@ RUN pip install cffi send2trash /tmp/jupyter_enterprise_gateway*.whl && \
 	rm -f /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway_kernelspecs*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 COPY start-enterprise-gateway.sh /usr/local/share/jupyter
 COPY bootstrap-enterprise-gateway.sh /etc/bootstrap-enterprise-gateway.sh

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -2,7 +2,7 @@ FROM jupyter/scipy-notebook:61d8aaedaeaf
 
 RUN pip install pycrypto
 
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 COPY bootstrap-kernel.sh /etc/
 

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -14,7 +14,7 @@ RUN conda install --quiet --yes \
     fix-permissions $CONDA_DIR
 
 # Install OOTB kernelspecs
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 # Use our bootstrap file.  Kubernetes kernel yaml will reference this file
 # as the image's CMD in the k8s context.

--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -1,6 +1,6 @@
 FROM elyra/spark:v2.4.0
 
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 COPY bootstrap-kernel.sh /etc/
 

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -3,7 +3,7 @@ FROM elyra/spark-py:v2.4.0
 RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev && \
     pip install cffi ipykernel ipython jupyter_client pycrypto
 
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 RUN addgroup -S -g 620 eg-kernel && adduser -S -u 620 -G eg-kernel eg-kernel && \
 	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter /opt/spark/work-dir

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /usr/share/doc/R/html && \
         -e "devtools::install_github('IRkernel/IRkernel@0.8.14')"
 
 # Install OOTB kernelspecs
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 RUN addgroup -S -g 620 eg-kernel && adduser -S -u 620 -G eg-kernel eg-kernel && \
 	chown -R eg-kernel.eg-kernel /usr/local/share/jupyter /opt/spark/work-dir

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -2,7 +2,7 @@ FROM tensorflow/tensorflow:1.11.0-gpu-py3
 
 RUN pip install pycrypto
 
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 COPY bootstrap-kernel.sh /etc/
 

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -2,7 +2,7 @@ FROM tensorflow/tensorflow:1.11.0-py3
 
 RUN pip install pycrypto
 
-ADD jupyter_enterprise_gateway*.tar.gz /usr/local/share/jupyter/kernels/
+COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
 
 COPY bootstrap-kernel.sh /etc/
 

--- a/etc/kernel-launchers/R/bootstrap/bootstrap-kernel.sh
+++ b/etc/kernel-launchers/R/bootstrap/bootstrap-kernel.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-KERNEL_SPECS_PATH=${KERNEL_SPECS_PATH:-/usr/local/share/jupyter/kernels}
+KERNEL_LAUNCHERS_PATH=/usr/local/share/jupyter/kernel-launchers
 
 echo kernel-bootstrap.sh env: `env`
 
 if [[ "${KERNEL_LANGUAGE}" == "r" ]];
 then
-	echo "Rscript ${KERNEL_SPECS_PATH}/${KERNEL_NAME}/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
-	Rscript ${KERNEL_SPECS_PATH}/${KERNEL_NAME}/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
+	echo "Rscript ${KERNEL_LAUNCHERS_PATH}/R/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
+	Rscript ${KERNEL_LAUNCHERS_PATH}/R/scripts/launch_IRkernel.R ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
 else
 	echo "Unrecognized value for KERNEL_LANGUAGE: '${KERNEL_LANGUAGE}'!"
 	exit 1

--- a/etc/kernel-launchers/python/bootstrap/bootstrap-kernel.sh
+++ b/etc/kernel-launchers/python/bootstrap/bootstrap-kernel.sh
@@ -2,14 +2,14 @@
 
 export JPY_PARENT_PID=$$  # Force reset of parent pid since we're detached
 
-KERNEL_SPECS_PATH=${KERNEL_SPECS_PATH:-/usr/local/share/jupyter/kernels}
+KERNEL_LAUNCHERS_PATH=/usr/local/share/jupyter/kernel-launchers
 
 echo kernel-bootstrap.sh env: `env`
 
 if [[ "${KERNEL_LANGUAGE}" == "python" ]];
 then
-	echo "python ${KERNEL_SPECS_PATH}/${KERNEL_NAME}/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
-	python ${KERNEL_SPECS_PATH}/${KERNEL_NAME}/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
+	echo "python ${KERNEL_LAUNCHERS_PATH}/python/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}"
+	python ${KERNEL_LAUNCHERS_PATH}/python/scripts/launch_ipykernel.py ${KERNEL_CONNECTION_FILENAME} --RemoteProcessProxy.response-address ${EG_RESPONSE_ADDRESS} --RemoteProcessProxy.spark-context-initialization-mode ${KERNEL_SPARK_CONTEXT_INIT_MODE}
 else
 	echo "Unrecognized value for KERNEL_LANGUAGE: '${KERNEL_LANGUAGE}'!"
 	exit 1

--- a/etc/kernel-launchers/scala/bootstrap/bootstrap-kernel.sh
+++ b/etc/kernel-launchers/scala/bootstrap/bootstrap-kernel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KERNEL_SPECS_PATH=${KERNEL_SPECS_PATH:-/usr/local/share/jupyter/kernels}
+KERNEL_LAUNCHERS_PATH=/usr/local/share/jupyter/kernel-launchers
 
 echo kernel-bootstrap.sh env: `env`
 
@@ -10,7 +10,7 @@ then
 	exit 1
 fi
 
-PROG_HOME=${KERNEL_SPECS_PATH}/${KERNEL_NAME}
+PROG_HOME=${KERNEL_LAUNCHERS_PATH}/scala
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
 if [ ! -f ${TOREE_ASSEMBLY} ]; then

--- a/etc/kernelspecs/spark_R_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_R_kubernetes/bin/run.sh
@@ -22,7 +22,7 @@ if [ -z "${KERNEL_ID}" ]; then
   exit 1
 fi
 
-PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+PROG_HOME=/usr/local/share/jupyter/kernel-launchers/R
 
 set -x
 eval exec \

--- a/etc/kernelspecs/spark_python_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_python_kubernetes/bin/run.sh
@@ -22,7 +22,7 @@ if [ -z "${KERNEL_ID}" ]; then
   exit 1
 fi
 
-PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+PROG_HOME=/usr/local/share/jupyter/kernel-launchers/python
 
 set -x
 eval exec \

--- a/etc/kernelspecs/spark_scala_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_kubernetes/bin/run.sh
@@ -22,7 +22,7 @@ if [ -z "${KERNEL_ID}" ]; then
   exit 1
 fi
 
-PROG_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+PROG_HOME=/usr/local/share/jupyter/kernel-launchers/scala
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
 if [ ! -f ${TOREE_ASSEMBLY} ]; then


### PR DESCRIPTION
Rather than have a set of multiple language kernelspecs in each kernel-image,
this change only adds the appropriate _launcher files_ to each kernel image.
This enables applications to create their own kernelspec files for each of
the supported languages w/o requiring them to update the kernel-image or
have to share a volume with the kernel image in order to expose their kernel-spec.

Each kernel-image now contains a kernel-launchers/<language> directory in
/usr/local/share/jupyter.  There is no sibling kernels directory in these
images.  In addition, since the enterprise-gateway image needs to obtain the
actual name of the scala launcher files (since these contain version-specific
values), it too must have a kernel-launchers/scala directory (unfortunately).

NOTE: THIS PULL REQUEST SHOULD BE MERGED AFTER #492 SINCE IT IS BUILT FROM
THAT BRANCH!

Fixes #493
