### PR TITLE
Tolerate errors when closing response-socket

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -936,8 +936,11 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
 
         # If there's a response-socket, close it since its no longer needed.
         if self.response_socket:
-            self.response_socket.shutdown(SHUT_RDWR)
-            self.response_socket.close()
+            try:
+                self.response_socket.shutdown(SHUT_RDWR)
+                self.response_socket.close()
+            except OSError:
+                pass  # tolerate exceptions here since we don't need this socket and would like ot continue
             self.response_socket = None
 
         self.kernel_manager._connection_file_written = True  # allows for cleanup of local files (as necessary)


### PR DESCRIPTION
While performing local debugging (on mac) I found that errno 57 "socket is not connecte"
was being raised whenever EG went to shutdown and close the response socket that it no
longer needed.  Since the socket is no longer needed we should tolerate exceptions here.
This is probably a function of running the kernel locally as well as the operating system
(since this doesn't occur on RHEL systems).