### PR TITLE
Fix itest restarts - remove state check

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -29,8 +29,6 @@ class PythonKernelBaseTestCase(TestBase):
 
         self.assertTrue(self.kernel.restart())
 
-        self.assertRegexpMatches(self.kernel.get_state(), '(idle|starting)')
-
         error_result = self.kernel.execute("y = x + 1")
         self.assertRegexpMatches(error_result, 'NameError')
 

--- a/enterprise_gateway/itests/test_r_kernel.py
+++ b/enterprise_gateway/itests/test_r_kernel.py
@@ -29,8 +29,6 @@ class RKernelBaseTestCase(TestBase):
 
         self.assertTrue(self.kernel.restart())
 
-        self.assertRegexpMatches(self.kernel.get_state(), '(idle|starting)')
-
         error_result = self.kernel.execute("y = x + 1")
         self.assertRegexpMatches(error_result, 'Error in eval')
 

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -31,8 +31,6 @@ class ScalaKernelBaseTestCase(TestBase):
 
         self.assertTrue(self.kernel.restart())
 
-        self.assertRegexpMatches(self.kernel.get_state(), '(idle|starting)')
-
         error_result = self.kernel.execute("var y = x + 1")
         self.assertRegexpMatches(error_result, 'Compile Error')
 


### PR DESCRIPTION
The restart test was ensuring that the state was idle or starting, but then we started seeing the busy state cause failures.  Since the very next statement is what actually confirms the restart occurred and won't execute until the kernel reaches the idle state, I decided we're better off without the state check entirely.