### PR TITLE
#625: Helm chart

### DIFF
--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -397,7 +397,7 @@ deployment "enterprise-gateway" created
 
 ##### Uninstalling Enterprise Gateway
 
-- To shutdown Enterprise Gateway issue a delete command using the previously mentioned global label `app=enterprise-gateway`
+To shutdown Enterprise Gateway issue a delete command using the previously mentioned global label `app=enterprise-gateway`
 ```
 kubectl delete all -l app=enterprise-gateway
 ```

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -423,7 +423,7 @@ can override them with Helm's `--set` or `--values` options.
 | `cull_idle_timeout` | Idle timeout in seconds. Default is 1 hour. | `3600` |
 | `log_level` | Log output level. | `DEBUG` |
 | `kernel_launch_timeout` | Timeout for kernel launching in seconds. | `60` |
-| `kernel_whitelist` | List of kernel names that are available for use. | `{r_kubernetes,python_kubernetes,python_tf_kubernetes,python_tf_gpu_kubernetes,scala_kubernetes,spark_r_kubernetes,spark_python_kubernetes,spark_scala_kubernetes}` |
+| `kernel_whitelist` | List of kernel names that are available for use. | `{r_kubernetes,...}` (see `values.yaml`) |
 | `nfs.enabled` | Whether NFS-mounted kernelspecs are enabled. | `false` |
 | `nfs.internal_server_ip_address` | IP address of NFS server. Required if NFS is enabled. | `nil` |
 | `k8s_master_public_ip` | Master public IP on which to expose EG. | `nil` |

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -386,7 +386,7 @@ If it is not possible to pre-seed the nodes, you will likely need to adjust the 
 Choose this deployment option if you want to deploy directly from Kubernetes template files with kubectl, rather than using a package manager like Helm.
 
 ##### Create the Enterprise Gateway kubernetes service and deployment
-From the master node, create the service and deployment using the yaml file from the git repository:
+From the master node, create the service and deployment using the yaml file from a source release or the git repository:
 
 ```
 kubectl apply -f etc/kubernetes/enterprise-gateway.yaml
@@ -424,7 +424,7 @@ Choose this option if you want to deploy via a [Helm](https://helm.sh/) chart.
 
 ##### Create the Enterprise Gateway kubernetes service and deployment
 
-From anywhere with Helm cluster access, create the service and deployment by running Helm from the git repository:
+From anywhere with Helm cluster access, create the service and deployment by running Helm from a source release or the git repository:
 
 ```
 helm upgrade --install --atomic --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -395,18 +395,6 @@ service "enterprise-gateway" created
 deployment "enterprise-gateway" created
 ```
 
-#### Option 2: Deploying with Helm
-
-Choose this option if you want to deploy via a [Helm](https://helm.sh/) chart.
-
-##### Create the Enterprise Gateway kubernetes service and deployment
-
-From anywhere with Helm cluster access, create the service and deployment by running Helm from the git repository:
-
-```
-helm upgrade --install --atomic --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm
-```
-
 ##### Uninstalling Enterprise Gateway
 
 - To shutdown Enterprise Gateway issue a delete command using the previously mentioned global label `app=enterprise-gateway`
@@ -428,6 +416,18 @@ Also note that deleting the Enterprise Gateway namespace will not delete cluster
 ```
 kubectl delete clusterrole -l app=enterprise-gateway
 kubectl delete clusterrolebinding -l app=enterprise-gateway
+```
+
+#### Option 2: Deploying with Helm
+
+Choose this option if you want to deploy via a [Helm](https://helm.sh/) chart.
+
+##### Create the Enterprise Gateway kubernetes service and deployment
+
+From anywhere with Helm cluster access, create the service and deployment by running Helm from the git repository:
+
+```
+helm upgrade --install --atomic --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm
 ```
 
 ##### Configuration

--- a/docs/source/getting-started-kubernetes.md
+++ b/docs/source/getting-started-kubernetes.md
@@ -407,6 +407,29 @@ From anywhere with Helm cluster access, create the service and deployment by run
 helm upgrade --install --atomic --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm
 ```
 
