### PR TITLE
Minor refactor of integration tests to enable more platforms

### DIFF
--- a/enterprise_gateway/itests/test_base.py
+++ b/enterprise_gateway/itests/test_base.py
@@ -1,0 +1,24 @@
+import os
+
+expected_hostname = os.getenv("ITEST_HOSTNAME_PREFIX", "") + "*"  # use ${KERNEL_USERNAME} on k8s
+expected_application_id = os.getenv("EXPECTED_APPLICATION_ID", "application_*")  # use 'spark-application-*' on k8s
+expected_spark_version = os.getenv("EXPECTED_SPARK_VERSION", "2.4.*")  # use '2.4.*' on k8s
+expected_spark_master = os.getenv("EXPECTED_SPARK_MASTER", "yarn")  # use 'k8s:*' on k8s
+expected_deploy_mode = os.getenv("EXPECTED_DEPLOY_MODE", "(cluster|client)")  # use 'client' on k8s
+
+class TestBase(object):
+
+    def get_expected_application_id(self):
+        return expected_application_id
+
+    def get_expected_spark_version(self):
+        return expected_spark_version
+
+    def get_expected_spark_master(self):
+        return expected_spark_master
+
+    def get_expected_deploy_mode(self):
+        return expected_deploy_mode
+
+    def get_expected_hostname(self):
+        return expected_hostname


### PR DESCRIPTION
Performed some minor refactoring so that its easier to point nosetests
at different platforms (e.g., K8s cluster, Yarn cluster, etc.).  For example, 
the following could be used to run the Python kernel against a k8s cluster:
```bash
export PYTHON_KERNEL_CLUSTER_NAME=spark_python_kubernetes
export EXPECTED_APPLICATION_ID="spark-application-*"
export EXPECTED_DEPLOY_MODE="client"
export EXPECTED_SPARK_VERSION="2.4.*"
export EXPECTED_SPARK_MASTER="k8s:*"

export KERNEL_USERNAME=itest$$
export ITEST_HOSTNAME_PREFIX=${KERNEL_USERNAME}
export GATEWAY_HOST=k8s-omg-node-1.fyre.ibm.com/gateway

TESTS=enterprise_gateway.itests.test_python_kernel:TestPythonKernelCluster.test_get_hostname

nosetests -v $TESTS
```
