### PR TITLE
Add support for multiple YARN resource managers

### DIFF
--- a/docs/source/kern-yarn-cluster-mode.md
+++ b/docs/source/kern-yarn-cluster-mode.md
@@ -14,6 +14,10 @@ EG_YARN_ENDPOINT=http://${YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common
 ```
 Note: If Enterprise Gateway is using an applicable HADOOP_CONF_DIR that contains a valid `yarn-site.xml` file, then this config value can remain unset (default = None) and the YARN client library will locate the appropriate Resource Manager from the configuration.  This is also true in cases where the YARN cluster is configured for high availability.
 
+If Enterprise Gateway is remote from the YARN cluster (i.e., no HADOOP_CONF_DIR) and the YARN cluster is configured for high availability, then the alternate endpoint should also be specified...
+```
+EG_ALT_YARN_ENDPOINT=http://${ALT_YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
+```
 ### Configuring Kernels for YARN Cluster mode
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release [e.g. jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -235,7 +235,9 @@ Derived from `RemoteProcessProxy`, `YarnClusterProcessProxy` uses the `yarn-api-
 
 This process proxy is reliant on the `--EnterpriseGatewayApp.yarn_endpoint` command line option or the `EG_YARN_ENDPOINT` environment variable to determine where the YARN resource manager is located.  To accommodate increased flexibility, the endpoint definition can be defined within the process proxy stanza of the kernelspec, enabling the ability to direct specific kernels to different YARN clusters.
 
-Note: If Enterprise Gateway is running on an edge node of the YARN cluster and has a valid `yarn-site.xml` file in HADOOP_CONF_DIR, then the YARN endpoint is not required (default = None).  In such cases, the `yarn-api-client` library will choose the active Resource Manager from the configuration files.
+In cases where the YARN cluster is configured for high availability, then the `--EnterpriseGatewayApp.alt_yarn_endpoint` command line option or the `EG_ALT_YARN_ENDPOINT` environment variable should also be defined.  When set, the underlying `yarn-api-client` library will choose the active Resource Manager between the two.
+
+Note: If Enterprise Gateway is running on an edge node of the YARN cluster and has a valid `yarn-site.xml` file in HADOOP_CONF_DIR, neither of these values are required (default = None).  In such cases, the `yarn-api-client` library will choose the active Resource Manager from the configuration files.
 
 See [Enabling YARN Cluster Mode Support](kernel-yarn-cluster-mode.html#enabling-yarn-cluster-mode-support) for details.
 

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -65,6 +65,19 @@ class EnterpriseGatewayApp(KernelGatewayApp):
     def yarn_endpoint_default(self):
         return os.getenv(self.yarn_endpoint_env)
 
+    # Alt Yarn endpoint
+    alt_yarn_endpoint_env = 'EG_ALT_YARN_ENDPOINT'
+    alt_yarn_endpoint = Unicode(None, config=True, allow_none=True,
+                                help="""The http url specifying the alternate YARN Resource Manager.  This value should
+                                be set when YARN Resource Managers are configured for high availability.  Note: If both
+                                YARN endpoints are NOT set, the YARN library will use the files within the local
+                                HADOOP_CONFIG_DIR to determine the active resource manager.
+                                (EG_ALT_YARN_ENDPOINT env var)""")
+
+    @default('alt_yarn_endpoint')
+    def alt_yarn_endpoint_default(self):
+        return os.getenv(self.alt_yarn_endpoint_env)
+
     yarn_endpoint_security_enabled_env = 'EG_YARN_ENDPOINT_SECURITY_ENABLED'
     yarn_endpoint_security_enabled_default_value = False
     yarn_endpoint_security_enabled = Bool(yarn_endpoint_security_enabled_default_value, config=True,

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -41,23 +41,34 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         self.yarn_endpoint \
             = proxy_config.get('yarn_endpoint',
                                kernel_manager.parent.parent.yarn_endpoint)
+        self.alt_yarn_endpoint \
+            = proxy_config.get('alt_yarn_endpoint',
+                               kernel_manager.parent.parent.alt_yarn_endpoint)
+
         self.yarn_endpoint_security_enabled \
             = proxy_config.get('yarn_endpoint_security_enabled',
                                kernel_manager.parent.parent.yarn_endpoint_security_enabled)
 
-        yarn_master = None
-        yarn_port = None
+        yarn_master = alt_yarn_master = None
+        yarn_port = alt_yarn_port = None
         if self.yarn_endpoint:
             yarn_url = urlparse(self.yarn_endpoint)
             yarn_master = yarn_url.hostname
             yarn_port = yarn_url.port
+            # Only check alternate if "primary" is set.
+            if self.alt_yarn_endpoint:
+                alt_yarn_url = urlparse(self.alt_yarn_endpoint)
+                alt_yarn_master = alt_yarn_url.hostname
+                alt_yarn_port = alt_yarn_url.port
 
         self.resource_mgr = ResourceManager(address=yarn_master,
                                             port=yarn_port,
+                                            alt_address=alt_yarn_master,
+                                            alt_port=alt_yarn_port,
                                             kerberos_enabled=self.yarn_endpoint_security_enabled)
 
-        # Temporary until yarn-api-client can be extended to return host-port info when yarn_master is None.
-        self.rm_addr = yarn_master + ':' + str(yarn_port) if yarn_master is not None else '(see yarn-site.xml)'
+        host, port = self.resource_mgr.get_active_host_port()
+        self.rm_addr = host + ':' + str(port)
 
         # YARN applications tend to take longer than the default 5 second wait time.  Rather than
         # require a command-line option for those using YARN, we'll adjust based on a local env that

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@ dependencies:
   - tornado>=4.2.0
   - requests>=2.7,<3.0
   - paramiko>=2.1.2
-  - yarn-api-client>=0.3.3
+  - yarn-api-client>=0.3.5
   - pexpect>=4.2.0
   - pycrypto>=2.6.1
   - pyzmq>=17.0.0

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ Apache Spark, Kubernetes and others..
         'requests>=2.7,<3.0',
         'tornado>=4.2.0',
         'traitlets>=4.2.0',
-        'yarn-api-client>=0.3.3',
+        'yarn-api-client>=0.3.5',
         'jinja2>=2.10',
     ],
     python_requires='>=3.5',


### PR DESCRIPTION
Add support for specifying multiple YARN resource managers for HA-configured environments.  A new configuration option `alt_yarn_endpoint` compliments `yarn_endpoint` when YARN HA configurations are in use.  When both values are provided, the `yarn-api-client` library will the original config value for an active RM.  If not active, the library will check the alternate.

Note that both of these configuration values default to `None` (`yarn_endpoint` has been updated for this).  In cases where `yarn_endpoint` is `None`, the `yarn-api-client` library will read from the `yarn-site.xml` file located in `HADOOP_CONF_DIR` and choose the active resource manager - both HA and non-HA configurations.

This pull request is dependent on the [yarn-api-client PR #29](https://github.com/toidi/hadoop-yarn-api-python-client/pull/29).  Once merged and an updated version is available, [setup.py](https://github.com/jupyter/enterprise_gateway/blob/master/setup.py#L54) will be updated with the appropriate version.

Fixes: #595