+##### Uninstalling Enterprise Gateway
+
+- To shutdown Enterprise Gateway issue a delete command using the previously mentioned global label `app=enterprise-gateway`
+```
+kubectl delete all -l app=enterprise-gateway
+```
+or simply delete the namespace
+```
+kubectl delete ns enterprise-gateway
+```
+
+A kernel's objects can be similarly deleted using the kernel's namespace...
+```
+kubectl delete ns <kernel-namespace>
+```
+Note that this should not imply that kernels be "shutdown" using a the `kernel_id=` label.  This will likely trigger Jupyter's auto-restart logic - so its best to properly shutdown kernels prior to kubernetes object deletions.
+
+Also note that deleting the Enterprise Gateway namespace will not delete cluster-scoped resources like the cluster roles `enterprise-gateway-controller` and `kernel-controller` or the cluster role binding `enterprise-gateway-controller`. The following commands can be used to delete these:
+```
+kubectl delete clusterrole -l app=enterprise-gateway
+kubectl delete clusterrolebinding -l app=enterprise-gateway
+```
+
 ##### Configuration
 
 Here are all of the values that you can set when deploying the Helm chart. You
@@ -427,6 +450,14 @@ can override them with Helm's `--set` or `--values` options.
 | `nfs.enabled` | Whether NFS-mounted kernelspecs are enabled. | `false` |
 | `nfs.internal_server_ip_address` | IP address of NFS server. Required if NFS is enabled. | `nil` |
 | `k8s_master_public_ip` | Master public IP on which to expose EG. | `nil` |
+
+##### Uninstalling Enterprise Gateway
+
+When using Helm, you can uninstall Enterprise Gateway with the following command:
+
+```
+helm delete --purge enterprise-gateway
+```
 
 #### Confirm deployment and note the service port mapping
 ```
@@ -486,27 +517,6 @@ po/alice-5e755458-a114-4215-96b7-bcb016fc7b62   1/1       Running   0          2
 ```
 Note: because kernels are, by default, isolated to their own namespace, you could also find all objects of a
 given kernel using only the `--namespace <kernel-namespace>` clause.
