### PR TITLE
Replace centos with ubuntu in demo-base testing docker image

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-from time import sleep
 from enterprise_gateway.client.gateway_client import GatewayClient
 
 

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+from time import sleep
 from enterprise_gateway.client.gateway_client import GatewayClient
 
 
@@ -71,16 +72,8 @@ class PythonKernelBaseYarnTestCase(PythonKernelBaseTestCase):
     """
 
     def test_get_application_id(self):
-        result = self.kernel.execute("print(sc.applicationId)")
-        self.assertRegexpMatches(result, 'application_')
-
-    def test_get_spark_version(self):
-        result = self.kernel.execute("sc.version")
-        self.assertRegexpMatches(result, '2.4.*')
-
-    def test_get_resource_manager(self):
-        result = self.kernel.execute("sc.getConf().get('spark.master')")
-        self.assertRegexpMatches(result, 'yarn.*')
+        result = self.kernel.execute("sc.getConf().get('spark.app.id')")
+        self.assertRegexpMatches(result, 'application_*')
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute("sc.getConf().get('spark.submit.deployMode')")
@@ -89,6 +82,14 @@ class PythonKernelBaseYarnTestCase(PythonKernelBaseTestCase):
     def test_get_hostname(self):
         result = self.kernel.execute("import subprocess; subprocess.check_output(['hostname'])")
         self.assertRegexpMatches(result, os.environ['ITEST_HOSTNAME_PREFIX'] + "*")
+
+    def test_get_resource_manager(self):
+        result = self.kernel.execute("sc.getConf().get('spark.master')")
+        self.assertRegexpMatches(result, 'yarn.*')
+
+    def test_get_spark_version(self):
+        result = self.kernel.execute("sc.version")
+        self.assertRegexpMatches(result, '2.4.*')
 
 
 class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
@@ -134,7 +135,6 @@ class TestPythonKernelDistributed(unittest.TestCase, PythonKernelBaseTestCase):
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 
-
 class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseYarnTestCase):
     KERNELSPEC = os.getenv("PYTHON_KERNEL_CLIENT_NAME", "spark_python_yarn_client")
 
@@ -147,6 +147,7 @@ class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseYarnTestCase):
         # initialize environment
         cls.gatewayClient = GatewayClient()
         cls.kernel = cls.gatewayClient.start_kernel(cls.KERNELSPEC)
+
 
     @classmethod
     def tearDownClass(cls):

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -1,119 +1,173 @@
-FROM centos:7
+FROM ubuntu:bionic
 
 MAINTAINER akchinSTC
 
-# INSTALL / DOWNLOAD ALL NEEDED PACKAGES
-RUN yum update -y && \
-    yum install -y which tar bzip2 wget curl sudo openssh-server openssh-clients java-1.8.0-openjdk.x86_64 less \
-                   unzip gcc krb5-devel file libunwind && \
-    yum clean all
+ARG NB_USER="jovyan"
+ARG NB_UID="1000"
+ARG NB_GID="100"
 
-# SYSTEM ENVS
-ENV JAVA_HOME /usr/lib/jvm/jre-1.8.0
-ENV PATH $PATH:$JAVA_HOME/bin
-ENV ANACONDA_HOME=/opt/anaconda2/
+USER root
 
-# SPARK ENVS
+ENV HADOOP_PREFIX=/usr/hdp/current/hadoop \
+    ANACONDA_HOME=/opt/anaconda2
+
+ENV SHELL=/bin/bash \
+    NB_USER=$NB_USER \
+    NB_UID=$NB_UID \
+    NB_GID=$NB_GID \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    SPARK_HOME=/usr/hdp/current/spark2-client \
+    PYSPARK_PYTHON=$ANACONDA_HOME/bin/python \
+    HADOOP_CONF_DIR=$HADOOP_PREFIX/etc/hadoop
+
+ENV HOME=/home/$NB_USER \
+    PATH=$ANACONDA_HOME/bin:$HADOOP_PREFIX/bin:$JAVA_HOME/bin:$SPARK_HOME/bin:$PATH
+
 ENV SPARK_VER 2.4.0
-ENV SPARK_HOME /usr/local/spark
-ENV PYSPARK_PYTHON=$ANACONDA_HOME/bin/python
-
-# HADOOP ENVS
 ENV HADOOP_VER 2.7.7
-ENV HADOOP_PREFIX /usr/local/hadoop
-ENV HADOOP_CONF_DIR $HADOOP_PREFIX/etc/hadoop
 
-ENV PATH=$ANACONDA_HOME/bin:$HADOOP_PREFIX/bin:$SPARK_HOME/bin:$PATH
+# INSTALL / DOWNLOAD ALL NEEDED PACKAGES
+RUN apt-get update && apt-get -yq dist-upgrade \
+ && apt-get install -yq --no-install-recommends \
+    wget \
+    bzip2 \
+    tar \
+    curl \
+    less \
+    nano \
+    ca-certificates \
+    libkrb5-dev \
+    sudo \
+    locales \
+    gcc \
+    fonts-liberation \
+    unzip \
+    libsm6 \
+    libxext-dev \
+    libxrender1 \
+    openjdk-8-jdk \
+    openssh-server \
+    openssh-client \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+ADD fix-permissions /usr/local/bin/fix-permissions
+# Create jovyan user with UID=1000 and in the 'users' group
+# and make sure these dirs are writable by the `users` group.
+RUN groupadd wheel -g 11 && \
+    echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
+    useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
+    mkdir -p $ANACONDA_HOME && \
+    mkdir -p /usr/hdp/current && \
+    mkdir -p /usr/local/share/jupyter && \
+    chown $NB_USER:$NB_GID $ANACONDA_HOME && \
+    chmod g+w /etc/passwd && \
+    chmod +x /usr/local/bin/fix-permissions && \
+    fix-permissions $HOME && \
+    fix-permissions $ANACONDA_HOME && \
+    fix-permissions /usr/hdp/current && \
+    fix-permissions /usr/local/share/jupyter
+
+# Create service user 'jovyan'. Pin uid/gid to 1000.
+RUN useradd -m -s /bin/bash -N -u 1111 elyra && \
+    useradd -m -s /bin/bash -N -u 1112 bob  && \
+    useradd -m -s /bin/bash -N -u 1113 alice
+
+USER $NB_UID
+
+# Setup work directory for backward-compatibility
+RUN mkdir /home/$NB_USER/work && \
+    fix-permissions /home/$NB_USER
 
 # DOWNLOAD HADOOP AND SPARK
-RUN curl -s http://www.eu.apache.org/dist/hadoop/common/hadoop-$HADOOP_VER/hadoop-$HADOOP_VER.tar.gz | tar -xz -C /usr/local
-RUN mkdir -p /tmp/native && curl -Ls http://dl.bintray.com/sequenceiq/sequenceiq-bin/hadoop-native-64-2.7.0.tar | tar -x -C /tmp/native
-RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | tar -xz -C /usr/local
+RUN curl -s http://www.eu.apache.org/dist/hadoop/common/hadoop-$HADOOP_VER/hadoop-$HADOOP_VER.tar.gz | tar -xz -C /usr/hdp/current
+RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | tar -xz -C /usr/hdp/current
+
+# SETUP SPARK AND HADOOP SYMLINKS
+RUN cd /usr/hdp/current && ln -s ./hadoop-$HADOOP_VER hadoop && ln -s ./spark-${SPARK_VER}-bin-hadoop2.7 spark2-client
 
 # INSTALL MINI-CONDA AND PYTHON PACKAGES
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p $ANACONDA_HOME && \
+    /bin/bash ~/miniconda.sh -f -b -p $ANACONDA_HOME && \
     rm ~/miniconda.sh && \
-    ln -s /opt/anaconda2/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-    echo ". /opt/anaconda2/etc/profile.d/conda.sh" >> ~/.bashrc && \
-    echo "conda activate base" >> ~/.bashrc
-RUN conda install -v --yes --quiet pip jupyter r-devtools r-stringr
+    conda clean -tipsy && \
+    rm -rf /home/$NB_USER/.cache/yarn && \
+    fix-permissions $ANACONDA_HOME && \
+    fix-permissions /home/$NB_USER
+
+RUN conda install --yes --quiet \
+    'pip' \
+    'jupyter' \
+    'r-devtools' \
+    'r-stringr' && \
+    conda clean -tipsy && \
+    fix-permissions $ANACONDA_HOME && \
+    fix-permissions /home/$NB_USER
+
 RUN Rscript -e 'install.packages("argparser", repos="http://cran.cnr.berkeley.edu")' \
-	        -e 'install.packages("IRkernel", repos="http://cran.cnr.berkeley.edu", lib="/opt/anaconda2/lib/R/library")' \
-	        -e 'IRkernel::installspec(prefix = "/usr/local")' \
-            -e 'devtools::install_github("apache/spark@v$SPARK_VER", subdir="R/pkg")'
+            -e 'install.packages("IRkernel", repos="http://cran.cnr.berkeley.edu", lib="/opt/anaconda2/lib/R/library")' \
+            -e 'IRkernel::installspec(prefix = "/usr/local/")' \
+            -e 'devtools::install_github("apache/spark@v2.4.0", subdir="R/pkg")' && \
+    fix-permissions $ANACONDA_HOME && \
+    fix-permissions /home/$NB_USER
 
 # SETUP HADOOP CONFIGS
-RUN cd /usr/local && ln -s ./hadoop-$HADOOP_VER hadoop
-RUN sed -i '/^export JAVA_HOME/ s:.*:export JAVA_HOME=/usr/lib/jvm/jre-1.8.0\nexport HADOOP_PREFIX=/usr/local/hadoop\nexport HADOOP_HOME=/usr/local/hadoop\n:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
-RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+RUN sed -i '/^export JAVA_HOME/ s:.*:export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64\nexport HADOOP_PREFIX=/usr/hdp/current/hadoop\nexport HADOOP_HOME=/usr/hdp/current/hadoop\n:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
+RUN sed -i '/^export HADOOP_CONF_DIR/ s:.*:export HADOOP_CONF_DIR=/usr/hdp/current/hadoop/etc/hadoop/:' $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
 # SETUP PSEUDO - DISTRIBUTED CONFIGS FOR HADOOP
 COPY ["core-site.xml.template", "hdfs-site.xml", "mapred-site.xml", "yarn-site.xml.template", \
       "$HADOOP_PREFIX/etc/hadoop/"]
-RUN sed s/HOSTNAME/localhost/ /usr/local/hadoop/etc/hadoop/core-site.xml.template > /usr/local/hadoop/etc/hadoop/core-site.xml
 
 # working around docker.io build error
-RUN ls -la /usr/local/hadoop/etc/hadoop/*-env.sh && \
-    chmod +x /usr/local/hadoop/etc/hadoop/*-env.sh && \
-    ls -la /usr/local/hadoop/etc/hadoop/*-env.sh
-
-# SETUP SPARK CONFIGS
-RUN cd /usr/local && \
-    ln -s spark-${SPARK_VER}-bin-hadoop2.7 spark
+RUN ls -la /usr/hdp/current/hadoop/etc/hadoop/*-env.sh && \
+    chmod +x /usr/hdp/current/hadoop/etc/hadoop/*-env.sh && \
+    ls -la /usr/hdp/current/hadoop/etc/hadoop/*-env.sh
 
 # Install Toree
 RUN cd /tmp && \
-	curl -O https://dist.apache.org/repos/dist/release/incubator/toree/0.3.0-incubating/toree-pip/toree-0.3.0.tar.gz && \
-	pip install --upgrade setuptools --user python && \
-	pip install /tmp/toree-0.3.0.tar.gz && \
-	jupyter toree install --spark_home=/usr/local/spark --kernel_name="Spark 2.4.0" --interpreters=Scala && \
-	rm -f /tmp/toree-0.3.0.tar.gz
+    curl -O https://dist.apache.org/repos/dist/release/incubator/toree/0.3.0-incubating/toree-pip/toree-0.3.0.tar.gz && \
+    pip install --upgrade setuptools --user python && \
+    pip install /tmp/toree-0.3.0.tar.gz && \
+    jupyter toree install --spark_home=$SPARK_HOME --kernel_name="Spark 2.4.0" --interpreters=Scala && \
+    rm -f /tmp/toree-0.3.0.tar.gz && \
+    fix-permissions $ANACONDA_HOME && \
+    fix-permissions /home/$NB_USER
 
-# SETUP HADOOP NATIVE SUPPORT - not sure if this works with 2.7.7
-# using recompiled 64 libs from SequenceIQ
-RUN rm -rf $HADOOP_PREFIX/lib/native && mv /tmp/native $HADOOP_PREFIX/lib
+# SETUP PASSWORDLESS SSH FOR $NB_USER
+RUN ssh-keygen -q -N "" -t rsa -f /home/$NB_USER/.ssh/id_rsa && \
+    cp /home/$NB_USER/.ssh/id_rsa.pub /home/$NB_USER/.ssh/authorized_keys && \
+    chmod 0700 /home/$NB_USER
+
+USER root
 
 # SETUP PASSWORDLESS SSH
-RUN ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key && \
-    ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key && \
-    ssh-keygen -q -N "" -t rsa -f /root/.ssh/id_rsa && \
+RUN yes y | ssh-keygen -q -N "" -t dsa -f /etc/ssh/ssh_host_dsa_key && \
+    yes y | ssh-keygen -q -N "" -t rsa -f /etc/ssh/ssh_host_rsa_key && \
+    yes y | ssh-keygen -q -N "" -t rsa -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+
 RUN ssh-keygen -A
 COPY ssh_config /root/.ssh/config
 RUN chmod 600 /root/.ssh/config && \
     chown root:root /root/.ssh/config && \
-    echo "Port 2122" >> /etc/ssh/sshd_config
-RUN pkill sshd; /usr/sbin/sshd
+    echo "Port 2122" >> /etc/ssh/sshd_config && \
+    echo "${NB_USER} ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN service ssh restart
 
-# Create service user 'jovyan'. Pin uid/gid to 1000.
-# Grant sudo privs to jovyan. Unlock passwd (for ssh).
-# Add users 'bob' and 'alice' and 'elyra' for test/demo purposes.
-RUN adduser jovyan -u 1000 -G users && \
-	echo "jovyan ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/jovyan && \
-	chmod 0440 /etc/sudoers.d/jovyan && \
-	passwd -fu jovyan && \
-	adduser bob -u 1112 -G users && \
-	adduser alice -u 1113 -G users && \
-	adduser elyra -u 1111 -G users
-
-USER jovyan
-
-# SETUP PASSWORDLESS SSH FOR JOVYAN
-RUN ssh-keygen -q -N "" -t rsa -f /home/jovyan/.ssh/id_rsa && \
-	cp /home/jovyan/.ssh/id_rsa.pub /home/jovyan/.ssh/authorized_keys && \
-	chmod 0700 /home/jovyan
-
-USER root
-
-COPY ssh_config /home/jovyan/.ssh/config
-RUN chmod 600 /home/jovyan/.ssh/config && \
-    chown jovyan: /home/jovyan/.ssh/config
+COPY ssh_config /home/$NB_USER/.ssh/config
+RUN chmod 600 /home/$NB_USER/.ssh/config && \
+    chown $NB_USER: /home/$NB_USER/.ssh/config
 
 COPY bootstrap-yarn-spark.sh /usr/local/bin/
-RUN chown root.root /usr/local/bin/bootstrap-yarn-spark.sh && \
-	chmod 0700 /usr/local/bin/bootstrap-yarn-spark.sh
+RUN chown $NB_USER: /usr/local/bin/bootstrap-yarn-spark.sh && \
+    chmod 0700 /usr/local/bin/bootstrap-yarn-spark.sh
 
-CMD /usr/local/bin/bootstrap-yarn-spark.sh
+CMD ["/usr/local/bin/bootstrap-yarn-spark.sh"]
 
 LABEL Hadoop.version=$HADOOP_VER
 LABEL Spark.version=$SPARK_VER
@@ -126,3 +180,5 @@ EXPOSE 50010 50020 50070 50075 50090 8020 9000 \
 8030 8031 8032 8033 8040 8042 8088 \
 #Other ports
 49707 2122
+
+USER $NB_USER

--- a/etc/docker/demo-base/README.md
+++ b/etc/docker/demo-base/README.md
@@ -1,7 +1,7 @@
 # What this image Gives You
 * CentOS base image : latest
 * Hadoop 2.7.7 with 64-bit native libraries
-* Apache Spark 2.3.1
+* Apache Spark 2.4.0
 * Java 1.8 runtime
 * Mini-conda 4.5.11 (python 2.7.15) with R packages
 * Toree 0.3.0-incubating

--- a/etc/docker/demo-base/bootstrap-yarn-spark.sh
+++ b/etc/docker/demo-base/bootstrap-yarn-spark.sh
@@ -24,10 +24,10 @@ then
 	exit 0
 fi
 
-: ${HADOOP_PREFIX:=/usr/local/hadoop}
+: ${HADOOP_PREFIX:=/usr/hdp/current/hadoop}
 : ${YARN_HOST:=$HOSTNAME}
-: ${SPARK_HOME:=/usr/local/spark}
-: ${SPARK_VER:=2.3.1}
+: ${SPARK_HOME:=/usr/hdp/current/spark2-client}
+: ${SPARK_VER:=2.4.0}
 
 # Set all the hadoop envs for this shell
 $HADOOP_PREFIX/etc/hadoop/hadoop-env.sh
@@ -38,8 +38,8 @@ rm /tmp/*.pid
 cd $HADOOP_PREFIX/share/hadoop/common ; for cp in ${ACP//,/ }; do  echo == $cp; curl -LO $cp ; done; cd -
 
 ## altering the hostname in core-site and enterprise-gateway startup configuration
-sed s/HOSTNAME/$YARN_HOST/ /usr/local/hadoop/etc/hadoop/core-site.xml.template > /usr/local/hadoop/etc/hadoop/core-site.xml
-sed s/HOSTNAME/$YARN_HOST/ /usr/local/hadoop/etc/hadoop/yarn-site.xml.template > /usr/local/hadoop/etc/hadoop/yarn-site.xml
+sed s/HOSTNAME/$YARN_HOST/ /usr/hdp/current/hadoop/etc/hadoop/core-site.xml.template > /usr/hdp/current/hadoop/etc/hadoop/core-site.xml
+sed s/HOSTNAME/$YARN_HOST/ /usr/hdp/current/hadoop/etc/hadoop/yarn-site.xml.template > /usr/hdp/current/hadoop/etc/hadoop/yarn-site.xml
 #
 # setting spark defaults
 cp $SPARK_HOME/conf/spark-defaults.conf.template  $SPARK_HOME/conf/spark-defaults.conf
@@ -48,33 +48,28 @@ echo "spark.yarn.jars hdfs://$YARN_HOST:9000/spark/*.jar" >>  $SPARK_HOME/conf/s
 # place metastore db and derby.log in /tmp
 echo "spark.driver.extraJavaOptions -Dderby.system.home=/tmp" >>  $SPARK_HOME/conf/spark-defaults.conf
 
-cp $SPARK_HOME/conf/metrics.properties.template $SPARK_HOME/conf/metrics.properties
-
 ##/usr/sbin/rsyslog
 echo "********** STARTING SSH DAEMON ***********"
-/usr/sbin/sshd
+sudo service ssh restart
 
-sudo -u jovyan ssh $(hostname -i) "whoami"
-#
 # If we're not running in standalone mode, don't run as jovyan.
 # If we're running in standalone mode, startup yarn, hdfs, etc.
 if [[ "$YARN_HOST" == "$HOSTNAME" || "$FROM" == "YARN" ]];
 then
     echo "********** FORMATTING NAMENODE ***********"
-    hdfs namenode -format
+    $HADOOP_PREFIX/bin/hdfs namenode -format
     $HADOOP_PREFIX/sbin/start-dfs.sh
-    nohup $HADOOP_PREFIX/bin/hdfs namenode &
     $HADOOP_PREFIX/sbin/start-yarn.sh
 
     echo "********** LEAVING HDFS SAFE MODE...... ***********"
     $HADOOP_PREFIX/bin/hadoop dfsadmin -safemode leave
 
     echo "********** UPLOADING SPARK JARS TO HDFS..... ***********"
-    hdfs dfs -put $SPARK_HOME-${SPARK_VER}-bin-hadoop2.7/jars /spark
+    hdfs dfs -put $SPARK_HOME/jars /spark
 
     ## Add HDFS folders for our users (jovyan, bob, alice)...
     echo "Setting up HDFS folders for Enterprise Gateway users..."
-    hdfs dfs -mkdir -p /user/{jovyan,bob,alice} /tmp/hive
+    hdfs dfs -mkdir -p /user/{jovyan,bob,alice,root} /tmp/hive
     hdfs dfs -chown jovyan:jovyan /user/jovyan
     hdfs dfs -chown bob:bob /user/bob
     hdfs dfs -chown alice:alice /user/alice
@@ -88,20 +83,20 @@ fi
 
 if [[ "$CMD" == "--yarn" ]];
 then
-    echo "YARN application logs can be found at '/usr/local/hadoop/logs/userlogs'"
+    echo "YARN application logs can be found at '/usr/hdp/current/hadoop/logs/userlogs'"
     prev_count=0
     while [ 1 ]
     do
         # Every minute list any new application directories that have been created since
         # last time.
         sleep 60
-        if ls -ld /usr/local/hadoop/logs/userlogs/application* > /dev/null 2>&1;
+        if ls -ld /usr/hdp/current/hadoop/logs/userlogs/application* > /dev/null 2>&1;
         then
-            count=`ls -ld /usr/local/hadoop/logs/userlogs/application*|wc -l`
+            count=`ls -ld /usr/hdp/current/hadoop/logs/userlogs/application*|wc -l`
             if [[ $count > $prev_count ]];
             then
                 new_apps=`expr $count - $prev_count`
-                ls -ldt /usr/local/hadoop/logs/userlogs/application*|head --lines=$new_apps
+                ls -ldt /usr/hdp/current/hadoop/logs/userlogs/application*|head --lines=$new_apps
             fi
             # reset each time in case count < prev_count
             prev_count=$count
@@ -110,7 +105,7 @@ then
 elif [[ "$FROM" == "YARN" ]];
 then
     echo ""
-    echo "Note:  YARN application logs can be found at '/usr/local/hadoop/logs/userlogs'"
+    echo "Note:  YARN application logs can be found at '/usr/hdp/current/hadoop/logs/userlogs'"
     "$*"
 fi
 

--- a/etc/docker/demo-base/fix-permissions
+++ b/etc/docker/demo-base/fix-permissions
@@ -1,0 +1,35 @@
+#!/bin/bash
+# set permissions on a directory
+# after any installation, if a directory needs to be (human) user-writable,
+# run this script on it.
+# It will make everything in the directory owned by the group $NB_GID
+# and writable by that group.
+# Deployments that want to set a specific user id can preserve permissions
+# by adding the `--group-add users` line to `docker run`.
+
+# uses find to avoid touching files that already have the right permissions,
+# which would cause massive image explosion
+
+# right permissions are:
+# group=$NB_GID
+# AND permissions include group rwX (directory-execute)
+# AND directories have setuid,setgid bits set
+
+set -e
+
+for d in "$@"; do
+  find "$d" \
+    ! \( \
+      -group $NB_GID \
+      -a -perm -g+rwX  \
+    \) \
+    -exec chgrp $NB_GID {} \; \
+    -exec chmod g+rwX {} \;
+  # setuid,setgid *on directories only*
+  find "$d" \
+    \( \
+        -type d \
+        -a ! -perm -6000  \
+    \) \
+    -exec chmod +6000 {} \;
+done

--- a/etc/docker/demo-base/hdfs-site.xml
+++ b/etc/docker/demo-base/hdfs-site.xml
@@ -3,8 +3,4 @@
         <name>dfs.replication</name>
         <value>1</value>
     </property>
-    <property>
-        <name>dfs.namenode.name.dir</name>
-        <value>namenode-default</value>
-    </property>
 </configuration>

--- a/etc/docker/demo-base/yarn-site.xml.template
+++ b/etc/docker/demo-base/yarn-site.xml.template
@@ -53,7 +53,7 @@
   </property>
   <property>
       <name>yarn.application.classpath</name>
-      <value>/usr/local/hadoop/etc/hadoop, /usr/local/hadoop/share/hadoop/common/*, /usr/local/hadoop/share/hadoop/common/lib/*, /usr/local/hadoop/share/hadoop/hdfs/*, /usr/local/hadoop/share/hadoop/hdfs/lib/*, /usr/local/hadoop/share/hadoop/mapreduce/*, /usr/local/hadoop/share/hadoop/mapreduce/lib/*, /usr/local/hadoop/share/hadoop/yarn/*, /usr/local/hadoop/share/hadoop/yarn/lib/*, /usr/local/hadoop/share/spark/*</value>
-   </property>
+      <value> /usr/hdp/current/hadoop/etc/hadoop, /usr/hdp/current/hadoop/share/hadoop/common/*, /usr/hdp/current/hadoop/share/hadoop/common/lib/*, /usr/hdp/current/hadoop/share/hadoop/hdfs/*, /usr/hdp/current/hadoop/share/hadoop/hdfs/lib/*, /usr/hdp/current/hadoop/share/hadoop/mapreduce/*, /usr/hdp/current/hadoop/share/hadoop/mapreduce/lib/*, /usr/hdp/current/hadoop/share/hadoop/yarn/*, /usr/hdp/current/hadoop/share/hadoop/yarn/lib/*</value>
+  </property>
 
 </configuration>

--- a/etc/docker/enterprise-gateway-demo/Dockerfile
+++ b/etc/docker/enterprise-gateway-demo/Dockerfile
@@ -3,38 +3,50 @@ ARG TAG
 
 FROM $HUB_ORG/demo-base:$TAG
 
+ENV NB_USER="jovyan"
+
+USER $NB_USER
+
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp
 
 RUN pip install /tmp/jupyter_enterprise_gateway*.whl && \
-    pip install --upgrade ipykernel jupyter-client notebook && \
-	rm -f /tmp/jupyter_enterprise_gateway*.whl
+    pip install --upgrade ipykernel jupyter-client notebook
 
 ADD jupyter_enterprise_gateway_kernelspecs*.tar.gz /usr/local/share/jupyter/kernels/
-COPY start-enterprise-gateway.sh.template /usr/local/bin/
+
+USER root
+RUN fix-permissions /usr/local/share/jupyter/kernels/
+
+COPY start-enterprise-gateway.sh.template /usr/local/bin/start-enterprise-gateway.sh
+RUN chown $NB_USER: /usr/local/bin/start-enterprise-gateway.sh && \
+    chmod +x /usr/local/bin/start-enterprise-gateway.sh
+
+USER $NB_USER
 
 # Massage kernelspecs to docker image env...
 # Create symbolic link to preserve hdp-related directories
 # Copy toree jar from install to scala kernelspec lib directory
 # Add YARN_CONF_DIR to each env stanza, Add alternate-sigint to vanilla toree
-RUN mkdir -p /usr/hdp/current /tmp/byok/kernels && \
-	ln -s /usr/local/spark-2.4.0-bin-hadoop2.7 /usr/hdp/current/spark2-client && \
+RUN mkdir -p /tmp/byok/kernels && \
 	cp /usr/local/share/jupyter/kernels/spark_2.4.0_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_cluster/lib && \
 	cp /usr/local/share/jupyter/kernels/spark_2.4.0_scala/lib/*.jar /usr/local/share/jupyter/kernels/spark_scala_yarn_client/lib && \
 	cd /usr/local/share/jupyter/kernels && \
-	for dir in spark_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/local\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
+	for dir in spark_*; do cat $dir/kernel.json | sed s/'"env": {'/'"env": {|    "YARN_CONF_DIR": "\/usr\/hdp\/current\/hadoop\/etc\/hadoop",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json $dir/kernel.json; done && \
 	cat spark_2.4.0_scala/kernel.json | sed s/'"__TOREE_OPTS__": "",'/'"__TOREE_OPTS__": "--alternate-sigint USR2",'/ | tr '|' '\n' > xkernel.json; mv xkernel.json spark_2.4.0_scala/kernel.json && \
 	touch /usr/local/share/jupyter/enterprise-gateway.log && \
 	chmod 0666 /usr/local/share/jupyter/enterprise-gateway.log
 
-# install boot script 
-COPY bootstrap-enterprise-gateway.sh /usr/local/bin/bootstrap-enterprise-gateway.sh
-RUN chown root.root /usr/local/bin/bootstrap-enterprise-gateway.sh && \
-	chmod 0700 /usr/local/bin/bootstrap-enterprise-gateway.sh
+USER root
 
-WORKDIR /usr/local/share/jupyter 
+# install boot script
+COPY bootstrap-enterprise-gateway.sh /usr/local/bin/bootstrap-enterprise-gateway.sh
+RUN chown $NB_USER: /usr/local/bin/bootstrap-enterprise-gateway.sh && \
+	chmod 0700 /usr/local/bin/bootstrap-enterprise-gateway.sh
 
 ENTRYPOINT ["/usr/local/bin/bootstrap-enterprise-gateway.sh"]
 CMD ["--help"]
 
 EXPOSE 8888
+
+USER $NB_USER

--- a/etc/docker/enterprise-gateway-demo/bootstrap-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway-demo/bootstrap-enterprise-gateway.sh
@@ -35,10 +35,8 @@ export FROM="EG"
 
 if [[ "$CMD" == "--gateway" ]];
 then
-    sed s/HOSTNAME/$YARN_HOST/ /usr/local/bin/start-enterprise-gateway.sh.template > /usr/local/bin/start-enterprise-gateway.sh
-    chmod 0755 /usr/local/bin/start-enterprise-gateway.sh
-
-    sudo -u jovyan /usr/local/bin/start-enterprise-gateway.sh
+    sudo sed -i "s/HOSTNAME/$YARN_HOST/" /usr/local/bin/start-enterprise-gateway.sh
+    /usr/local/bin/start-enterprise-gateway.sh
 fi
 
 exit 0

--- a/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
+++ b/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
@@ -3,21 +3,6 @@
 # Allow for mounts of kernelspecs to /tmp/byok/kernels
 export JUPYTER_PATH=${JUPYTER_PATH:-/tmp/byok}
 
-export ANACONDA_HOME=${ANACONDA_HOME:-/opt/anaconda2}
-export JAVA_HOME=${JAVA_HOME:-/usr/java/default}
-export SPARK_HOME=${SPARK_HOME:-/usr/local/spark}
-
-export HADOOP_PREFIX=${HADOOP_PREFIX:-/usr/local/hadoop}
-export HADOOP_HDFS_HOME=${HADOOP_PREFIX}
-export HADOOP_COMMON_HOME=${HADOOP_PREFIX}
-export HADOOP_YARN_HOME=${HADOOP_PREFIX}
-export HADOOP_MAPRED_HOME={HADOOP_PREFIX}
-export HADOOP_CONF_DIR=${HADOOP_PREFIX}/etc/hadoop
-export YARN_CONF_DIR={HADOOP_PREFIX}/etc/hadoop
-
-export PYSPARK_PYTHON=${ANACONDA_HOME}/bin/python
-export PATH=${ANACONDA_HOME}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${JAVA_HOME}/bin:${SPARK_HOME}/bin:${HADOOP_PREFIX}/bin
-
 # Enterprise Gateway variables
 export EG_REMOTE_HOSTS=${EG_REMOTE_HOSTS:-HOSTNAME}
 export EG_YARN_ENDPOINT=${EG_YARN_ENDPOINT:-http://HOSTNAME:8088/ws/v1/cluster}


### PR DESCRIPTION
Replace Centos base image in demo-base with ubuntu to be more in line with jupyter docker images. Should additionally resolve build issues related to compiling R libraries when using CRAN instead of conda repos.