### PR TITLE
Reset watch-activity callback on remote-proxy restarts

### DIFF
--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -178,6 +178,17 @@ class Kernel:
         else:
             raise RuntimeError('Unexpected response restarting kernel {}: {}'.format(self.kernel_id, response.content))
 
+    def get_state(self):
+        url = "{}".format(self.kernel_http_api_endpoint)
+        response = requests.get(url)
+        if response.status_code == 200:
+            json = response.json()
+            print('Kernel {} state: {}'.format(self.kernel_id, json))
+            return json['execution_state']
+        else:
+            raise RuntimeError('Unexpected response retrieving state for kernel {}: {}'.
+                               format(self.kernel_id, response.content))
+
     def start_interrupt_thread(self, wait_time=DEFAULT_INTERRUPT_WAIT):
         self.interrupt_thread = Thread(target=self.perform_interrupt, args=(wait_time,))
         self.interrupt_thread.start()

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -24,6 +24,8 @@ class PythonKernelBaseTestCase(object):
 
         self.assertTrue(self.kernel.restart())
 
+        self.assertEquals(self.kernel.get_state(), "idle")
+
         error_result = self.kernel.execute("y = x + 1")
         self.assertRegexpMatches(error_result, 'NameError')
 


### PR DESCRIPTION
When EG restarts remote kernels, it creates a new set of ports.  This
was causing the activity_stream code, tied to iopub, to stop getting
updated.  This change starts a new activity-watcher on restarts of
RemoteProcessProxy instances.

Added the capability to fetch a kernel's activity for use in test code.