-
-- To shutdown Enterprise Gateway issue a delete command using the previously mentioned global label `app=enterprise-gateway`
-```
-kubectl delete all -l app=enterprise-gateway
-```
-or simply delete the namespace
-```
-kubectl delete ns enterprise-gateway
-```
-
-A kernel's objects can be similarly deleted using the kernel's namespace...
-```
-kubectl delete ns <kernel-namespace>
-```
-Note that this should not imply that kernels be "shutdown" using a the `kernel_id=` label.  This will likely trigger Jupyter's auto-restart logic - so its best to properly shutdown kernels prior to kubernetes object deletions.
-
-Also note that deleting the Enterprise Gateway namespace will not delete cluster-scoped resources like the cluster roles `enterprise-gateway-controller` and `kernel-controller` or the cluster role binding `enterprise-gateway-controller`. The following commands can be used to delete these:
-```
-kubectl delete clusterrole -l app=enterprise-gateway 
-kubectl delete clusterrolebinding -l app=enterprise-gateway
-```
 
 - To enter into a given pod (i.e., container) in order to get a better idea of what might be happening within the container, use the exec command with the pod name
 ```

--- a/etc/kubernetes/helm/Chart.yaml
+++ b/etc/kubernetes/helm/Chart.yaml
@@ -1,0 +1,3 @@
+name: enterprise-gateway
+version: 1.0.0
+

--- a/etc/kubernetes/helm/Chart.yaml
+++ b/etc/kubernetes/helm/Chart.yaml
@@ -1,3 +1,3 @@
 name: enterprise-gateway
-version: 1.0.0
+version: 0.8.0
 

--- a/etc/kubernetes/helm/templates/clusterrole.yaml
+++ b/etc/kubernetes/helm/templates/clusterrole.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: enterprise-gateway-controller
+  labels:
+    app: enterprise-gateway
+    component: enterprise-gateway
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "services", "configmaps", "secrets", "persistentvolumes", "persistentvolumeclaims"]
+    verbs: ["get", "watch", "list", "create", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["rolebindings"]
+    verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  # Referenced by EG_KERNEL_CLUSTER_ROLE in the Deployment
+  name: kernel-controller
+  labels:
+    app: enterprise-gateway
+    component: kernel
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list", "create", "delete"]

--- a/etc/kubernetes/helm/templates/clusterrolebinding.yaml
+++ b/etc/kubernetes/helm/templates/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: enterprise-gateway-controller
+  labels:
+    app: enterprise-gateway
+    component: enterprise-gateway
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: enterprise-gateway-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: enterprise-gateway-controller
+  apiGroup: rbac.authorization.k8s.io

--- a/etc/kubernetes/helm/templates/deployment.yaml
+++ b/etc/kubernetes/helm/templates/deployment.yaml
@@ -25,36 +25,36 @@ spec:
       # Created by this chart.
       serviceAccountName: enterprise-gateway-sa
       containers:
-        - name: enterprise-gateway
-          image: {{ .Values.image }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          args: ["--gateway"]
-          env:
-          - name: EG_NAMESPACE
-            value: {{ .Release.Namespace }}
-          - name: EG_KERNEL_CLUSTER_ROLE
-            value: {{ .Values.kernel_cluster_role }}
-          - name: EG_SHARED_NAMESPACE
-            value: {{ if .Values.shared_namespace }}"True"{{ else }}"False"{{ end }}
-          - name: EG_MIRROR_WORKING_DIRS
-            value: {{ if .Values.mirror_working_dirs }}"True"{{ else }}"False"{{ end }}
-          - name: EG_CULL_IDLE_TIMEOUT
-            value: !!str {{ .Values.cull_idle_timeout }}
-          - name: EG_LOG_LEVEL
-            value: {{ .Values.log_level }}
-          - name: EG_KERNEL_LAUNCH_TIMEOUT
-            value: !!str {{ .Values.kernel_launch_timeout }}
-          - name: EG_KERNEL_WHITELIST
-            value: {{ toJson .Values.kernel_whitelist | squote }}
-          ports:
-          - containerPort: 8888
-{{ if .Values.nfs.enabled }}
-          volumeMounts:
-          - name: kernelspecs
-            mountPath: "/usr/local/share/jupyter/kernels"
-        volumes:
+      - name: enterprise-gateway
+        image: {{ .Values.image }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        args: ["--gateway"]
+        env:
+        - name: EG_NAMESPACE
+          value: {{ .Release.Namespace }}
+        - name: EG_KERNEL_CLUSTER_ROLE
+          value: {{ .Values.kernel_cluster_role }}
+        - name: EG_SHARED_NAMESPACE
+          value: {{ if .Values.shared_namespace }}"True"{{ else }}"False"{{ end }}
+        - name: EG_MIRROR_WORKING_DIRS
+          value: {{ if .Values.mirror_working_dirs }}"True"{{ else }}"False"{{ end }}
+        - name: EG_CULL_IDLE_TIMEOUT
+          value: !!str {{ .Values.cull_idle_timeout }}
+        - name: EG_LOG_LEVEL
+          value: {{ .Values.log_level }}
+        - name: EG_KERNEL_LAUNCH_TIMEOUT
+          value: !!str {{ .Values.kernel_launch_timeout }}
+        - name: EG_KERNEL_WHITELIST
+          value: {{ toJson .Values.kernel_whitelist | squote }}
+        ports:
+        - containerPort: 8888
+{{- if .Values.nfs.enabled }}
+        volumeMounts:
         - name: kernelspecs
-          nfs:
-            server: {{ .Values.nfs.internal_server_ip_address }}
-            path: "/usr/local/share/jupyter/kernels"
-{{ end }}
+          mountPath: "/usr/local/share/jupyter/kernels"
+      volumes:
+      - name: kernelspecs
+        nfs:
+          server: {{ .Values.nfs.internal_server_ip_address }}
+          path: "/usr/local/share/jupyter/kernels"
+{{- end }}

--- a/etc/kubernetes/helm/templates/deployment.yaml
+++ b/etc/kubernetes/helm/templates/deployment.yaml
@@ -55,6 +55,6 @@ spec:
         volumes:
         - name: kernelspecs
           nfs:
-            server: {{ .Values.internal_server_ip_address }}
+            server: {{ .Values.nfs.internal_server_ip_address }}
             path: "/usr/local/share/jupyter/kernels"
 {{ end }}

--- a/etc/kubernetes/helm/templates/deployment.yaml
+++ b/etc/kubernetes/helm/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: enterprise-gateway
+  namespace: enterprise-gateway
+  labels:
+    gateway-selector: enterprise-gateway
+    app: enterprise-gateway
+    component: enterprise-gateway
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      gateway-selector: enterprise-gateway
+  template:
+    metadata:
+      labels:
+        gateway-selector: enterprise-gateway
+        app: enterprise-gateway
+        component: enterprise-gateway
+    spec:
+      # Created by this chart.
+      serviceAccountName: enterprise-gateway-sa
+      containers:
+        - name: enterprise-gateway
+          image: {{ .Values.image }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args: ["--gateway"]
+          env:
+          - name: EG_NAMESPACE
+            value: {{ .Release.Namespace }}
+          - name: EG_KERNEL_CLUSTER_ROLE
+            value: {{ .Values.kernel_cluster_role }}
+          - name: EG_SHARED_NAMESPACE
+            value: {{ if .Values.shared_namespace }}"True"{{ else }}"False"{{ end }}
+          - name: EG_MIRROR_WORKING_DIRS
+            value: {{ if .Values.mirror_working_dirs }}"True"{{ else }}"False"{{ end }}
+          - name: EG_CULL_IDLE_TIMEOUT
+            value: !!str {{ .Values.cull_idle_timeout }}
+          - name: EG_LOG_LEVEL
+            value: {{ .Values.log_level }}
+          - name: EG_KERNEL_LAUNCH_TIMEOUT
+            value: !!str {{ .Values.kernel_launch_timeout }}
+          - name: EG_KERNEL_WHITELIST
+            value: {{ toJson .Values.kernel_whitelist | squote }}
+          ports:
+          - containerPort: 8888
+{{ if .Values.nfs.enabled }}
+          volumeMounts:
+          - name: kernelspecs
+            mountPath: "/usr/local/share/jupyter/kernels"
+        volumes:
+        - name: kernelspecs
+          nfs:
+            server: {{ .Values.internal_server_ip_address }}
+            path: "/usr/local/share/jupyter/kernels"
+{{ end }}

--- a/etc/kubernetes/helm/templates/service.yaml
+++ b/etc/kubernetes/helm/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
     gateway-selector: enterprise-gateway
   sessionAffinity: ClientIP
   type: NodePort
-{{ if .Values.k8s_master_public_ip }}
+{{- if .Values.k8s_master_public_ip }}
   externalIPs:
   - {{ .Values.k8s_master_public_ip }}
-{{ end }}
+{{- end }}

--- a/etc/kubernetes/helm/templates/service.yaml
+++ b/etc/kubernetes/helm/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: enterprise-gateway
+    component: enterprise-gateway
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: enterprise-gateway
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: http
+    port: 8888
+    targetPort: 8888
+  selector:
+    gateway-selector: enterprise-gateway
+  sessionAffinity: ClientIP
+  type: NodePort
+{{ if .Values.k8s_master_public_ip }}
+  externalIPs:
+  - {{ .Values.k8s_master_public_ip }}
+{{ end }}

--- a/etc/kubernetes/helm/templates/serviceaccount.yaml
+++ b/etc/kubernetes/helm/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: enterprise-gateway-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: enterprise-gateway
+    component: enterprise-gateway
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -1,27 +1,10 @@
-# Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run.
 image: elyra/enterprise-gateway:dev
-
-# Use IfNotPresent policy so that dev-based systems don't automatically
-# update. This provides more control.  Since formal tags will be release-specific
-# this policy should be sufficient for them as well.
 imagePullPolicy: IfNotPresent
-
-# Update to deploy multiple replicas of EG
 replicas: 1
-
-# Created by this chart.  Used if no KERNEL_NAMESPACE is provided by client.
 kernel_cluster_role: "kernel-controller"
-
-# All kernels reside in the EG namespace if true, otherwise KERNEL_NAMESPACE
-# must be provided or one will be created for each kernel.
 shared_namespace: false
-
-# NOTE: This requires appropriate volume mounts to make notebook dir accessible.
 mirror_working_dirs: false
-
-# Current idle timeout is 1 hour.
 cull_idle_timeout: 3600
-
 log_level: "DEBUG"
 kernel_launch_timeout: 60
 kernel_whitelist:

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -1,11 +1,11 @@
 image: elyra/enterprise-gateway:dev
 imagePullPolicy: IfNotPresent
 replicas: 1
-kernel_cluster_role: "kernel-controller"
+kernel_cluster_role: kernel-controller
 shared_namespace: false
 mirror_working_dirs: false
 cull_idle_timeout: 3600
-log_level: "DEBUG"
+log_level: DEBUG
 kernel_launch_timeout: 60
 kernel_whitelist:
   - r_kubernetes
@@ -18,9 +18,7 @@ kernel_whitelist:
   - spark_scala_kubernetes
 
 nfs:
-  # Set to true to enable NFS-mounted kernelspecs.
   enabled: false
   internal_server_ip_address:
 
-# Set in order to use <k8s-master>:8888.
 k8s_master_public_ip:

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -1,0 +1,43 @@
+# Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run.
+image: elyra/enterprise-gateway:dev
+
+# Use IfNotPresent policy so that dev-based systems don't automatically
+# update. This provides more control.  Since formal tags will be release-specific
+# this policy should be sufficient for them as well.
+imagePullPolicy: IfNotPresent
+
+# Update to deploy multiple replicas of EG
+replicas: 1
+
+# Created by this chart.  Used if no KERNEL_NAMESPACE is provided by client.
+kernel_cluster_role: "kernel-controller"
+
+# All kernels reside in the EG namespace if true, otherwise KERNEL_NAMESPACE
+# must be provided or one will be created for each kernel.
+shared_namespace: false
+
+# NOTE: This requires appropriate volume mounts to make notebook dir accessible.
+mirror_working_dirs: false
+
+# Current idle timeout is 1 hour.
+cull_idle_timeout: 3600
+
+log_level: "DEBUG"
+kernel_launch_timeout: 60
+kernel_whitelist:
+  - r_kubernetes
+  - python_kubernetes
+  - python_tf_kubernetes
+  - python_tf_gpu_kubernetes
+  - scala_kubernetes
+  - spark_r_kubernetes
+  - spark_python_kubernetes
+  - spark_scala_kubernetes
+
+nfs:
+  # Set to true to enable NFS-mounted kernelspecs.
+  enabled: false
+  internal_server_ip_address:
+
+# Set in order to use <k8s-master>:8888.
+k8s_master_public_ip:

--- a/release.sh
+++ b/release.sh
@@ -188,6 +188,9 @@ function update_version_to_release {
     # Update Kubernetes deployment descriprot
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/enterprise-gateway.yaml
 
+    # Update Kubernetes Helm values
+    sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/helm/values.yaml
+
     # Update Makefile
     sed -i .bak "s@$CURRENT_VERSION@$RELEASE_VERSION@g" Makefile
 
@@ -202,6 +205,9 @@ function update_version_to_development {
 
     # Update Kubernetes deployment descriprot
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/enterprise-gateway.yaml
+
+    # Update Kubernetes Helm values
+    sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/helm/values.yaml
 
     # Update Makefile
     sed -i .bak "s@$RELEASE_VERSION@$DEVELOPMENT_VERSION@g" Makefile


### PR DESCRIPTION
##### Changes

This PR includes an optional Helm chart for deploying Enterprise Gateway, and the corresponding documentation updates to describe using it.

I started by copying the existing `etc/kubernetes/enterprise-gateway.yaml` and splitting it into separate per-resource template files as per Helm convention. Then, I factored out any apparent customization points into documented Helm values that get plumbed into the templates. That way, modifying the Helm chart should generally not be necessary on a per-deployment basis, and customization can happen directly via overrides on the Helm command-line.

In a few cases, I opted to support specification of the values as native YAML types rather than as strings. This includes `true`/`false`, various integer values, and the Kernel whitelist as a list. This made it easier to deal with these values in Helm templates. And they are converted to strings before being passed into the Enterprise Gateway pod as environment variables, so there should be no functional difference.

I also added metadata labels that are usually found on Helm chart resources.

##### Testing

```bash
$ helm upgrade --install --atomic --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm
Release "enterprise-gateway" has been upgraded. Happy Helming!
...
```

I ensured things appeared to be running:

```
$ kubectl get all --all-namespaces -l app=enterprise-gateway
NAMESPACE            NAME                        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
enterprise-gateway   deploy/enterprise-gateway   1         1         1            1           1h

