### PR TITLE
Package kernel launcher files for custom kernel images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ dev: ## Make a server in jupyter_websocket mode
 docs: ## Make HTML documentation
 	$(SA) $(ENV) && make -C docs html
 
-kernelspecs:  kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker ## Create archives with sample kernelspecs
-kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker: 
+kernelspecs:  kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker kernel_image_files ## Create archives with sample kernelspecs
+kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker kernel_image_files: 
 	make VERSION=$(VERSION) TAG=$(TAG) -C  etc $@
 
 install: ## Make a conda env with dist/*.whl and dist/*.tar.gz installed

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -26,7 +26,7 @@ clean: ## Make a clean source tree
 #
 
 KERNELSPECS := kernelspecs_all kernelspecs_yarn kernelspecs_conductor kernelspecs_kubernetes kernelspecs_docker
-kernelspecs: $(KERNELSPECS)
+kernelspecs: $(KERNELSPECS) kernel_image_files
 
 FILE_kernelspecs_all:=../dist/jupyter_enterprise_gateway_kernelspecs-$(VERSION).tar.gz
 FILE_kernelspecs_yarn:=../dist/jupyter_enterprise_gateway_kernelspecs_yarn-$(VERSION).tar.gz
@@ -40,15 +40,18 @@ TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -ty
 
 ../build/kernelspecs: kernel-launchers/scala/lib  $(FILES_kernelspecs_all) 
 	@rm -rf ../build/kernelspecs
-	@mkdir ../build/kernelspecs
+	@mkdir -p ../build/kernelspecs
     # Seed the build tree with initial files
 	cp -r kernelspecs ../build
     # Distribute language and config-sensitive files.
