### PR TITLE
Add imagePullPolicy to make sure latest :dev is always pulled

### DIFF
--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -170,6 +170,10 @@ spec:
           value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
         # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
         image: elyra/enterprise-gateway:dev
+        # k8s will only pull :latest all the time.  
+        # the following line will make sure that :dev is always pulled
+        # You should remove this if you want to pin EG to a release tag
+        imagePullPolicy: Always
         name: enterprise-gateway
         args: ["--gateway"]
         ports:


### PR DESCRIPTION
k8s will only pull :latest, this makes sure that the latest :dev is always pulled.  One would likely want to remove this when using a stable release tag.  