### PR TITLE
Set YARN endpoint default to None

### DIFF
--- a/docs/source/getting-started-cluster-mode.md
+++ b/docs/source/getting-started-cluster-mode.md
@@ -8,12 +8,16 @@ The distributed capabilities are currently based on an Apache Spark cluster util
 ```
 SPARK_HOME:/usr/hdp/current/spark2-client                            #For HDP distribution
 ```
-
-* EG_YARN_ENDPOINT: Must point to the YARN Resource Manager endpoint
+* EG_YARN_ENDPOINT: Must point to the YARN Resource Manager endpoint if remote from YARN cluster
 ```
 EG_YARN_ENDPOINT=http://${YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
 ```
+Note: If Enterprise Gateway is using an applicable HADOOP_CONF_DIR that contains a valid `yarn-site.xml` file, then this config value can remain unset (default = None) and the YARN client library will locate the appropriate Resource Manager from the configuration.  This is also true in cases where the YARN cluster is configured for high availability.
 
+If Enterprise Gateway is remote from the YARN cluster (i.e., no HADOOP_CONF_DIR) and the YARN cluster is configured for high availability, then the alternate endpoint should also be specified...
+```
+EG_ALT_YARN_ENDPOINT=http://${ALT_YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
+```
 ### Configuring Kernels for YARN Cluster mode
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release [e.g. jupyter_enterprise_gateway_kernelspecs-2.1.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.1.0.dev2/jupyter_enterprise_gateway_kernelspecs-2.1.0.dev2.tar.gz).

--- a/docs/source/getting-started-cluster-mode.md
+++ b/docs/source/getting-started-cluster-mode.md
@@ -14,10 +14,6 @@ EG_YARN_ENDPOINT=http://${YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common
 ```
 Note: If Enterprise Gateway is using an applicable HADOOP_CONF_DIR that contains a valid `yarn-site.xml` file, then this config value can remain unset (default = None) and the YARN client library will locate the appropriate Resource Manager from the configuration.  This is also true in cases where the YARN cluster is configured for high availability.
 
-If Enterprise Gateway is remote from the YARN cluster (i.e., no HADOOP_CONF_DIR) and the YARN cluster is configured for high availability, then the alternate endpoint should also be specified...
-```
-EG_ALT_YARN_ENDPOINT=http://${ALT_YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster #Common to YARN deployment
-```
 ### Configuring Kernels for YARN Cluster mode
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release [e.g. jupyter_enterprise_gateway_kernelspecs-2.1.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.1.0.dev2/jupyter_enterprise_gateway_kernelspecs-2.1.0.dev2.tar.gz).

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -229,20 +229,15 @@ defaults to 30 seconds if unspecified.  Since all `KERNEL_` environment variable
 timeout can be specified as a client attribute of the Notebook session.
 
 ###### YarnClusterProcessProxy
-As part of its base offering, Enterprise Gateway provides an implementation of a process proxy 
-that communicates with the YARN resource manager that has been instructed to launch a kernel
-on one of its worker nodes.  The node on which the kernel is launched is up to the resource
-manager - which enables an optimized distribution of kernel resources.
+As part of its base offering, Enterprise Gateway provides an implementation of a process proxy that communicates with the YARN resource manager that has been instructed to launch a kernel on one of its worker nodes.  The node on which the kernel is launched is up to the resource manager - which enables an optimized distribution of kernel resources.
 
-Derived from `RemoteProcessProxy`, `YarnClusterProcessProxy` uses the `yarn-api-client` library
-to locate the kernel and monitor its life-cycle.  However, once the kernel has returned its
-connection information, the primary kernel operations naturally take place over the ZeroMQ ports.
+Derived from `RemoteProcessProxy`, `YarnClusterProcessProxy` uses the `yarn-api-client` library to locate the kernel and monitor its life-cycle.  However, once the kernel has returned its connection information, the primary kernel operations naturally take place over the ZeroMQ ports.
 
-This process proxy is reliant on the `--EnterpriseGatewayApp.yarn_endpoint` command line 
-option or the `EG_YARN_ENDPOINT` environment variable to determine where the YARN resource manager is 
-located.  To accommodate increased flexibility, the endpoint definition can be defined within 
-the process proxy stanza of the kernelspec, enabling the ability to direct specific kernels to 
-different YARN clusters.
+This process proxy is reliant on the `--EnterpriseGatewayApp.yarn_endpoint` command line option or the `EG_YARN_ENDPOINT` environment variable to determine where the YARN resource manager is located.  To accommodate increased flexibility, the endpoint definition can be defined within the process proxy stanza of the kernelspec, enabling the ability to direct specific kernels to different YARN clusters.
+
+In cases where the YARN cluster is configured for high availability, then the `--EnterpriseGatewayApp.alt_yarn_endpoint` command line option or the `EG_ALT_YARN_ENDPOINT` environment variable should also be defined.  When set, the underlying `yarn-api-client` library will choose the active Resource Manager between the two.
+
+Note: If Enterprise Gateway is running on an edge node of the YARN cluster and has a valid `yarn-site.xml` file in HADOOP_CONF_DIR, neither of these values are required (default = None).  In such cases, the `yarn-api-client` library will choose the active Resource Manager from the configuration files.
 
 See [Enabling YARN Cluster Mode Support](getting-started-cluster-mode.html#enabling-yarn-cluster-mode-support) for details.
 

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -235,9 +235,7 @@ Derived from `RemoteProcessProxy`, `YarnClusterProcessProxy` uses the `yarn-api-
 
 This process proxy is reliant on the `--EnterpriseGatewayApp.yarn_endpoint` command line option or the `EG_YARN_ENDPOINT` environment variable to determine where the YARN resource manager is located.  To accommodate increased flexibility, the endpoint definition can be defined within the process proxy stanza of the kernelspec, enabling the ability to direct specific kernels to different YARN clusters.
 
