### PR TITLE
Use vanilla kernel images as base for spark kernel images

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) Juper Development Team.
+# Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
 .PHONY: help clean clean-images clean-enterprise-gateway clean-enterprise-gateway-demo clean-nb2kg clean-demo-base \

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,11 +1,17 @@
 # Ubuntu 18.04.1 LTS Bionic
-FROM jupyter/scipy-notebook:61d8aaedaeaf
+FROM jupyter/scipy-notebook
 
-RUN pip install pycrypto
+ENV PATH=$PATH:$CONDA_DIR/bin
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+RUN pip install cffi ipykernel ipython jupyter_client pycrypto
+
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 USER root
+
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    libkrb5-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,18 +1,21 @@
-# FIXME: This image is from April 8 (https://github.com/jupyter/docker-stacks/commit/8a1b90cbcba5355e6174a9fc24fe225813befe92)
-# Attempts to use newer versions - within a couple months of 9/18/2018 - were encountering this issue:
-# https://github.com/jupyter/docker-stacks/issues/679 - r-notebook kernel crashes because of png support
-# Ubuntu 16.04.4 LTS - Xenial
-FROM jupyter/r-notebook:8a1b90cbcba5
+# Ubuntu 18.04.1 LTS Bionic
+FROM jupyter/r-notebook
 
-# Additional package needed by launcher, update IRkernel to fix kernel shutdown.
-RUN Rscript --slave --no-save --no-restore-history \
-        -e "install.packages(pkgs=c('argparse','IRkernel'), repos='http://cran.cnr.berkeley.edu/')" && \
+RUN conda install --quiet --yes \
+    'r-argparse' && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
+# Switch back to root to modify ownerships
 USER root
+
+RUN apt-get update && apt-get install -y \
+    less \
+    curl \
+    libkrb5-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \

--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -1,6 +1,6 @@
 FROM elyra/spark:v2.4.0
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 RUN adduser -S -u 1000 -G users jovyan && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -1,16 +1,40 @@
-FROM elyra/spark-py:v2.4.0
+ARG HUB_ORG
+ARG TAG
 
-RUN apk del python3 && \
-    apk add --no-cache build-base libffi-dev openssl-dev python-dev python3-dev && \
-    pip3 install cffi ipykernel ipython jupyter_client pycrypto && \
-    pip install cffi ipykernel ipython jupyter_client pycrypto && \
-    rm -r /root/.cache
+# Ubuntu 18.04.1 LTS Bionic
+FROM $HUB_ORG/kernel-py:$TAG
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ENV SPARK_VER 2.4.0
+ENV SPARK_HOME /opt/spark
+ENV KERNEL_LANGUAGE python
+ENV R_LIBS_USER $R_LIBS_USER:${SPARK_HOME}/R/lib
+ENV PATH $PATH:$SPARK_HOME/bin
 
-RUN adduser -S -u 1000 -G users jovyan && \
-    chown -R jovyan:users /usr/local/bin/kernel-launchers /opt/spark/work-dir
+USER root
+
+RUN apt-get update && \
+    apt-get install -yq --no-install-recommends \
+    openjdk-8-jdk \
+    less \
+    curl \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+# Download and install Spark
+RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
+    tar -xz -C /opt
+RUN ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME
+
+COPY entrypoint.sh /opt/
+RUN chmod a+x /opt/entrypoint.sh
+
+WORKDIR $SPARK_HOME/work-dir
+RUN chmod g+w $SPARK_HOME/work-dir
+
+ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
 USER jovyan
 
-ENV KERNEL_LANGUAGE python
+

