### PR TITLE
Drop support for Python 2.x

### DIFF
--- a/docs/source/getting-started-client-mode.md
+++ b/docs/source/getting-started-client-mode.md
@@ -50,9 +50,9 @@ After that, you should have a kernel.json that looks similar to the one below:
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "PYSPARK_PYTHON": "/opt/anaconda3/bin/python",
+    "PYSPARK_PYTHON": "/opt/conda/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
-    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip,PATH=/opt/anaconda2/bin:$PATH",
+    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip,PATH=/opt/conda/bin:$PATH",
     "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
     "LAUNCH_OPTS": ""
   },
@@ -86,9 +86,9 @@ Please see below how a kernel.json would look like for integrating with Spark St
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "PYSPARK_PYTHON": "/opt/anaconda3/bin/python",
+    "PYSPARK_PYTHON": "/opt/conda/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
-    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip,PATH=/opt/anaconda2/bin:$PATH",
+    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip,PATH=/opt/conda/bin:$PATH",
     "SPARK_OPTS": "--master spark://127.0.0.1:7077  --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
     "LAUNCH_OPTS": ""
   },

--- a/docs/source/getting-started-cluster-mode.md
+++ b/docs/source/getting-started-cluster-mode.md
@@ -46,9 +46,9 @@ After that, you should have a kernel.json that looks similar to the one below:
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "PYSPARK_PYTHON": "/opt/anaconda3/bin/python",
+    "PYSPARK_PYTHON": "/opt/conda/bin/python",
     "PYTHONPATH": "${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
-    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip,PATH=/opt/anaconda2/bin:$PATH",
+    "SPARK_YARN_USER_ENV": "PYTHONUSERBASE=/home/yarn/.local,PYTHONPATH=${HOME}/.local/lib/python3.6/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip,PATH=/opt/conda/bin:$PATH",
     "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false",
     "LAUNCH_OPTS": ""
   },

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -159,20 +159,20 @@ but it failed with a "Kernel error" and a SSHException.**
 
     ```
     Traceback (most recent call last):
-      File "/opt/anaconda2/lib/python2.7/site-packages/tornado/web.py", line 1512, in _execute
+      File "/opt/conda/lib/python3.7/site-packages/tornado/web.py", line 1512, in _execute
         result = yield result
-      File "/opt/anaconda2/lib/python2.7/site-packages/tornado/gen.py", line 1055, in run
+      File "/opt/conda/lib/python3.7/site-packages/tornado/gen.py", line 1055, in run
         value = future.result()
       ....
       ....
       ....
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/kernels/remotemanager.py", line 125, in _launch_kernel
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/kernels/remotemanager.py", line 125, in _launch_kernel
         return self.process_proxy.launch_process(kernel_cmd, **kw)
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/yarn.py", line 63, in launch_process
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/processproxies/yarn.py", line 63, in launch_process
         self.confirm_remote_startup(kernel_cmd, **kw)
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/yarn.py", line 174, in confirm_remote_startup
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/processproxies/yarn.py", line 174, in confirm_remote_startup
         ready_to_connect = self.receive_connection_info()
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 565, in receive_connection_info
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 565, in receive_connection_info
         raise e
     TypeError: Incorrect padding
     ```
@@ -199,17 +199,17 @@ but it failed with a "Kernel error" and a SSHException.**
 
     ```
     Traceback (most recent call last):
-      File "/opt/anaconda2/lib/python2.7/site-packages/tornado/web.py", line 1511, in _execute
+      File "/opt/conda/lib/python3.7/site-packages/tornado/web.py", line 1511, in _execute
         result = yield result
-      File "/opt/anaconda2/lib/python2.7/site-packages/tornado/gen.py", line 1055, in run
+      File "/opt/conda/lib/python3.7/site-packages/tornado/gen.py", line 1055, in run
         value = future.result()
       ....
       ....
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 478, in __init__
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 478, in __init__
         super(RemoteProcessProxy, self).__init__(kernel_manager, proxy_config)
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 87, in __init__
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 87, in __init__
         self._validate_port_range(proxy_config)
-      File "/opt/anaconda2/lib/python2.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 407, in _validate_port_range
+      File "/opt/conda/lib/python3.7/site-packages/enterprise_gateway/services/processproxies/processproxy.py", line 407, in _validate_port_range
         "port numbers is (1024, 65535).".format(self.lower_port))
     RuntimeError: Invalid port range '1000..2000' specified. Range for valid port numbers is (1024, 65535).
     ```

