### PR TITLE
Support kernel working dir

### DIFF
--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -25,6 +25,8 @@ default_kernel_gid = '100'  # users group is the default
 uid_blacklist = os.getenv("EG_UID_BLACKLIST", "0").split(',')
 gid_blacklist = os.getenv("EG_GID_BLACKLIST", "0").split(',')
 
+mirror_working_dirs = bool((os.getenv('EG_MIRROR_WORKING_DIRS', 'false').lower() == 'true'))
+
 
 class ContainerProcessProxy(RemoteProcessProxy):
     """Kernel lifecycle management for container-based kernels."""
@@ -55,6 +57,10 @@ class ContainerProcessProxy(RemoteProcessProxy):
 
         kwargs['env']['KERNEL_IMAGE'] = self.kernel_image
         kwargs['env']['KERNEL_EXECUTOR_IMAGE'] = self.kernel_executor_image
+
+        if not mirror_working_dirs:  # If mirroring is not enabled, remove working directory if present
+            if 'KERNEL_WORKING_DIR' in kwargs['env']:
+                del kwargs['env']['KERNEL_WORKING_DIR']
 
         self._enforce_uid_gid_blacklists(**kwargs)
 

--- a/etc/docker/enterprise-gateway-docker.sh
+++ b/etc/docker/enterprise-gateway-docker.sh
@@ -9,6 +9,8 @@ export KG_PORT=${KG_PORT:-8888}
 export EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK:-enterprise-gateway}
 export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"['r_docker','python_docker','python_tf_docker','python_tf_gpu_docker','scala_docker']"}
 export EG_NAME=${EG_NAME:-enterprise-gateway}
+# NOTE: This requires appropriate volume mounts to make notebook dir accessible
+export EG_MIRROR_WORKING_DIRS=False
 
 # It's often helpful to mount the kernelspec files from the host into the container.
 MOUNT_KERNELSPECS=
@@ -23,10 +25,16 @@ docker network create --label app=enterprise-gateway -d overlay --attachable ${E
 # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
 docker run -d -it \
 	--network ${EG_DOCKER_NETWORK} \
-	-l app=enterprise-gateway -l component=enterprise-gateway \
-	-e EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK} -e EG_KERNEL_LAUNCH_TIMEOUT=60 -e EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST} -e KG_PORT=${KG_PORT} \
+	-l app=enterprise-gateway \
+	-l component=enterprise-gateway \
 	${MOUNT_KERNELSPECS} \
 	-u 0 -v /var/run/docker.sock:/var/run/docker.sock \
 	-p ${KG_PORT}:${KG_PORT} \
+	-e EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK} \
+	-e EG_KERNEL_LAUNCH_TIMEOUT=60 \
+	-e EG_CULL_IDLE_TIMEOUT=3600 \
+	-e EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST} \
+	-e EG_MIRROR_WORKING_DIRS=${EG_MIRROR_WORKING_DIRS} \
+	-e KG_PORT=${KG_PORT} \
 	--name ${EG_NAME} \
 	elyra/enterprise-gateway:VERSION --gateway

--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -16,8 +16,8 @@ export EG_ENABLE_TUNNELING=${EG_ENABLE_TUNNELING:-False}
 
 export EG_LOG_LEVEL=${EG_LOG_LEVEL:-DEBUG}
 export EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-43200}  # default to 12 hours
-export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-30}
-export EG_CULL_CONNECTED=${EG_CULL_CONNECTED:-True}
+export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-60}
+export EG_CULL_CONNECTED=${EG_CULL_CONNECTED:-False}
 export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"['r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker']"}
 
 

--- a/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml
+++ b/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml
@@ -49,4 +49,4 @@ spec:
     - name: KERNEL_NAMESPACE
       value: ${kernel_namespace}
     image: ${kernel_image}
-    name: ${kernel_username}-${kernel_id}
+    name: ${kernel_pod_name}

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -69,6 +69,11 @@ def launch_kubernetes_kernel(kernel_id, response_addr, spark_context_init_mode):
     for k8s_obj in k8s_objs:
         if k8s_obj.get('kind'):
             if k8s_obj['kind'] == 'Pod':
+                #print("{}".format(k8s_obj))  # useful for debug
+                # If workingDir is not in the yaml and kernel_working_dir exists, use that as the workingDir
+                if 'workingDir' not in k8s_obj['spec']['containers'][0] and 'kernel_working_dir' in keywords:
+                    k8s_obj['spec']['containers'][0]['workingDir'] = keywords['kernel_working_dir']
+
                 client.CoreV1Api(client.ApiClient()).create_namespaced_pod(body=k8s_obj, namespace=kernel_namespace)
             elif k8s_obj['kind'] == 'Secret':
                 client.CoreV1Api(client.ApiClient()).create_namespaced_secret(body=k8s_obj, namespace=kernel_namespace)

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -25,7 +25,7 @@ metadata:
     component: enterprise-gateway
 rules:
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "services", "configmaps", "secrets", "persistentvolumnes", "persistentvolumeclaims"]
+    resources: ["pods", "namespaces", "services", "configmaps", "secrets", "persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "watch", "list", "create", "delete"]
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
@@ -120,16 +120,23 @@ spec:
         - name: EG_SHARED_NAMESPACE
           value: "False"
 
-        - name: EG_TUNNELING_ENABLED
+          # NOTE: This requires appropriate volume mounts to make notebook dir accessible
+        - name: EG_MIRROR_WORKING_DIRS
           value: "False"
+
+          # Current idle timeout is 1 hour.
         - name: EG_CULL_IDLE_TIMEOUT
-          value: "600"
+          value: "3600"
+
         - name: EG_LOG_LEVEL
           value: "DEBUG"
+
         - name: EG_KERNEL_LAUNCH_TIMEOUT
           value: "60"
+
         - name: EG_KERNEL_WHITELIST
           value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','python_tf_gpu_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
+
         # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
         image: elyra/enterprise-gateway:dev
         # Use IfNotPresent policy so that dev-based systems don't automatically


### PR DESCRIPTION
Added the ability to mirror the notebook working directory by adjusting
the kernel container's working directory prior to its launch.  When
`KERNEL_WORKING_DIR` is provided **and** `EG_MIRROR_WORKING_DIRS=True`
Enterprise Gateway will set the container's working directory to the value
of `KERNEL_WORKING_DIR`.

For Notebook users, this change should be used with NB2KG versions >= 0.4.0
as `KERNEL_WORKING_DIR` will be set to the appropriate value automatically.

Because this feature requires coordinated volume mounts (typically of the
user's home directory) `EG_MIRROR_WORKING_DIRS` is disabled by default.

Also:
Updated docs with some recently added environment variables.
Adjusted default culling parameters in the EG containerized environments.

Fixes #570