-	@echo ../build/kernelspecs/{spark_,dask_,}python_* | xargs -t -n 1 cp -r kernel-launchers/python/scripts
-	@echo ../build/kernelspecs/{spark_,}R_* | xargs -t -n 1 cp -r kernel-launchers/R/scripts
-	@echo ../build/kernelspecs/{spark_,}scala_* | xargs -t -n 1 cp -r kernel-launchers/scala/lib
+    # On-prem kernelspecs get launcher files in the kernelspec hierarchy
+	@echo ../build/kernelspecs/python_distributed | xargs -t -n 1 cp -r kernel-launchers/python/scripts
+	@echo ../build/kernelspecs/dask_python_* | xargs -t -n 1 cp -r kernel-launchers/python/scripts
+	@echo ../build/kernelspecs/spark_python_{conductor*,yarn*} | xargs -t -n 1 cp -r kernel-launchers/python/scripts
+	@echo ../build/kernelspecs/spark_R_{conductor*,yarn*} | xargs -t -n 1 cp -r kernel-launchers/R/scripts
+	@echo ../build/kernelspecs/spark_scala_{conductor*,yarn*} | xargs -t -n 1 cp -r kernel-launchers/scala/lib
+	# Container-based kernelspecs just get the container launchers
 	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_kubernetes | xargs -t -n 1 cp -r kernel-launchers/kubernetes/*
-    # Fixme - deal with spark-based docker containers...
 	@echo ../build/kernelspecs/{python,R,scala,python_tf,python_tf_gpu}_docker | xargs -t -n 1 cp -r kernel-launchers/docker/*
     # Perform the copy again to enable local, per-kernel, overrides
 	cp -r kernelspecs ../build
@@ -74,7 +77,19 @@ kernel-launchers/scala/lib: $(TOREE_LAUNCHER_FILES)
 	mkdir -p kernel-launchers/scala/lib
 	@(cd kernel-launchers/scala/toree-launcher; sbt -Dversion=$(VERSION) package; cp target/scala-2.11/*.jar ../lib)
 	curl -L https://repository.apache.org/content/repositories/releases/org/apache/toree/toree-assembly/0.3.0-incubating/toree-assembly-0.3.0-incubating.jar --output ./kernel-launchers/scala/lib/toree-assembly-0.3.0-incubating.jar
-	
+
+KERNEL_IMAGE_FILE:=../dist/jupyter_enterprise_gateway_kernel_image_files-$(VERSION).tar.gz
+kernel_image_files: ../build/kernel_image_files
+	rm -f $(KERNEL_IMAGE_FILE)
+	@( cd ../build/kernel_image_files; tar -pvczf "../$(KERNEL_IMAGE_FILE)" . )
+
+../build/kernel_image_files: kernel-launchers/scala/lib kernel-launchers/bootstrap/bootstrap-kernel.sh
+	@rm -rf ../build/kernel_image_files
+	@mkdir -p ../build/kernel_image_files/kernel-launchers
+	cp kernel-launchers/bootstrap/* ../build/kernel_image_files
+	cp -r kernel-launchers/{python,R,scala} ../build/kernel_image_files/kernel-launchers
+	rm -rf ../build/kernel_image_files/kernel-launchers/scala/{\.*DS*,toree-launcher}  # leave only lib
+
 #
 # Docker image build section ***********************************************
 #
@@ -109,29 +124,14 @@ TARGETS_kernel-py TARGETS_kernel-spark-py TARGETS_kernel-r TARGETS_kernel-spark-
 FILES_nb2kg :=
 FILES_demo-base :=
 FILES_enterprise-gateway-demo := ../dist/jupyter_enterprise_gateway_kernelspecs-* ../dist/jupyter_enterprise_gateway*.whl
-FILES_enterprise-gateway := ../dist/jupyter_enterprise_gateway_kernelspecs-* ../dist/jupyter_enterprise_gateway*.whl
-FILES_kernel-py := kernel-launchers/bootstrap/*
-FILES_kernel-spark-py :=
-FILES_kernel-tf-py := kernel-launchers/bootstrap/*
-FILES_kernel-tf-gpu-py := kernel-launchers/bootstrap/*
-FILES_kernel-r := kernel-launchers/bootstrap/*
-FILES_kernel-spark-r :=
-FILES_kernel-scala := kernel-launchers/bootstrap/*
-
-# Trim out only the kernelspec files needed in each of the kernel images. Note that because kernel-based
-# images only require the launcher (and supporting files) and launchers are consistent across kernel types,
-# we can use the base kernelspecs.
-LAUNCHER_FILES_nb2kg :=
-LAUNCHER_FILES_demo-base :=
-LAUNCHER_FILES_enterprise-gateway-demo :=
-LAUNCHER_FILES_enterprise-gateway := kernel-launchers/scala
-LAUNCHER_FILES_kernel-py := kernel-launchers/python
-LAUNCHER_FILES_kernel-spark-py := kernel-launchers/python
-LAUNCHER_FILES_kernel-tf-py := kernel-launchers/python
-LAUNCHER_FILES_kernel-tf-gpu-py := kernel-launchers/python
-LAUNCHER_FILES_kernel-r := kernel-launchers/R
-LAUNCHER_FILES_kernel-spark-r := kernel-launchers/R
-LAUNCHER_FILES_kernel-scala := kernel-launchers/scala
+FILES_enterprise-gateway := ../dist/jupyter_enterprise_gateway_kernel_image_files* ../dist/jupyter_enterprise_gateway_kernelspecs-* ../dist/jupyter_enterprise_gateway*.whl
+FILES_kernel-py := ../dist/jupyter_enterprise_gateway_kernel_image_files*
+FILES_kernel-spark-py := ../dist/jupyter_enterprise_gateway_kernel_image_files*
+FILES_kernel-tf-py := ../dist/jupyter_enterprise_gateway_kernel_image_files*
+FILES_kernel-tf-gpu-py := ../dist/jupyter_enterprise_gateway_kernel_image_files*
+FILES_kernel-r := ../dist/jupyter_enterprise_gateway_kernel_image_files*
+FILES_kernel-spark-r := ../dist/jupyter_enterprise_gateway_kernel_image_files*
+FILES_kernel-scala := ../dist/jupyter_enterprise_gateway_kernel_image_files*
 
 # Generate image creation targets for each entry in $(DOCKER_IMAGES).  Switch 'eval' to 'info' to see what is produced.
 define BUILD_IMAGE
@@ -140,7 +140,6 @@ $1: ../.image-$1
 	@make clean-$1 TARGETS_$1
 	@mkdir -p ../build/docker/$1
 	@cp -r docker/$1/* $$(FILES_$1) ../build/docker/$1
-	@(if [[ ! -z "$$(LAUNCHER_FILES_$1)" ]]; then mkdir -p ../build/docker/$1/kernel-launchers; cp -r $$(LAUNCHER_FILES_$1) ../build/docker/$1/kernel-launchers; fi;)
 	@(cd ../build/docker/$1; docker build --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} -t $(HUB_ORG)/$1:$(TAG) .)
 	@touch ../.image-$1
 	@-docker images $(HUB_ORG)/$1:$(TAG)

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install cffi send2trash /tmp/jupyter_enterprise_gateway*.whl && \
 	rm -f /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway_kernelspecs*.tar.gz /usr/local/share/jupyter/kernels/
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 COPY start-enterprise-gateway.sh bootstrap-enterprise-gateway.sh /usr/local/bin/
 
@@ -17,8 +17,9 @@ RUN adduser -S -u 1000 -G users jovyan && \
     chown jovyan:users /usr/local/bin/bootstrap-enterprise-gateway.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-enterprise-gateway.sh && \
 	touch /usr/local/share/jupyter/enterprise-gateway.log && \
-	chown -R jovyan:users /usr/local/share/jupyter && \
-	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log
+	chown -R jovyan:users /usr/local/share/jupyter /usr/local/bin/kernel-launchers && \
+	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log && \
+	rm -f /usr/local/bin/bootstrap-kernel.sh
 
 USER jovyan
 

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -3,14 +3,14 @@ FROM jupyter/scipy-notebook:61d8aaedaeaf
 
 RUN pip install pycrypto
 
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
-
-COPY bootstrap-kernel.sh /usr/local/bin/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
 USER root
 
 RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
-	chown -R jovyan:users /usr/local/share/jupyter
+	chown -R jovyan:users /usr/local/bin/kernel-launchers
 
 USER jovyan
+ENV KERNEL_LANGUAGE python
+CMD /usr/local/bin/bootstrap-kernel.sh

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -10,19 +10,15 @@ RUN Rscript --slave --no-save --no-restore-history \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 
-# Install OOTB kernelspecs
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
-# Use our bootstrap file.  Kubernetes kernel yaml will reference this file
-# as the image's CMD in the k8s context.
-COPY bootstrap-kernel.sh /usr/local/bin/
-
-# Switch back to root to create the kernel user
 USER root
 
 RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
-	chown -R jovyan:users /usr/local/share/jupyter
+	chown -R jovyan:users /usr/local/bin/kernel-launchers
 
 USER jovyan
+ENV KERNEL_LANGUAGE R
+CMD /usr/local/bin/bootstrap-kernel.sh
 

--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -1,13 +1,14 @@
 FROM elyra/spark:v2.4.0
 
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
-
-COPY bootstrap-kernel.sh /usr/local/bin/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
 RUN adduser -S -u 1000 -G users jovyan && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
-	chown -R jovyan:users /usr/local/share/jupyter /opt/spark/work-dir
+    chown -R jovyan:users /usr/local/bin/kernel-launchers /opt/spark/work-dir
 
 USER jovyan
+ENV KERNEL_LANGUAGE scala
+CMD /usr/local/bin/bootstrap-kernel.sh
+
 

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -3,11 +3,11 @@ FROM elyra/spark-py:v2.4.0
 RUN apk add --no-cache build-base libffi-dev openssl-dev python-dev && \
     pip install cffi ipykernel ipython jupyter_client pycrypto
 
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
 RUN adduser -S -u 1000 -G users jovyan && \
-    chown -R jovyan:users /usr/local/share/jupyter /opt/spark/work-dir
+    chown -R jovyan:users /usr/local/bin/kernel-launchers /opt/spark/work-dir
 
 USER jovyan
 
-
+ENV KERNEL_LANGUAGE python

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -16,12 +16,11 @@ RUN mkdir -p /usr/share/doc/R/html && \
                                     lib='/usr/lib/R/library', repos=c('http://cran.cnr.berkeley.edu/'))" \
         -e "versions::install.versions('devtools', '1.13.6', lib='/usr/lib/R/library')"
 
-# Install OOTB kernelspecs
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
 RUN adduser -S -u 1000 -G users jovyan && \
-	chown -R jovyan:users /usr/local/share/jupyter /opt/spark/work-dir
+    chown -R jovyan:users /usr/local/bin/kernel-launchers /opt/spark/work-dir
 
 USER jovyan
 
-ENV R_LIBS_USER ${R_HOME}/library:${SPARK_HOME}/R/lib
+ENV KERNEL_LANGUAGE=R R_LIBS_USER=${R_HOME}/library:${SPARK_HOME}/R/lib

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -3,15 +3,16 @@ FROM tensorflow/tensorflow:1.11.0-gpu-py3
 
 RUN pip install pycrypto
 
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
-
-COPY bootstrap-kernel.sh /usr/local/bin/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
 USER root
 
 RUN adduser --system --uid 1000 --gid 100 jovyan && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
-	chown -R jovyan:users /usr/local/share/jupyter
+	chown -R jovyan:users /usr/local/bin/kernel-launchers
+
 
 USER jovyan
+ENV KERNEL_LANGUAGE python
+CMD /usr/local/bin/bootstrap-kernel.sh

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -3,15 +3,16 @@ FROM tensorflow/tensorflow:1.11.0-py3
 
 RUN pip install pycrypto
 
-COPY kernel-launchers /usr/local/share/jupyter/kernel-launchers/
-
-COPY bootstrap-kernel.sh /usr/local/bin/
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
 
 USER root
 
 RUN adduser --system --uid 1000 --gid 100 jovyan && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
-	chown -R jovyan:users /usr/local/share/jupyter
+	chown -R jovyan:users /usr/local/bin/kernel-launchers
+
 
 USER jovyan
+ENV KERNEL_LANGUAGE python
+CMD /usr/local/bin/bootstrap-kernel.sh

--- a/etc/kernel-launchers/R/scripts/launch_IRkernel.R
+++ b/etc/kernel-launchers/R/scripts/launch_IRkernel.R
@@ -240,13 +240,15 @@ if (!is.na(argv$RemoteProcessProxy.response_address)){
 }
 
 # If spark context creation is desired go ahead and initialize the session/context
-# Otherwise, skip spark context creation if set to none
-if (!identical(argv$RemoteProcessProxy.spark_context_initialization_mode, "none")){
-    # Add custom application name (spark.app.name) spark config if available
-    if (!is.na(argv$customAppName)){
-        sparkConfigList[['spark.app.name']] <- argv$customAppName
+# Otherwise, skip spark context creation if set to none or not provided
+if (!is.na(argv$RemoteProcessProxy.spark_context_initialization_mode)){
+    if (!identical(argv$RemoteProcessProxy.spark_context_initialization_mode, "none")){
+        # Add custom application name (spark.app.name) spark config if available
+        if (!is.na(argv$customAppName)){
+            sparkConfigList[['spark.app.name']] <- argv$customAppName
+        }
+        initialize_spark_session(argv$RemoteProcessProxy.spark_context_initialization_mode)
     }
-    initialize_spark_session(argv$RemoteProcessProxy.spark_context_initialization_mode)
 }
 
 # Start the kernel

--- a/etc/kernel-launchers/docker/scripts/launch_docker.py
+++ b/etc/kernel-launchers/docker/scripts/launch_docker.py
@@ -54,7 +54,6 @@ def launch_docker_kernel(kernel_id, response_addr, spark_context_init_mode):
         endpoint_spec = EndpointSpec(mode='dnsrr')
         restart_policy = RestartPolicy(condition='none')
         kernel_service = client.services.create(image_name,
-                                               command='/usr/local/bin/bootstrap-kernel.sh',
                                                name=container_name,
                                                endpoint_spec=endpoint_spec,
                                                restart_policy=restart_policy,
@@ -66,7 +65,6 @@ def launch_docker_kernel(kernel_id, response_addr, spark_context_init_mode):
     else:
         volumes = {'/usr/local/share/jupyter/kernels': {'bind': '/usr/local/share/jupyter/kernels', 'mode': 'ro'}}
         kernel_container = client.containers.run(image_name,
-                                                 command='/usr/local/bin/bootstrap-kernel.sh',
                                                  name=container_name,
                                                  hostname=container_name,
                                                  environment=param_env,
@@ -92,7 +90,7 @@ if __name__ == '__main__':
                         metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
     parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
                         nargs='?', help='Indicates whether or how a spark context should be created',
-                        default='lazy')
+                        default='none')
 
     arguments = vars(parser.parse_args())
     kernel_id = arguments['kernel_id']

--- a/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml
+++ b/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml
@@ -37,4 +37,3 @@ spec:
       value: ${kernel_namespace}
     image: ${kernel_image}
     name: ${kernel_username}-${kernel_id}
-    command: ["/usr/local/bin/bootstrap-kernel.sh"]

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
                         metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
     parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
                         nargs='?', help='Indicates whether or how a spark context should be created',
-                        default='lazy')
+                        default='none')
 
     arguments = vars(parser.parse_args())
     kernel_id = arguments['kernel_id']

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -328,7 +328,7 @@ if __name__ == "__main__":
     parser.add_argument('--RemoteProcessProxy.port-range', dest='port_range', nargs='?',
                         metavar='<lowerPort>..<upperPort>', help='Port range to impose for kernel ports')
     parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='init_mode', nargs='?',
-                        default='lazy', help='the initialization mode of the spark context: lazy, eager or none')
+                        default='none', help='the initialization mode of the spark context: lazy, eager or none')
     parser.add_argument('--RemoteProcessProxy.cluster-type', dest='cluster_type', nargs='?',
                         default='spark', help='the kind of cluster to initialize: spark, dask, or none')
 

--- a/etc/kernelspecs/R_docker/kernel.json
+++ b/etc/kernelspecs/R_docker/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/R_kubernetes/kernel.json
+++ b/etc/kernelspecs/R_kubernetes/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/python_docker/kernel.json
+++ b/etc/kernelspecs/python_docker/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/python_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_kubernetes/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/python_tf_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_docker/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/python_tf_gpu_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_docker/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/python_tf_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_kubernetes/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/scala_docker/kernel.json
+++ b/etc/kernelspecs/scala_docker/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/scala_kubernetes/kernel.json
+++ b/etc/kernelspecs/scala_kubernetes/kernel.json
@@ -17,8 +17,6 @@
     "--RemoteProcessProxy.kernel-id",
     "{kernel_id}",
     "--RemoteProcessProxy.response-address",
-    "{response_address}",
-    "--RemoteProcessProxy.spark-context-initialization-mode",
-    "none"
+    "{response_address}"
   ]
 }

--- a/etc/kernelspecs/spark_R_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_R_kubernetes/bin/run.sh
@@ -22,7 +22,8 @@ if [ -z "${KERNEL_ID}" ]; then
   exit 1
 fi
 
-PROG_HOME=/usr/local/share/jupyter/kernel-launchers/R
+KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-/usr/local/bin/kernel-launchers}
+PROG_HOME=${KERNEL_LAUNCHERS_DIR}/R
 
 set -x
 eval exec \

--- a/etc/kernelspecs/spark_python_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_python_kubernetes/bin/run.sh
@@ -22,7 +22,8 @@ if [ -z "${KERNEL_ID}" ]; then
   exit 1
 fi
 
-PROG_HOME=/usr/local/share/jupyter/kernel-launchers/python
+KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-/usr/local/bin/kernel-launchers}
+PROG_HOME=${KERNEL_LAUNCHERS_DIR}/python
 
 set -x
 eval exec \

--- a/etc/kernelspecs/spark_scala_kubernetes/bin/run.sh
+++ b/etc/kernelspecs/spark_scala_kubernetes/bin/run.sh
@@ -22,7 +22,8 @@ if [ -z "${KERNEL_ID}" ]; then
   exit 1
 fi
 
-PROG_HOME=/usr/local/share/jupyter/kernel-launchers/scala
+KERNEL_LAUNCHERS_DIR=${KERNEL_LAUNCHERS_DIR:-/usr/local/bin/kernel-launchers}
+PROG_HOME=${KERNEL_LAUNCHERS_DIR}/scala
 KERNEL_ASSEMBLY=`(cd "${PROG_HOME}/lib"; ls -1 toree-assembly-*.jar;)`
 TOREE_ASSEMBLY="${PROG_HOME}/lib/${KERNEL_ASSEMBLY}"
 if [ ! -f ${TOREE_ASSEMBLY} ]; then

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -132,10 +132,10 @@ spec:
           value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
         # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
         image: elyra/enterprise-gateway:dev
-        # k8s will only pull :latest all the time.  
-        # the following line will make sure that :dev is always pulled
-        # You should remove this if you want to pin EG to a release tag
-        imagePullPolicy: Always
+	# Use IfNotPresent policy so that dev-based systems don't automatically
+	# update. This provides more control.  Since formal tags will be release-specific
+	# this policy should be sufficient for them as well.
+        imagePullPolicy: IfNotPresent
         name: enterprise-gateway
         args: ["--gateway"]
         ports:


### PR DESCRIPTION
This change reorganizes the kernel-launcher and kernel-bootstrap files that are
used when launching kernel images.  These files are then packaged into a tar.gz
file that can be downloaded from github relative to a given release.

As a result of this reorganization, the kernel-launchers sub-directory has been
moved to be co-located with the `bootstrap-kernel.sh` located in /usr/local/bin
by default.  This directory can be changed by specifying a different value for
KERNEL_LAUNCHERS_DIR when starting the kernel image.

The kernel image CMD entries have also been defaulted to the bootstrap-kernel.sh
file so kernel images can be launched w/o having to specify a command.  However,
attempts to manually launch these images will fail unless envs `KERNEL_ID` and
`EG_RESPONSE_ADDRESS` have been provided.

A _customization_ topic will be included as part of the efforts for #524.  This
will include how to create your own kernel image and corresponding kernelspec.

Note: I've also changed the `imagePullPolicy` for the enterprise-gateway image
from `Always` to `IfNotPresent` since it was updating to the wrong image that
I needed to test with prior to the PR.  This setting should be sufficient for
release-based images, but users should remove their dev based images if they
need to update to the latest dev tag.

Note 2: There's some odd issue happening with the kernel-r image.  The kernel-
spark-r image works fine.  Some kind of library issue.  I suspect there was a
change to the base notebook image that is now side-affecting ours.  Since Alan
is visiting the R images, I'm going to move on since the portions I've changed
test out.

Fixes #526