--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -107,7 +107,7 @@ class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
 
 
 class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
-    KERNELSPEC = os.getenv("PYTHON_KERNEL_LOCAL_NAME", "python2")  # python_kubernetes for k8s
+    KERNELSPEC = os.getenv("PYTHON_KERNEL_LOCAL_NAME", "python3")
 
     @classmethod
     def setUpClass(cls):

--- a/enterprise_gateway/tests/notebook_http/swagger/test_parser.py
+++ b/enterprise_gateway/tests/notebook_http/swagger/test_parser.py
@@ -3,7 +3,6 @@
 """Tests for notebook cell parsing."""
 
 import unittest
-import sys
 from kernel_gateway.notebook_http.swagger.parser import SwaggerCellParser
 
 
@@ -153,51 +152,48 @@ class TestSwaggerAPICellParser(unittest.TestCase):
                          '# ResponseInfo operationId: get\n')
 
     def test_undeclared_operations(self):
-        if sys.version_info[:2] >= (3, 4):
-            """Parser should warn about operations that aren't documented in the
-            swagger cell
-            """
-            source_cells = [
-                {"source": '```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'}, # noqa
-                {"source": '# operationId: get'},
-                {"source": '# operationId: postbar '},
-                {"source": '# operationId: putbar'},
-                {"source": '# operationId: extraOperation'},
-            ]
-            with self.assertLogs(level='WARNING') as warnings:
-                SwaggerCellParser(comment_prefix='#', notebook_cells=source_cells)
-                for output in warnings.output:
-                    self.assertRegex(output, 'extraOperation')
+        """Parser should warn about operations that aren't documented in the
+        swagger cell
+        """
+        source_cells = [
+            {"source":'```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'},# noqa
+            {"source": '# operationId: get'},
+            {"source": '# operationId: postbar '},
+            {"source": '# operationId: putbar'},
+            {"source": '# operationId: extraOperation'},
+        ]
+        with self.assertLogs(level='WARNING') as warnings:
+            SwaggerCellParser(comment_prefix='#', notebook_cells=source_cells)
+            for output in warnings.output:
+                self.assertRegex(output, 'extraOperation')
 
     def test_undeclared_operations_reversed(self):
-        if sys.version_info[:2] >= (3, 4):
-            """Parser should warn about operations that aren't documented in the
-            swagger cell
-            """
-            source_cells = [
-                {"source": '# operationId: get'},
-                {"source": '# operationId: postbar '},
-                {"source": '# operationId: putbar'},
-                {"source": '# operationId: extraOperation'},
-                {"source": '```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'}, # noqa
-            ]
-            with self.assertLogs(level='WARNING') as warnings:
-                SwaggerCellParser(comment_prefix='#', notebook_cells=source_cells)
-                for output in warnings.output:
-                    self.assertRegex(output, 'extraOperation')
+        """Parser should warn about operations that aren't documented in the
+        swagger cell
+        """
+        source_cells = [
+            {"source": '# operationId: get'},
+            {"source": '# operationId: postbar '},
+            {"source": '# operationId: putbar'},
+            {"source": '# operationId: extraOperation'},
+            {"source":'```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'},# noqa
+        ]
+        with self.assertLogs(level='WARNING') as warnings:
+            SwaggerCellParser(comment_prefix='#', notebook_cells=source_cells)
+            for output in warnings.output:
+                self.assertRegex(output, 'extraOperation')
 
     def test_unreferenced_operations(self):
-        if sys.version_info[:2] >= (3, 4):
-            """Parser should warn about documented operations that aren't referenced
-            in a cell
-            """
-            source_cells = [
-                {"source": '```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'}, # noqa
-                {"source": '# operationId: get'},
-                {"source": '# operationId: putbar'},
-                {"source": '# operationId: putbar '}
-            ]
-            with self.assertLogs(level='WARNING') as warnings:
-                SwaggerCellParser(comment_prefix='#', notebook_cells=source_cells)
-                for output in warnings.output:
-                    self.assertRegex(output, 'postbar')
+        """Parser should warn about documented operations that aren't referenced
+        in a cell
+        """
+        source_cells = [
+            {"source": '```\n{"swagger":"2.0", "paths": {"/foo": {"put": {"operationId":"putbar","parameters": [{"name": "bar"}]},"post":{"operationId":"postbar"},"get": {"operationId":"get","parameters": [{"name": "bar"}]}}}}\n```\n'},# noqa
+            {"source": '# operationId: get'},
+            {"source": '# operationId: putbar'},
+            {"source": '# operationId: putbar '}
+        ]
+        with self.assertLogs(level='WARNING') as warnings:
+            SwaggerCellParser(comment_prefix='#', notebook_cells=source_cells)
+            for output in warnings.output:
+                self.assertRegex(output, 'postbar')

