### PR TITLE
update conda requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -14,8 +14,8 @@ dependencies:
   - pexpect>=4.2.0
   - pycrypto>=2.6.1
   - pyzmq>=17.0.0
-  - kubernetes>=4.0.0
-  - docker>=3.5.0
+  - python-kubernetes>=4.0.0
+  - docker-py>=3.5.0
   - pip
 
   # Documentation Requirements


### PR DESCRIPTION
when make virtual environment using `conda`
I have faced package not found error

```
$ make env
Fetching package metadata ...........

NoPackagesFoundError: Package missing in current osx-64 channels:
  - kubernetes >=4.0.0

make: [env] Error 1 (ignored)
```

and I think it's because of `conda-forge` packages about [kubernetes](https://anaconda.org/conda-forge/python-kubernetes) and [docker](https://anaconda.org/conda-forge/docker-py)