NAMESPACE            NAME                               DESIRED   CURRENT   READY     AGE
enterprise-gateway   rs/enterprise-gateway-64fb7c779c   1         1         1         1h
enterprise-gateway   rs/enterprise-gateway-6db45fb858   0         0         0         1h
enterprise-gateway   rs/enterprise-gateway-6fb884bb5f   0         0         0         1h
enterprise-gateway   rs/enterprise-gateway-bc5b4676b    0         0         0         1h

NAMESPACE                                    NAME                                                                 READY     STATUS    RESTARTS   AGE
enterprise-gateway                           po/enterprise-gateway-64fb7c779c-jrxkq                               1/1       Running   0          1h

NAMESPACE            NAME                     TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
enterprise-gateway   svc/enterprise-gateway   NodePort   100.66.108.35   <none>        8888:30913/TCP   1h
```

I started a `kubectl port-forward` to Enterprise Gateway on port 8888, and then I started a notebook locally to connect, selecting the Python Spark Kubernetes kernel. Then I printed `sc` within the notebook to confirm that the Spark context was working.

I also tried overriding a few of the configurable values to make sure that worked. For instance, including
`--set kernel_whitelist={spark_python_kubernetes}` with the Helm upgrade ensured that only a single kernel showed up in the Jupyter UI. Setting `--set replicas=2` ensured that two Enterprise Gateway pods got spun up. (Although I had to include the `--recreate-pods` Helm option.) Including `--set mirror_working_dirs=true` ensured that "True" was passed to the Enterprise Gateway pod for that option.

Here's the full pod YAML from one of these tests:

```
$ kubectl get pods -n enterprise-gateway -o yaml
apiVersion: v1
items:
- apiVersion: v1
  kind: Pod
  metadata:
    creationTimestamp: 2019-04-04T19:32:19Z
    generateName: enterprise-gateway-64fb7c779c-
    labels:
      app: enterprise-gateway
      component: enterprise-gateway
      gateway-selector: enterprise-gateway
      pod-template-hash: "2096373357"
    name: enterprise-gateway-64fb7c779c-jrxkq
    namespace: enterprise-gateway
    ownerReferences:
    - apiVersion: apps/v1
      blockOwnerDeletion: true
      controller: true
      kind: ReplicaSet
      name: enterprise-gateway-64fb7c779c
      uid: a83ebe09-570f-11e9-838d-06c5023a10da
    resourceVersion: "56510328"
    selfLink: /api/v1/namespaces/enterprise-gateway/pods/enterprise-gateway-64fb7c779c-jrxkq
    uid: 5c4fab58-5710-11e9-838d-06c5023a10da
  spec:
    containers:
    - args:
      - --gateway
      env:
      - name: EG_NAMESPACE
        value: enterprise-gateway
      - name: EG_KERNEL_CLUSTER_ROLE
        value: kernel-controller
      - name: EG_SHARED_NAMESPACE
        value: "False"
      - name: EG_MIRROR_WORKING_DIRS
        value: "False"
      - name: EG_CULL_IDLE_TIMEOUT
        value: "3600"
      - name: EG_LOG_LEVEL
        value: DEBUG
      - name: EG_KERNEL_LAUNCH_TIMEOUT
        value: "60"
      - name: EG_KERNEL_WHITELIST
        value: '["spark_python_kubernetes"]'
      image: elyra/enterprise-gateway:dev
      imagePullPolicy: IfNotPresent
      name: enterprise-gateway
      ports:
      - containerPort: 8888
        protocol: TCP
      resources: {}
      terminationMessagePath: /dev/termination-log
      terminationMessagePolicy: File
      volumeMounts:
      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
        name: enterprise-gateway-sa-token-4c484
        readOnly: true
    dnsPolicy: ClusterFirst
    nodeName: REDACTED.internal
    priority: 0
    restartPolicy: Always
    schedulerName: default-scheduler
    securityContext: {}
    serviceAccount: enterprise-gateway-sa
    serviceAccountName: enterprise-gateway-sa
    terminationGracePeriodSeconds: 30
    tolerations:
    - effect: NoExecute
      key: node.kubernetes.io/not-ready
      operator: Exists
      tolerationSeconds: 300
    - effect: NoExecute
      key: node.kubernetes.io/unreachable
      operator: Exists
      tolerationSeconds: 300
    volumes:
    - name: enterprise-gateway-sa-token-4c484
      secret:
        defaultMode: 420
        secretName: enterprise-gateway-sa-token-4c484
  status:
    conditions:
    - lastProbeTime: null
      lastTransitionTime: 2019-04-04T19:32:19Z
      status: "True"
      type: Initialized
    - lastProbeTime: null
      lastTransitionTime: 2019-04-04T19:32:20Z
      status: "True"
      type: Ready
    - lastProbeTime: null
      lastTransitionTime: null
      status: "True"
      type: ContainersReady
    - lastProbeTime: null
      lastTransitionTime: 2019-04-04T19:32:19Z
      status: "True"
      type: PodScheduled
    containerStatuses:
    - containerID: docker://6c7f58c9dd77ff4063537eef1116aa10990d709f6a7e357d65433195412a6f1b
      image: elyra/enterprise-gateway:dev
      imageID: docker-pullable://elyra/enterprise-gateway@sha256:5621319b2813b614b2f4f2b2ce2db238aff63c8bceae6bd06988227c9348ca14
      lastState: {}
      name: enterprise-gateway
      ready: true
      restartCount: 0
      state:
        running:
          startedAt: 2019-04-04T19:32:20Z
    hostIP: 172.19.34.186
    phase: Running
    podIP: 100.96.3.249
    qosClass: BestEffort
    startTime: 2019-04-04T19:32:19Z
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```