--- a/enterprise_gateway/tests/test_jupyter_websocket.py
+++ b/enterprise_gateway/tests/test_jupyter_websocket.py
@@ -17,18 +17,6 @@ from tornado.httpclient import HTTPRequest
 from tornado.testing import gen_test
 from tornado.escape import json_encode, json_decode, url_escape
 
-PY3 = sys.version_info >= (3,)
-if PY3:
-    # On python 3, mixing unittest2 and unittest (including doctest)
-    # doesn't seem to work, so always use unittest.
-    import unittest
-else:
-    # On python 2, prefer unittest2 when available.
-    try:
-        import unittest2 as unittest  # type: ignore # noqa
-    except ImportError:
-        import unittest  # type: ignore # noqa
-
 
 class TestJupyterWebsocket(TestGatewayAppBase):
     """Base class for jupyter-websocket mode tests that spawn kernels."""

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -9,7 +9,7 @@ ARG NB_GID="100"
 USER root
 
 ENV HADOOP_PREFIX=/usr/hdp/current/hadoop \
-    ANACONDA_HOME=/opt/anaconda2
+    ANACONDA_HOME=/opt/conda
 
 ENV SHELL=/bin/bash \
     NB_USER=$NB_USER \
@@ -92,7 +92,7 @@ RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER
 RUN cd /usr/hdp/current && ln -s ./hadoop-$HADOOP_VER hadoop && ln -s ./spark-${SPARK_VER}-bin-hadoop2.7 spark2-client
 
 # INSTALL MINI-CONDA AND PYTHON PACKAGES
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -f -b -p $ANACONDA_HOME && \
     rm ~/miniconda.sh && \
     conda clean -tipsy && \
@@ -110,7 +110,7 @@ RUN conda install --yes --quiet \
     fix-permissions $ANACONDA_HOME && \
     fix-permissions /home/$NB_USER
 
-RUN Rscript -e 'install.packages("IRkernel", repos="http://cran.cnr.berkeley.edu", lib="/opt/anaconda2/lib/R/library")' \
+RUN Rscript -e 'install.packages("IRkernel", repos="http://cran.cnr.berkeley.edu", lib="/opt/conda/lib/R/library")' \
             -e 'IRkernel::installspec(prefix = "/usr/local")' \
             -e 'devtools::install_github("apache/spark@v2.4.0", subdir="R/pkg")' && \
     fix-permissions $ANACONDA_HOME && \