--- a/etc/docker/kernel-spark-py/README.md
+++ b/etc/docker/kernel-spark-py/README.md
@@ -3,6 +3,7 @@ This image enables the use of an IPython kernel launched from [Jupyter Enterpris
 # What it Gives You
 * IPython kernel support 
 * Spark on kubernetes support from within a Jupyter Notebook
+* [Data science libraries](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook)
 
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.

--- a/etc/docker/kernel-spark-py/entrypoint.sh
+++ b/etc/docker/kernel-spark-py/entrypoint.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# echo commands to the terminal output
+set -ex
+
+# Check whether there is a passwd entry for the container UID
+myuid=$(id -u)
+mygid=$(id -g)
+# turn off -e for getent because it will return error code in anonymous uid case
+set +e
+uidentry=$(getent passwd $myuid)
+set -e
+
+# If there is no passwd entry for the container UID, attempt to create one
+if [ -z "$uidentry" ] ; then
+    if [ -w /etc/passwd ] ; then
+        echo "$myuid:x:$myuid:$mygid:${SPARK_USER_NAME:-anonymous uid}:$SPARK_HOME:/bin/false" >> /etc/passwd
+    else
+        echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID"
+    fi
+fi
+
+SPARK_K8S_CMD="$1"
+case "$SPARK_K8S_CMD" in
+    driver | driver-py | driver-r | executor)
+      shift 1
+      ;;
+    "")
+      ;;
+    *)
+      echo "Non-spark-on-k8s command provided, proceeding in pass-through mode..."
+      exec tini -g -- "$@"
+      ;;
+esac
+
+SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
+env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
+readarray -t SPARK_EXECUTOR_JAVA_OPTS < /tmp/java_opts.txt
+
+if [ -n "$SPARK_EXTRA_CLASSPATH" ]; then
+  SPARK_CLASSPATH="$SPARK_CLASSPATH:$SPARK_EXTRA_CLASSPATH"
+fi
+
+if [ -n "$PYSPARK_FILES" ]; then
+    PYTHONPATH="$PYTHONPATH:$PYSPARK_FILES"
+fi
+
+PYSPARK_ARGS=""
+if [ -n "$PYSPARK_APP_ARGS" ]; then
+    PYSPARK_ARGS="$PYSPARK_APP_ARGS"
+fi
+
+R_ARGS=""
+if [ -n "$R_APP_ARGS" ]; then
+    R_ARGS="$R_APP_ARGS"
+fi
+
+if [ "$PYSPARK_MAJOR_PYTHON_VERSION" == "2" ]; then
+    pyv="$(python -V 2>&1)"
+    export PYTHON_VERSION="${pyv:7}"
+    export PYSPARK_PYTHON="python"
+    export PYSPARK_DRIVER_PYTHON="python"
+elif [ "$PYSPARK_MAJOR_PYTHON_VERSION" == "3" ]; then
+    pyv3="$(python3 -V 2>&1)"
+    export PYTHON_VERSION="${pyv3:7}"
+    export PYSPARK_PYTHON="python3"
+    export PYSPARK_DRIVER_PYTHON="python3"
+fi
+
+if ! [ -z ${HADOOP_CONF_DIR+x} ]; then
+  SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
+fi
+
+case "$SPARK_K8S_CMD" in
+  driver)
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --deploy-mode client
+      "$@"
+    )
+    ;;
+  executor)
+    CMD=(
+      ${JAVA_HOME}/bin/java
+      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
+      -Xms$SPARK_EXECUTOR_MEMORY
+      -Xmx$SPARK_EXECUTOR_MEMORY
+      -cp "$SPARK_CLASSPATH"
+      org.apache.spark.executor.CoarseGrainedExecutorBackend
+      --driver-url $SPARK_DRIVER_URL
+      --executor-id $SPARK_EXECUTOR_ID
+      --cores $SPARK_EXECUTOR_CORES
+      --app-id $SPARK_APPLICATION_ID
+      --hostname $SPARK_EXECUTOR_POD_IP
+    )
+    ;;
+
+  *)
+    echo "Unknown command: $SPARK_K8S_CMD" 1>&2
+    exit 1
+esac
+
+exec tini -g -- "${CMD[@]}"

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -1,26 +1,34 @@
-FROM elyra/spark-r:v2.4.0
+ARG HUB_ORG
+ARG TAG
 
-# Install items necessary for IRKernel and launcher to run.
-# First some python things...
-RUN apk add --no-cache build-base libzmq python-dev && \
-    python -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip && \
-    pip install --upgrade pip setuptools jupyter_client && \
-    rm -r /root/.cache
+FROM $HUB_ORG/kernel-r:$TAG
 
-# then some R things...
-RUN mkdir -p /usr/share/doc/R/html && \
-    Rscript --slave --no-save --no-restore-history \
-        -e "install.packages(pkgs=c('argparse','jsonlite','uuid','stringr','repr','IRkernel','IRdisplay', \
-                                    'evaluate', 'crayon', 'pbdZMQ', 'digest', 'base64enc','versions'), \
-                                    lib='/usr/lib/R/library', repos=c('http://cran.cnr.berkeley.edu/'))" \
-        -e "versions::install.versions('devtools', '1.13.6', lib='/usr/lib/R/library')"
+USER root
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ENV SPARK_VER 2.4.0
+ENV SPARK_HOME /opt/spark
+ENV KERNEL_LANGUAGE=R
+ENV R_LIBS_USER $R_LIBS_USER:${R_HOME}/library:${SPARK_HOME}/R/lib
+ENV PATH $PATH:$SPARK_HOME/bin
 
-RUN adduser -S -u 1000 -G users jovyan && \
-    chown -R jovyan:users /usr/local/bin/kernel-launchers /opt/spark/work-dir
+RUN apt-get update && apt-get install -y \
+    openjdk-8-jdk \
+    libssl-dev
+
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
+
+# Download and install Spark
+RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
+    tar -xz -C /opt
+RUN ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME
+
+COPY entrypoint.sh /opt/
+RUN chmod a+x /opt/entrypoint.sh
+
+WORKDIR $SPARK_HOME/work-dir
+RUN chmod g+w $SPARK_HOME/work-dir
+
+ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
 USER jovyan
 
-ENV KERNEL_LANGUAGE=R R_LIBS_USER=${R_HOME}/library:${SPARK_HOME}/R/lib

