### PR TITLE
Increase write permissions on SPARK_HOME/work-dir

### DIFF
--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -5,7 +5,8 @@ ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 RUN adduser -S -u 1000 -G users jovyan && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
-    chown -R jovyan:users /usr/local/bin/kernel-launchers /opt/spark/work-dir
+	chmod 0777 /opt/spark/work-dir && \
+    chown -R jovyan:users /usr/local/bin/kernel-launchers
 
 USER jovyan
 ENV KERNEL_LANGUAGE scala

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -36,7 +36,8 @@ RUN cd /opt/ && \
     ln -sfn /opt/conda/bin/tini /sbin/tini
 
 WORKDIR $SPARK_HOME/work-dir
-RUN chmod g+w $SPARK_HOME/work-dir
+# Ensure that work-dir is writable by everyone
+RUN chmod 0777 $SPARK_HOME/work-dir
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -32,7 +32,8 @@ RUN cd /opt/ && \
     ln -sfn /opt/conda/bin/tini /sbin/tini
 
 WORKDIR $SPARK_HOME/work-dir
-RUN chmod g+w $SPARK_HOME/work-dir
+# Ensure that work-dir is writable by everyone
+RUN chmod 0777 $SPARK_HOME/work-dir
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 


### PR DESCRIPTION
When changing the spark-based images to jupyter-based images, we dropped chown to `jovyan` for the SPARK_HOME/work-dir.  As a result, the jupyter-based images would get failures running spark jobs that required executors.  This change increases the permissions of the work-dir, not the owners, since we can run images as non-jovyan users today.

An image to test this with exists at: `kbates/kernel-spark-py:workdir`.