### PR TITLE
Add kernel-id parameter, cleanup launchers

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -140,6 +140,7 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
         self.response_address = None
         self.sigint_value = None
         self.port_range = None
+        self.kernel_id = None
         self.user_overrides = {}
         self.restarting = False  # need to track whether we're in a restart situation or not
 
@@ -169,22 +170,25 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
                                     key in self.parent.parent.personality.env_whitelist})
 
     def format_kernel_cmd(self, extra_arguments=None):
-        """replace templated args (e.g. {response_address} or {port_range})"""
+        """replace templated args (e.g. {response_address}, {port_range}, or {kernel_id})"""
         cmd = super(RemoteKernelManager, self).format_kernel_cmd(extra_arguments)
 
-        if self.response_address or self.port_range:
+        if self.response_address or self.port_range or self.kernel_id:
             ns = self._launch_args.copy()
             if self.response_address:
                 ns['response_address'] = self.response_address
             if self.port_range:
                 ns['port_range'] = self.port_range
+            if self.kernel_id:
+                ns['kernel_id'] = self.kernel_id
 
             pat = re.compile(r'\{([A-Za-z0-9_]+)\}')
+
             def from_ns(match):
                 """Get the key out of ns if it's there, otherwise no change."""
                 return ns.get(match.group(1), match.group())
 
-            return [ pat.sub(from_ns, arg) for arg in cmd ]
+            return [pat.sub(from_ns, arg) for arg in cmd]
         return cmd
 
     def _launch_kernel(self, kernel_cmd, **kw):

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -104,8 +104,9 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
         self.kernel_manager.ip = '0.0.0.0'
         self.log = kernel_manager.log
         # extract the kernel_id string from the connection file and set the KERNEL_ID environment variable
-        self.kernel_id = os.path.basename(self.kernel_manager.connection_file). \
+        self.kernel_manager.kernel_id = os.path.basename(self.kernel_manager.connection_file). \
             replace('kernel-', '').replace('.json', '')
+        self.kernel_id = self.kernel_manager.kernel_id
         self.kernel_launch_timeout = default_kernel_launch_timeout
         self.lower_port = 0
         self.upper_port = 0
@@ -331,16 +332,6 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
         if result == 0:
             return None
         return False
-
-    def get_connection_filename(self):
-        """
-            Although we're just using the same connection file (location) on the remote system, go ahead and 
-            keep this method in case we want the remote connection file to be in a different location.  Should
-            we decide to keep the current code, we should probably force the local location by requiring that
-            either JUPYTER_DATA_DIR or JUPYTER_RUNTIME_DIR envs be set and issue a warning if not - which could
-            also be done from this method.
-        """
-        return self.kernel_manager.connection_file
 
     def _enforce_authorization(self, **kw):
         """

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -39,7 +39,8 @@ FILES_kernelspecs_all:=$(shell find kernel-launchers kernelspecs -type f -name '
 TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -type f -name '*')
 
 ../build/kernelspecs: kernel-launchers/scala/lib  $(FILES_kernelspecs_all) 
-	@mkdir -p ../build/kernelspecs
+	@rm -rf ../build/kernelspecs
+	@mkdir ../build/kernelspecs
     # Seed the build tree with initial files
 	cp -r kernelspecs ../build
     # Distribute language and config-sensitive files.

--- a/etc/kernelspecs/R_docker/kernel.json
+++ b/etc/kernelspecs/R_docker/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/R_docker/scripts/launch_docker.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/R_kubernetes/kernel.json
+++ b/etc/kernelspecs/R_kubernetes/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/R_kubernetes/scripts/launch_kubernetes.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/python_distributed/kernel.json
+++ b/etc/kernelspecs/python_distributed/kernel.json
@@ -9,7 +9,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_distributed/scripts/launch_ipykernel.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/python_docker/kernel.json
+++ b/etc/kernelspecs/python_docker/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_docker/scripts/launch_docker.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/python_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_kubernetes/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_kubernetes.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/python_tf_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_docker/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_tf_docker/scripts/launch_docker.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/python_tf_gpu_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_docker/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_tf_gpu_docker/scripts/launch_docker.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_tf_gpu_kubernetes/scripts/launch_kubernetes.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/python_tf_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_kubernetes/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/python_tf_kubernetes/scripts/launch_kubernetes.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/scala_docker/kernel.json
+++ b/etc/kernelspecs/scala_docker/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/scala_docker/scripts/launch_docker.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/scala_kubernetes/kernel.json
@@ -14,7 +14,8 @@
   "argv": [
     "python",
     "/usr/local/share/jupyter/kernels/scala_kubernetes/scripts/launch_kubernetes.py",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/spark_R_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_conductor_cluster/kernel.json
@@ -11,7 +11,8 @@
     "LAUNCH_OPTS": "--customAppName ${KERNEL_ID}"
   },
   "argv": [
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_R_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_R_kubernetes/kernel.json
@@ -17,7 +17,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_R_kubernetes/bin/run.sh",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -13,7 +13,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_R_yarn_client/bin/run.sh",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -13,7 +13,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_R_yarn_cluster/bin/run.sh",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
@@ -11,7 +11,8 @@
     "LAUNCH_OPTS": ""
   },
   "argv": [ 
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_python_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_python_kubernetes/kernel.json
@@ -17,7 +17,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_python_kubernetes/bin/run.sh",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -15,7 +15,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_python_yarn_client/bin/run.sh",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -15,7 +15,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_python_yarn_cluster/bin/run.sh",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_scala_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_conductor_cluster/kernel.json
@@ -13,8 +13,8 @@
     "DEFAULT_INTERPRETER": "Scala"
   },
   "argv": [
-    "--profile",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_scala_kubernetes/kernel.json
@@ -19,8 +19,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_scala_kubernetes/bin/run.sh",
-    "--profile",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.spark-context-initialization-mode",

--- a/etc/kernelspecs/spark_scala_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_client/kernel.json
@@ -15,8 +15,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_scala_yarn_client/bin/run.sh",
-    "--profile",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",

--- a/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_scala_yarn_cluster/kernel.json
@@ -15,8 +15,8 @@
   },
   "argv": [
     "/usr/local/share/jupyter/kernels/spark_scala_yarn_cluster/bin/run.sh",
-    "--profile",
-    "{connection_file}",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
     "--RemoteProcessProxy.response-address",
     "{response_address}",
     "--RemoteProcessProxy.port-range",


### PR DESCRIPTION
Replaced the `{connection_file}` parameter in the `kernel.json` files with
`--RemoteProcessProxy.kernel-id {kernel_id}` since the former parameter was
used solely to extract the kernel's ID and create a new file to hold the
connection information.

The scala and python launchers will still honor `{connection_file}` but give
preference to the new parameter if both are provided.  They will also issue a
warning in such cases indicating that `{connection_file}` is deprecated.

The R launcher, however, uses the `argparser` library which does not support
optional positional arguments (like `{connection_file}` now becomes).  As a
result, the R launcher doesn't support the previous form.  This should only
be a problem where there `kernel.json` has not been updated, but the launcher
has been updated (which shouldn't happen).  I felt the trade-off between that
and switching to the `argparse` library was safer, since existing systems
won't necessarily have `argparse`.  That said, we may want to switch from
`argparser` to `argparse` at some point to acheive consistency with python.

I also enhanced the logging in the python and R launchers so poll requests do
not produce output (which happens every 3 seconds).

Fixed a dependency bug in `make kernelspecs` which was preventing the tar
files from getting rebuilt whenever one of their files was updated.

Fixes #500