### PR TITLE
Launcher changes to enable local usage.

### DIFF
--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -345,10 +345,6 @@ if __name__ == "__main__":
         raise RuntimeError("At least one of the parameters: 'connection_file' or "
                            "'--RemoteProcessProxy.kernel-id' must be provided!")
 
-    if kernel_id is None:
-        logger.warning("Parameter 'connection_file' is deprecated.  Update kernel.json file to use "
-                       "'--RemoteProcessProxy.kernel-id {kernel_id}'")
-
     # If the connection file doesn't exist, then create it.
     if (connection_file and not os.path.isfile(connection_file)) or kernel_id is not None:
         key = str_to_bytes(str(uuid.uuid4()))

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
@@ -90,7 +90,7 @@ object ToreeLauncher extends LogLike {
           i += 1
           profilePath = args(i).trim
           toreeArgs += arg
-          toreeArgs += profilePath  // This will be replaced in determineConnectionFile()
+          toreeArgs += profilePath
 
         // Alternate sigint is a straight pass-thru to toree
         case "--alternate-sigint" =>
@@ -187,10 +187,6 @@ object ToreeLauncher extends LogLike {
       logger.error("At least one of '--profile' or '--RemoteProcessProxy.kernel_id' " +
         "must be provided - exiting!")
       sys.exit(-1)
-    }
-    if (kernelId == null){
-      logger.warn("Parameter 'connection_file' is deprecated.  " +
-        "Update kernel.json file to use '--RemoteProcessProxy.kernel-id {kernel_id}'")
     }
 
     if (!pathExists(profilePath)) {


### PR DESCRIPTION
Minor changes.  The R launcher needed some refactoring since support for the `{connection_file}` parameter had been removed.  Python and Scala launchers just removed messages regarding `connection_file`'s (premature) deprecation.

I've also attached screen shots from launches via notebook and a tar file containing local-mode kernelspecs.  Note the Apache Toree jar is not included in the scala example - so it needs to be added into the lib directory.  I had some issues with Scala interrupts outside of EG.  It's actually probably best to not use the ToreeLauncher outside of EG so SIGINT can get into the Toree kernel.  (EG uses the alternate sigint approach.)

Spark Python Local...
![spark_python_local](https://user-images.githubusercontent.com/22599560/53289360-0f945e00-374a-11e9-9bee-9452c0452b4f.png)

Spark R Local...
![spark_r_local](https://user-images.githubusercontent.com/22599560/53289361-14591200-374a-11e9-9602-3064305207b7.png)

[spark_local_kspecs.tar.zip](https://github.com/jupyter/enterprise_gateway/files/2897022/spark_local_kspecs.tar.zip)

Fixes #584