### PR TITLE
Lightweight Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: required
 language: python
 
 python:
-    - 2.7
-    - 3.4
+    - 3.5
     - 3.6
 
 services:


### PR DESCRIPTION
Remove Python 2.x from Travis build
Remove Python 3.4 from Travis build
Build Python 3.5 and 3.6 python versions