--- a/etc/docker/kernel-spark-r/entrypoint.sh
+++ b/etc/docker/kernel-spark-r/entrypoint.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# echo commands to the terminal output
+set -ex
+
+# Check whether there is a passwd entry for the container UID
+myuid=$(id -u)
+mygid=$(id -g)
+# turn off -e for getent because it will return error code in anonymous uid case
+set +e
+uidentry=$(getent passwd $myuid)
+set -e
+
+# If there is no passwd entry for the container UID, attempt to create one
+if [ -z "$uidentry" ] ; then
+    if [ -w /etc/passwd ] ; then
+        echo "$myuid:x:$myuid:$mygid:${SPARK_USER_NAME:-anonymous uid}:$SPARK_HOME:/bin/false" >> /etc/passwd
+    else
+        echo "Container ENTRYPOINT failed to add passwd entry for anonymous UID"
+    fi
+fi
+
+SPARK_K8S_CMD="$1"
+case "$SPARK_K8S_CMD" in
+    driver | driver-py | driver-r | executor)
+      shift 1
+      ;;
+    "")
+      ;;
+    *)
+      echo "Non-spark-on-k8s command provided, proceeding in pass-through mode..."
+      exec tini -g -- "$@"
+      ;;
+esac
+
+SPARK_CLASSPATH="$SPARK_CLASSPATH:${SPARK_HOME}/jars/*"
+env | grep SPARK_JAVA_OPT_ | sort -t_ -k4 -n | sed 's/[^=]*=\(.*\)/\1/g' > /tmp/java_opts.txt
+readarray -t SPARK_EXECUTOR_JAVA_OPTS < /tmp/java_opts.txt
+
+if [ -n "$SPARK_EXTRA_CLASSPATH" ]; then
+  SPARK_CLASSPATH="$SPARK_CLASSPATH:$SPARK_EXTRA_CLASSPATH"
+fi
+
+if [ -n "$PYSPARK_FILES" ]; then
+    PYTHONPATH="$PYTHONPATH:$PYSPARK_FILES"
+fi
+
+PYSPARK_ARGS=""
+if [ -n "$PYSPARK_APP_ARGS" ]; then
+    PYSPARK_ARGS="$PYSPARK_APP_ARGS"
+fi
+
+R_ARGS=""
+if [ -n "$R_APP_ARGS" ]; then
+    R_ARGS="$R_APP_ARGS"
+fi
+
+if [ "$PYSPARK_MAJOR_PYTHON_VERSION" == "2" ]; then
+    pyv="$(python -V 2>&1)"
+    export PYTHON_VERSION="${pyv:7}"
+    export PYSPARK_PYTHON="python"
+    export PYSPARK_DRIVER_PYTHON="python"
+elif [ "$PYSPARK_MAJOR_PYTHON_VERSION" == "3" ]; then
+    pyv3="$(python3 -V 2>&1)"
+    export PYTHON_VERSION="${pyv3:7}"
+    export PYSPARK_PYTHON="python3"
+    export PYSPARK_DRIVER_PYTHON="python3"
+fi
+
+if ! [ -z ${HADOOP_CONF_DIR+x} ]; then
+  SPARK_CLASSPATH="$HADOOP_CONF_DIR:$SPARK_CLASSPATH";
+fi
+
+case "$SPARK_K8S_CMD" in
+  driver)
+    CMD=(
+      "$SPARK_HOME/bin/spark-submit"
+      --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --deploy-mode client
+      "$@"
+    )
+    ;;
+  executor)
+    CMD=(
+      ${JAVA_HOME}/bin/java
+      "${SPARK_EXECUTOR_JAVA_OPTS[@]}"
+      -Xms$SPARK_EXECUTOR_MEMORY
+      -Xmx$SPARK_EXECUTOR_MEMORY
+      -cp "$SPARK_CLASSPATH"
+      org.apache.spark.executor.CoarseGrainedExecutorBackend
+      --driver-url $SPARK_DRIVER_URL
+      --executor-id $SPARK_EXECUTOR_ID
+      --cores $SPARK_EXECUTOR_CORES
+      --app-id $SPARK_APPLICATION_ID
+      --hostname $SPARK_EXECUTOR_POD_IP
+    )
+    ;;
+
+  *)
+    echo "Unknown command: $SPARK_K8S_CMD" 1>&2
+    exit 1
+esac
+
+exec tini -g -- "${CMD[@]}"

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -3,7 +3,7 @@ FROM tensorflow/tensorflow:1.12.0-gpu-py3
 
 RUN pip install pycrypto
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 USER root
 

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -3,7 +3,7 @@ FROM tensorflow/tensorflow:1.12.0-py3
 
 RUN pip install pycrypto
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 USER root
 


### PR DESCRIPTION
- Both Spark-based Python and R kernel images will now use each respective
  vanilla kernel as its base image
- Updated kernel-r dockerfile to use latest now that docker-stacks ISSUE-679
  has been resolved
- Updated kernel-py docker file to use latest jupyter/scipy-notebook
- Conda support in both respective spark-based images now with more robust libraries
- Small misc fixes