### PR TITLE
fix save-restore for sessions

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -287,21 +287,6 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
             self.process_proxy = None
         return super(RemoteKernelManager, self).cleanup(connection_file)
 
-    def get_connection_info(self, session=False):
-        info = super(RemoteKernelManager, self).get_connection_info(session)
-        # Convert bytes to string for persistence.  Will reverse operation in load_connection_info
-        info_key = info.get('key')
-        if info_key:
-            info['key'] = bytes_to_str(info_key)
-        return info
-
-    def load_connection_info(self, info):
-        # get the key back to bytes...
-        info_key = info.get('key')
-        if info_key:
-            info['key'] = str_to_bytes(info_key)
-        return super(RemoteKernelManager, self).load_connection_info(info)
-
     def write_connection_file(self):
         # If this is a remote kernel that's using a response address or we're restarting, we should skip the
         # write_connection_file since it will create 5 useless ports that would not adhere to port-range


### PR DESCRIPTION
current version have issue: 
after deserialization session modified in-place and can't serialize again

bug on path
1) pass connection_info in self.kernel_manager.start_kernel_from_session
2) kernel manager invoke km.load_connection_info(connection_info)
3) load_connection_info modify key in-place (convert str_to_bytes)
4) try store updated list of sessions in _commit_sessions cause serialization exception (can't store bytes)

what done:
1) localize work related how we serialize/deserialize data to storage in one place
2) for serialization/deserialization always create full copy of data, for prevent unexpected modification