### PR TITLE
Fix max-kernels-per-user when KERNEL_USERNAME not set

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -10,6 +10,7 @@ import uuid
 from ipython_genutils.importstring import import_item
 from kernel_gateway.services.kernels.manager import SeedingMappingKernelManager, KernelGatewayIOLoopKernelManager
 from ..processproxies.processproxy import LocalProcessProxy, RemoteProcessProxy
+from ..sessions.kernelsessionmanager import KernelSessionManager
 from tornado import gen
 from ipython_genutils.py3compat import (bytes_to_str, str_to_bytes, unicode_type)
 
@@ -26,6 +27,7 @@ def get_process_proxy_config(kernelspec):
                 return process_proxy  # Return what we found (plus config stanza if necessary)
     return {"class_name": "enterprise_gateway.services.processproxies.processproxy.LocalProcessProxy", "config": {}}
 
+
 class RemoteMappingKernelManager(SeedingMappingKernelManager):
     """Extends the SeedingMappingKernelManager.
 
@@ -37,7 +39,9 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
 
     @gen.coroutine
     def start_kernel(self, *args, **kwargs):
-        self.log.debug("RemoteMappingKernelManager.start_kernel: {}".format(kwargs['kernel_name']))
+        username = KernelSessionManager.get_kernel_username(**kwargs)
+        self.log.debug("RemoteMappingKernelManager.start_kernel: {kernel_name}, kernel_username: {username}".
+                       format(kernel_name=kwargs['kernel_name'], username=username))
         kernel_id = yield gen.maybe_future(super(RemoteMappingKernelManager, self).start_kernel(*args, **kwargs))
         self.parent.kernel_session_manager.create_session(kernel_id, **kwargs)
         raise gen.Return(kernel_id)

--- a/enterprise_gateway/services/processproxies/k8s.py
+++ b/enterprise_gateway/services/processproxies/k8s.py
@@ -7,6 +7,7 @@ import logging
 from socket import *
 from .container import ContainerProcessProxy
 from kubernetes import client, config
+from ..sessions.kernelsessionmanager import KernelSessionManager
 import urllib3
 urllib3.disable_warnings()
 
@@ -132,7 +133,8 @@ class KubernetesProcessProxy(ContainerProcessProxy):
                 self.log.warning("Shared namespace has been configured.  All kernels will reside in EG namespace: {}".
                                  format(namespace))
             else:
-                namespace = self._create_kernel_namespace(self.get_kernel_username(**kw), service_account_name)
+                namespace = self._create_kernel_namespace(KernelSessionManager.get_kernel_username(**kw),
+                                                          service_account_name)
             kw['env']['KERNEL_NAMESPACE'] = namespace  # record in env since kernel needs this
         else:
             self.log.info("KERNEL_NAMESPACE provided by client: {}".format(namespace))


### PR DESCRIPTION
When the `KERNEL_USERNAME` is not provided in the kernel creation request,
the code that manages sessions would use a value of 'unspecified' while the
code that enforces limits would use the server's process username.  This
change uses a consolidated method so all locations render the same behavior
relative to defaulted values.

We will now also display the value of the kernel username when starting the kernel.

Note: These changes need to be merged into the 1.x branch where applicable.

Fixes #490