### PR TITLE
Bump JKG version for kernelspec resource change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ Apache Spark, Kubernetes and others..
         'docker>=3.5.0'
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',
-        'jupyter_kernel_gateway>=2.1.0',
+        'jupyter_kernel_gateway>=2.2.0',
         'kubernetes>=4.0.0',
         'notebook>=5.3.0,<6.0',
         'paramiko>=2.1.2',


### PR DESCRIPTION
With this change, kernelspec resources can be served to the notebook via NB2KG >= 0.5.0.