### PR TITLE
Fix launcher side effect

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -90,6 +90,21 @@ class PythonKernelBaseYarnTestCase(PythonKernelBaseTestCase):
         result = self.kernel.execute("sc.version")
         self.assertRegexpMatches(result, '2.4.*')
 
+    def test_run_pi_example(self):
+        # Build the example code...
+        pi_code = list()
+        pi_code.append("import random\n")
+        pi_code.append("from operator import add\n")
+        pi_code.append("partitions = 20\n")
+        pi_code.append("n = 100000 * partitions\n")
+        pi_code.append("def f(_):\n")
+        pi_code.append("    x = random() * 2 - 1\n")
+        pi_code.append("    y = random() * 2 - 1\n")
+        pi_code.append("    return 1 if x ** 2 + y ** 2 <= 1 else 0\n")
+        pi_code.append("count = sc.parallelize(range(1, n + 1), partitions).map(f).reduce(add)\n")
+        pi_code.append("print(\"Pi is roughly %f\" % (4.0 * count / n))\n")
+        result = self.kernel.execute(pi_code)
+        self.assertRegexpMatches(result, 'Pi is roughly 3.14*')
 
 class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
     KERNELSPEC = os.getenv("PYTHON_KERNEL_LOCAL_NAME", "python2")

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -4,10 +4,10 @@ import base64
 import json
 import logging
 import os
-import random
 import socket
 import tempfile
 import uuid
+from random import random
 from threading import Thread
 
 from Crypto.Cipher import AES


### PR DESCRIPTION
This fix addresses a bizarre issue introduced when the launcher started
passing the `local_ns` parameter to `embed_kernel()`.  Apparently, the
import statements from the launcher can side-effect the code running in
cells.  This was causing cells using `random()` to fail *downstream* in
an unusual fashion, so cells containing something like the SparkPi example
code would fail - despite the rest of the spark context working fine.

We eventually found that changing the launcher's `import random` to
`from random import random` sufficiently "fixed" things and SparkPi
example worked again.

Since we learned that confirming the spark context is properly
established is not sufficient, this commit also adds `test_run_pi_example`
to trigger some deeper interactions with Spark.