### PR TITLE
Update IRkernel to pull from CRAN instead of Github

### DIFF
--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -37,12 +37,10 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86
     ln -s /opt/anaconda2/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/anaconda2/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc
-RUN conda install -v --yes --quiet pip jupyter r-irkernel r-devtools && \
-	Rscript -e 'install.packages("argparser", repos="https://cran.rstudio.com")' \
-            -e 'devtools::install_github("apache/spark@v2.3.1", subdir="R/pkg")' \
-            -e "options(unzip = 'internal')" \
-            -e "Sys.setenv(TAR = '/bin/tar')" \
-            -e "devtools::install_github('IRkernel/IRkernel@0.8.14')"
+RUN conda install -v --yes --quiet pip jupyter r-devtools && \
+	Rscript -e 'install.packages("argparser", repos="http://cran.cnr.berkeley.edu")' \
+	        -e 'install.packages("IRkernel", repos="http://cran.cnr.berkeley.edu", lib="/opt/anaconda2/lib/R/library")' \
+            -e 'devtools::install_github("apache/spark@v2.3.1", subdir="R/pkg")'
 
 # SETUP HADOOP CONFIGS
 RUN cd /usr/local && ln -s ./hadoop-$HADOOP_VER hadoop

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER akchinSTC
 # INSTALL / DOWNLOAD ALL NEEDED PACKAGES
 RUN yum update -y && \
     yum install -y which tar bzip2 wget curl sudo openssh-server openssh-clients java-1.8.0-openjdk.x86_64 less \
-                   unzip gcc krb5-devel && \
+                   unzip gcc krb5-devel file libunwind && \
     yum clean all
 
 # SYSTEM ENVS
@@ -37,9 +37,10 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86
     ln -s /opt/anaconda2/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     echo ". /opt/anaconda2/etc/profile.d/conda.sh" >> ~/.bashrc && \
     echo "conda activate base" >> ~/.bashrc
-RUN conda install -v --yes --quiet pip jupyter r-devtools && \
-	Rscript -e 'install.packages("argparser", repos="http://cran.cnr.berkeley.edu")' \
+RUN conda install -v --yes --quiet pip jupyter r-devtools r-stringr
+RUN Rscript -e 'install.packages("argparser", repos="http://cran.cnr.berkeley.edu")' \
 	        -e 'install.packages("IRkernel", repos="http://cran.cnr.berkeley.edu", lib="/opt/anaconda2/lib/R/library")' \
+	        -e 'IRkernel::installspec(prefix = "/usr/local")' \
             -e 'devtools::install_github("apache/spark@v2.3.1", subdir="R/pkg")'
 
 # SETUP HADOOP CONFIGS

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -8,9 +8,7 @@ FROM jupyter/r-notebook:8a1b90cbcba5
 RUN conda install --quiet --yes \
     'r-argparser=0.4*' && \
      Rscript --slave --no-save --no-restore-history \
-        -e "options(unzip = 'internal')" \
-        -e "Sys.setenv(TAR = '/bin/tar')" \
-        -e "devtools::install_github('IRkernel/IRkernel@0.8.14')" && \
+        -e "install.packages('IRkernel', repos='http://cran.cnr.berkeley.edu/')" && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -11,10 +11,10 @@ RUN apk add --no-cache build-base libzmq python-dev && \
 # then some R things...
 RUN mkdir -p /usr/share/doc/R/html && \
     Rscript --slave --no-save --no-restore-history \
-        -e "install.packages(pkgs=c('argparser','jsonlite','uuid','stringr','repr','IRdisplay','evaluate', 'crayon', 'pbdZMQ', 'digest', 'base64enc', 'versions'), \
-        lib='/usr/lib/R/library', repos=c('http://cran.cnr.berkeley.edu/'))" \
-        -e "versions::install.versions('devtools', '1.13.6', lib='/usr/lib/R/library')" \
-        -e "devtools::install_github('IRkernel/IRkernel@0.8.14')"
+        -e "install.packages(pkgs=c('argparser','jsonlite','uuid','stringr','repr','IRkernel','IRdisplay', \
+                                    'evaluate', 'crayon', 'pbdZMQ', 'digest', 'base64enc','versions'), \
+                                    lib='/usr/lib/R/library', repos=c('http://cran.cnr.berkeley.edu/'))" \
+        -e "versions::install.versions('devtools', '1.13.6', lib='/usr/lib/R/library')"
 
 # Install OOTB kernelspecs
 COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/


### PR DESCRIPTION
Updated pulls for IRkernel v0.8.14 via CRAN.
Updated CRAN mirrors to be consistent across dockerfiles
Removed conda installation of IRkernel so all dockerfiles pull IRkernel from CRAN