### PR TITLE
Fix spark initialization in python launcher

### DIFF
--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -47,7 +47,12 @@ def initialize_namespace(cluster_type='spark'):
         def initialize_spark_session():
             """Initialize Spark session and replace global variable
             placeholders with real Spark session object references."""
+            global spark, sc, sql, sqlContext, sqlCtx
             spark = SparkSession.builder.getOrCreate()
+            sc = spark.sparkContext
+            sql = spark.sql
+            sqlContext = spark._wrapped
+            sqlCtx = sqlContext
 
             # Stop the spark session on exit
             atexit.register(lambda: spark.stop())


### PR DESCRIPTION
A recent change to the python launcher inadvertently removed the explicit
global designator of various spark context variables which side-affected
the ability to attempt to access them prior to the actual spark context
being initialized.  Attempts to access such variables (e.g., `sc`) would
result in a `KeyError: 'sc'` exception.  Subsequent access attempts,
following the spark context's initialization, would work.

Re-establishing these variables as global allows for early access by
properly waiting for the spark context initialization to complete.