### PR TITLE
[WIP] Updating to use OpenJDK instead of oracle

### DIFF
--- a/etc/docker/yarn-spark/Dockerfile
+++ b/etc/docker/yarn-spark/Dockerfile
@@ -4,10 +4,11 @@ FROM aghorbani/spark:2.1.0
 USER root
 
 ENV ANACONDA_HOME=/opt/anaconda2
-ENV PATH=$ANACONDA_HOME/bin:$PATH
+ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0
+ENV PATH=$ANACONDA_HOME/bin:$JAVA_HOME/bin:$PATH
 ENV PYSPARK_PYTHON=$ANACONDA_HOME/bin/python
 
-RUN yum install -y gcc krb5-devel; yum clean all
+RUN yum install -y gcc krb5-devel java-1.8.0-openjdk.x86_64; yum clean all
 
 COPY yarn-site.xml.template /usr/local/hadoop/etc/hadoop/
 
@@ -16,14 +17,6 @@ RUN cd /tmp && \
 	curl -LO 'http://vault.centos.org/6.9/os/Source/SPackages/rsyslog-5.8.10-10.el6_6.src.rpm' && \
 	rpm -i /tmp/rsyslog-5.8.10-10.el6_6.src.rpm && \
 	rm -f /tmp/rsyslog-5.8.10-10.el6_6.src.rpm
-
-# Update Java
-RUN cd /tmp && \
-	curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/jdk-8u181-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
-	rpm -e jdk-1.7.0_71-fcs.x86_64 && \
-	rpm -i /tmp/jdk-8u181-linux-x64.rpm && \
-	rm -f /tmp/jdk-8u181-linux-x64.rpm
-
 
 # Install Anaconda
 RUN cd /tmp && \


### PR DESCRIPTION
1.x builds were failing due to broken link to oracle JDK in image used for testing. Removed and replaced with OpenJDK from system packages (via yum) to avoid having to update the oracle link too frequently.