### PR TITLE
Updating Tensorflow kernel images

### DIFF
--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -1,18 +1,21 @@
-# Ubuntu:xenial
-FROM tensorflow/tensorflow:1.12.0-py3
+# Ubuntu:Bionic
+FROM jupyter/tensorflow-notebook
 
-RUN pip install pycrypto
+ENV KERNEL_LANGUAGE python
 
-ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin
+ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
+
+RUN conda install --quiet --yes \
+    pillow \
+    pycrypto && \
+    fix-permissions $CONDA_DIR
 
 USER root
 
-RUN adduser --system --uid 1000 --gid 100 jovyan && \
-    chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
+RUN chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
 	chown -R jovyan:users /usr/local/bin/kernel-launchers
 
-
 USER jovyan
-ENV KERNEL_LANGUAGE python
-CMD /usr/local/bin/bootstrap-kernel.sh
+
+CMD [ "/usr/local/bin/bootstrap-kernel.sh" ]


### PR DESCRIPTION
Initial changes 
- Use Jupyter's tensorflow-notebook image as our base image for kernel-tf-py