-In cases where the YARN cluster is configured for high availability, then the `--EnterpriseGatewayApp.alt_yarn_endpoint` command line option or the `EG_ALT_YARN_ENDPOINT` environment variable should also be defined.  When set, the underlying `yarn-api-client` library will choose the active Resource Manager between the two.
-
-Note: If Enterprise Gateway is running on an edge node of the YARN cluster and has a valid `yarn-site.xml` file in HADOOP_CONF_DIR, neither of these values are required (default = None).  In such cases, the `yarn-api-client` library will choose the active Resource Manager from the configuration files.
+Note: If Enterprise Gateway is running on an edge node of the YARN cluster and has a valid `yarn-site.xml` file in HADOOP_CONF_DIR, then the YARN endpoint is not required (default = None).  In such cases, the `yarn-api-client` library will choose the active Resource Manager from the configuration files.
 
 See [Enabling YARN Cluster Mode Support](getting-started-cluster-mode.html#enabling-yarn-cluster-mode-support) for details.
 

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -56,13 +56,27 @@ class EnterpriseGatewayApp(KernelGatewayApp):
 
     # Yarn endpoint
     yarn_endpoint_env = 'EG_YARN_ENDPOINT'
-    yarn_endpoint_default_value = 'http://localhost:8088/ws/v1/cluster'
-    yarn_endpoint = Unicode(yarn_endpoint_default_value, config=True,
-                            help="""The http url for accessing the YARN Resource Manager. (EG_YARN_ENDPOINT env var)""")
+    yarn_endpoint = Unicode(None, config=True, allow_none=True,
+                            help="""The http url specifying the YARN Resource Manager. Note: If this value is NOT set,
+                            the YARN library will use the files within the local HADOOP_CONFIG_DIR to determine the
+                            active resource manager. (EG_YARN_ENDPOINT env var)""")
 
     @default('yarn_endpoint')
     def yarn_endpoint_default(self):
-        return os.getenv(self.yarn_endpoint_env, self.yarn_endpoint_default_value)
+        return os.getenv(self.yarn_endpoint_env)
+
+    # Alt Yarn endpoint
+    alt_yarn_endpoint_env = 'EG_ALT_YARN_ENDPOINT'
+    alt_yarn_endpoint = Unicode(None, config=True, allow_none=True,
+                                help="""The http url specifying the alternate YARN Resource Manager.  This value should
+                                be set when YARN Resource Managers are configured for high availability.  Note: If both
+                                YARN endpoints are NOT set, the YARN library will use the files within the local
+                                HADOOP_CONFIG_DIR to determine the active resource manager.
+                                (EG_ALT_YARN_ENDPOINT env var)""")
+
+    @default('alt_yarn_endpoint')
+    def alt_yarn_endpoint_default(self):
+        return os.getenv(self.alt_yarn_endpoint_env)
 
     yarn_endpoint_security_enabled_env = 'EG_YARN_ENDPOINT_SECURITY_ENABLED'
     yarn_endpoint_security_enabled_default_value = False

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -65,19 +65,6 @@ class EnterpriseGatewayApp(KernelGatewayApp):
     def yarn_endpoint_default(self):
         return os.getenv(self.yarn_endpoint_env)
 
-    # Alt Yarn endpoint
-    alt_yarn_endpoint_env = 'EG_ALT_YARN_ENDPOINT'
-    alt_yarn_endpoint = Unicode(None, config=True, allow_none=True,
-                                help="""The http url specifying the alternate YARN Resource Manager.  This value should
-                                be set when YARN Resource Managers are configured for high availability.  Note: If both
-                                YARN endpoints are NOT set, the YARN library will use the files within the local
-                                HADOOP_CONFIG_DIR to determine the active resource manager.
-                                (EG_ALT_YARN_ENDPOINT env var)""")
-
-    @default('alt_yarn_endpoint')
-    def alt_yarn_endpoint_default(self):
-        return os.getenv(self.alt_yarn_endpoint_env)
-
     yarn_endpoint_security_enabled_env = 'EG_YARN_ENDPOINT_SECURITY_ENABLED'
     yarn_endpoint_security_enabled_default_value = False
     yarn_endpoint_security_enabled = Bool(yarn_endpoint_security_enabled_default_value, config=True,

--- a/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
+++ b/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
@@ -5,7 +5,7 @@ export JUPYTER_PATH=${JUPYTER_PATH:-/tmp/byok}
 
 # Enterprise Gateway variables
 export EG_REMOTE_HOSTS=${EG_REMOTE_HOSTS:-HOSTNAME}
-export EG_YARN_ENDPOINT=${EG_YARN_ENDPOINT:-http://HOSTNAME:8088/ws/v1/cluster}
+export EG_YARN_MASTERS=HOSTNAME:8088
 export EG_SSH_PORT=${EG_SSH_PORT:-2122}
 export KG_IP=${KG_IP:-0.0.0.0}
 export KG_PORT=${KG_PORT:-8888}

--- a/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
+++ b/etc/docker/enterprise-gateway-demo/start-enterprise-gateway.sh.template
@@ -5,7 +5,6 @@ export JUPYTER_PATH=${JUPYTER_PATH:-/tmp/byok}
 
 # Enterprise Gateway variables
 export EG_REMOTE_HOSTS=${EG_REMOTE_HOSTS:-HOSTNAME}
-export EG_YARN_MASTERS=HOSTNAME:8088
 export EG_SSH_PORT=${EG_SSH_PORT:-2122}
 export KG_IP=${KG_IP:-0.0.0.0}
 export KG_PORT=${KG_PORT:-8888}


### PR DESCRIPTION
This pull request is a split of PR #607 that changes the default value for the YARN endpoint configuration option to `None`.  By doing this, 90% of customers can take advantage of built-in behaviors in `yarn-api-client` which determine the YARN Resource Manager endpoint from local configuration files.  This is because 90% of customers install Enterprise Gateway on an edge node of their YARN cluster.  In addition, that logic will also handle the case where YARN is configured for HA.

Installations on which Enterprise Gateway is not installed on an edge node, will still need to provide a YARN endpoint parameter.  In addition, these installations cannot take advantage of HA configurations until [yarn-api-client PR #29](https://github.com/toidi/hadoop-yarn-api-python-client/pull/29) is merged.