### PR TITLE
Copy restart fix from 1.x (PR 514) to master

### DIFF
--- a/enterprise_gateway/client/gateway_client.py
+++ b/enterprise_gateway/client/gateway_client.py
@@ -178,6 +178,17 @@ class Kernel:
         else:
             raise RuntimeError('Unexpected response restarting kernel {}: {}'.format(self.kernel_id, response.content))
 
+    def get_state(self):
+        url = "{}".format(self.kernel_http_api_endpoint)
+        response = requests.get(url)
+        if response.status_code == 200:
+            json = response.json()
+            print('Kernel {} state: {}'.format(self.kernel_id, json))
+            return json['execution_state']
+        else:
+            raise RuntimeError('Unexpected response retrieving state for kernel {}: {}'.
+                               format(self.kernel_id, response.content))
+
     def start_interrupt_thread(self, wait_time=DEFAULT_INTERRUPT_WAIT):
         self.interrupt_thread = Thread(target=self.perform_interrupt, args=(wait_time,))
         self.interrupt_thread.start()

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -24,6 +24,8 @@ class PythonKernelBaseTestCase(object):
 
         self.assertTrue(self.kernel.restart())
 
+        self.assertEquals(self.kernel.get_state(), "idle")
+
         error_result = self.kernel.execute("y = x + 1")
         self.assertRegexpMatches(error_result, 'NameError')
 

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -232,6 +232,12 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
                 self.parent.shutdown_kernel(kernel_id, now=now)
                 return
         super(RemoteKernelManager, self).restart_kernel(now, **kw)
+        if isinstance(self.process_proxy, RemoteProcessProxy):  # for remote kernels...
+            # Re-establish activity watching...
+            if self._activity_stream:
+                self._activity_stream.close()
+                self._activity_stream = None
+            self.parent.start_watching_activity(kernel_id)
         # Refresh persisted state.
         self.parent.parent.kernel_session_manager.refresh_session(kernel_id)
         self.restarting = False


### PR DESCRIPTION
These changes are a copy of those used in PR #514...

When EG restarts remote kernels, it creates a new set of ports. This
was causing the activity_stream code, tied to iopub, to stop getting
updated. This change starts a new activity-watcher on restarts of
RemoteProcessProxy instances.

Added the capability to fetch a kernel's activity for use in test code.

Fixes #513