@@ -131,7 +131,7 @@ RUN ls -la /usr/hdp/current/hadoop/etc/hadoop/*-env.sh && \
 # Install Toree
 RUN cd /tmp && \
     curl -O https://dist.apache.org/repos/dist/release/incubator/toree/0.3.0-incubating/toree-pip/toree-0.3.0.tar.gz && \
-    pip install --upgrade setuptools --user python && \
+    pip install --upgrade setuptools --user && \
     pip install /tmp/toree-0.3.0.tar.gz && \
     jupyter toree install --spark_home=$SPARK_HOME --kernel_name="Spark 2.4.0" --interpreters=Scala && \
     rm -f /tmp/toree-0.3.0.tar.gz && \

--- a/etc/docker/demo-base/README.md
+++ b/etc/docker/demo-base/README.md
@@ -3,7 +3,7 @@
 * Hadoop 2.7.7 
 * Apache Spark 2.4.0
 * Java 1.8 runtime
-* Mini-conda 4.5.11 (python 2.7.15) with R packages
+* Mini-conda latest (python 3.7) with R packages
 * Toree 0.3.0-incubating
 * `jovyan` service user, with system users `elyra`, `bob`, and `alice`.  The jovyan uid is `1000` to match other jupyter
  images.

--- a/etc/kernelspecs/dask_python_yarn_remote/kernel.json
+++ b/etc/kernelspecs/dask_python_yarn_remote/kernel.json
@@ -8,7 +8,7 @@
   },
   "env": {
     "DASK_YARN_EXE": "/home/testuser/miniconda/envs/dask-env/bin/dask-yarn",
-    "DASK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --environment python:///opt/anaconda2/bin/python --temporary-security-credentials --deploy-mode remote",
+    "DASK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --environment python:///opt/conda/bin/python --temporary-security-credentials --deploy-mode remote",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/python_distributed/kernel.json
+++ b/etc/kernelspecs/python_distributed/kernel.json
@@ -1,5 +1,5 @@
 {
-  "display_name": "Python 2 (distributed)", 
+  "display_name": "Python 3 (distributed)",
   "language": "python", 
   "metadata": {
     "process_proxy": {

--- a/etc/kernelspecs/spark_R_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_client/kernel.json
@@ -8,7 +8,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.sparkr.r.command=/opt/anaconda2/lib/R/bin/Rscript ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.sparkr.r.command=/opt/conda/lib/R/bin/Rscript ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_R_yarn_cluster/kernel.json
@@ -8,7 +8,7 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/anaconda2/bin:$PATH --conf spark.sparkr.r.command=/opt/anaconda2/lib/R/bin/Rscript ${KERNEL_EXTRA_SPARK_OPTS}",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.am.waitTime=1d --conf spark.yarn.appMasterEnv.PATH=/opt/conda/bin:$PATH --conf spark.sparkr.r.command=/opt/conda/lib/R/bin/Rscript ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -8,8 +8,8 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
-    "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
+    "PYSPARK_PYTHON": "/opt/conda/bin/python",
+    "PYTHONPATH": "${HOME}/.local/lib/python3.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
     "SPARK_OPTS": "--master yarn --deploy-mode client --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -8,9 +8,9 @@
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",
-    "PYSPARK_PYTHON": "/opt/anaconda2/bin/python",
-    "PYTHONPATH": "${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
-    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.appMasterEnv.PYTHONUSERBASE=/home/${KERNEL_USERNAME}/.local --conf spark.yarn.appMasterEnv.PYTHONPATH=${HOME}/.local/lib/python2.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip --conf spark.yarn.appMasterEnv.PATH=/opt/anaconda2/bin:$PATH ${KERNEL_EXTRA_SPARK_OPTS}",
+    "PYSPARK_PYTHON": "/opt/conda/bin/python",
+    "PYTHONPATH": "${HOME}/.local/lib/python3.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip",
+    "SPARK_OPTS": "--master yarn --deploy-mode cluster --name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} --conf spark.yarn.submit.waitAppCompletion=false --conf spark.yarn.appMasterEnv.PYTHONUSERBASE=/home/${KERNEL_USERNAME}/.local --conf spark.yarn.appMasterEnv.PYTHONPATH=${HOME}/.local/lib/python3.7/site-packages:/usr/hdp/current/spark2-client/python:/usr/hdp/current/spark2-client/python/lib/py4j-0.10.6-src.zip --conf spark.yarn.appMasterEnv.PATH=/opt/conda/bin:$PATH ${KERNEL_EXTRA_SPARK_OPTS}",
     "LAUNCH_OPTS": ""
   },
   "argv": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal=1
+#universal=1
 
 [metadata]
 description-file=README.md

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,12 @@ from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+v = sys.version_info
+if v[:2] < (3, 5):
+    error = "ERROR: Jupyter Enterprise Gateway requires Python version 3.5 or above."
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
 version_ns = {}
 with open(os.path.join(here, 'enterprise_gateway', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
@@ -53,13 +59,13 @@ Apache Spark, Kubernetes and others..
         'traitlets>=4.2.0',
         'yarn-api-client>=0.3.3',
     ],
+    python_requires='>=3.5',
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3'
     ],
     include_package_data=True,


### PR DESCRIPTION
Jupyter has pledged to drop support for Python 2.x
and Jupyter Enterprise Gateway is going on the same
direction as several other Jupyter projects that have
already droped support for Python 2.x in favor of
Python 3.5 and above.

The following changes are part of this effort:

* Remove 'universal' flag for EG wheel distribution
* Remove conditional PY2/PY3 code
* Default kernelspec configurations to use version agnostic
values
* Update CI builds to only run tests on Python 3.5 and above
environments

Fixes #573