### PR TITLE
Change kernel-pod.yaml to jinja2 template (kernel-pod.yaml.j2)

### DIFF
--- a/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/kernel-pod.yaml.j2
@@ -1,5 +1,5 @@
 # This file defines the Kubernetes objects necessary for Enterprise Gateway kernels to run witihin Kubernetes.
-# Substitution parameters (wrapped with ${}) are processed by the launch_kubernetes.py code located in the
+# Substitution parameters are processed by the launch_kubernetes.py code located in the
 # same directory.  Some values are factory values, while others (typically prefixed with 'kernel_') can be
 # provided by the client.
 #
@@ -10,43 +10,62 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ${kernel_pod_name}
-  namespace: ${kernel_namespace}
+  name: "{{ kernel_pod_name }}"
+  namespace: "{{ kernel_namespace }}"
   labels:
-    kernel_id: ${kernel_id}
+    kernel_id: "{{ kernel_id }}"
     app: enterprise-gateway
     component: kernel
 spec:
   restartPolicy: Never
-  serviceAccountName: ${kernel_service_account_name}
-# Uncomment the following if you want to run the kernel pod as a different user and group
+  serviceAccountName: "{{ kernel_service_account_name }}"
 # NOTE: that using runAsGroup requires that feature-gate RunAsGroup be enabled.
 # WARNING: Only using runAsUser w/o runAsGroup or NOT enabling the RunAsGroup feature-gate
 # will result in the new kernel pod's effective group of 0 (root)! although the user will
 # correspond to the runAsUser value.  As a result, BOTH should be uncommented AND the feature-gate
 # should be enabled to ensure expected behavior.  In addition, 'fsGroup: 100' is recommended so
 # that /home/jovyan can be written to via the 'users' group (gid: 100) irrespective of the
-# ${kernel_uid} and ${kernel_gid} values.
-#
-#  securityContext:
-#    runAsUser: ${kernel_uid}
-#    runAsGroup: ${kernel_gid}
-#    fsGroup: 100
+# "kernel_uid" and "kernel_gid" values.
+  {% if kernel_uid is defined or kernel_gid is defined %}
+  securityContext:
+    {% if kernel_uid is defined %}
+    runAsUser: {{ kernel_uid | int }}
+    {% endif %}
+    {% if kernel_gid is defined %}
+    runAsGroup: {{ kernel_gid | int }}
+    {% endif %}
+    fsGroup: 100
+  {% endif %}
   containers:
   - env:
     - name: EG_RESPONSE_ADDRESS
-      value: ${eg_response_address}
+      value: "{{ eg_response_address }}"
     - name: KERNEL_LANGUAGE
-      value: ${kernel_language}
+      value: "{{ kernel_language }}"
     - name: KERNEL_SPARK_CONTEXT_INIT_MODE
-      value: ${kernel_spark_context_init_mode}
+      value: "{{ kernel_spark_context_init_mode }}"
     - name: KERNEL_NAME
-      value: ${kernel_name}
+      value: "{{ kernel_name }}"
     - name: KERNEL_USERNAME
-      value: ${kernel_username}
+      value: "{{ kernel_username }}"
     - name: KERNEL_ID
-      value: ${kernel_id}
+      value: "{{ kernel_id }}"
     - name: KERNEL_NAMESPACE
-      value: ${kernel_namespace}
-    image: ${kernel_image}
-    name: ${kernel_pod_name}
+      value: "{{ kernel_namespace }}"
+    image: "{{ kernel_image }}"
+    name: "{{ kernel_pod_name }}"
+    {% if kernel_working_dir is defined %}
+    workingDir: "{{ kernel_working_dir }}"
+    {% endif %}
+    {% if kernel_volume_mounts is defined %}
+    volumeMounts:
+      {% for volume_mount in kernel_volume_mounts %}
+    - {{ volume_mount }}
+      {% endfor %}
+    {% endif %}
+  {% if kernel_volumes is defined %}
+  volumes:
+    {% for volume in kernel_volumes %}
+  - {{ volume }}
+    {% endfor %}
+  {% endif %}

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,6 +16,7 @@ dependencies:
   - pyzmq>=17.0.0
   - python-kubernetes>=4.0.0
   - docker-py>=3.5.0
+  - jinja2>=2.10
   - pip
 
   # Test Requirements

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ Apache Spark, Kubernetes and others..
         'scripts/jupyter-enterprisegateway'
     ],
     install_requires=[
-        'docker>=3.5.0'
+        'docker>=3.5.0',
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',
         'jupyter_kernel_gateway>=2.3.0',
@@ -58,6 +58,7 @@ Apache Spark, Kubernetes and others..
         'tornado>=4.2.0',
         'traitlets>=4.2.0',
         'yarn-api-client>=0.3.3',
+        'jinja2>=2.10',
     ],
     python_requires='>=3.5',
     classifiers=[


### PR DESCRIPTION
jinja2 template supports rich operations in template file.
Now we don't have to modify `launch_kubernetes.py`, but just modify `kernel-pod.yaml.j2` and
add `KERNEL_` environment variable to customize kernel pod spec.

Signed-off-by: Eunsoo Park <esevan.park@gmail.com>

I believe this patch is a part of #527 .

I didn't test this in working EG instance yet since I was out of office so I didn't have any access to k8s.

But tested with following `test.py`
```test.py
KERNEL_VOLUME_STR = """[
    {"name": "test-volume", "awsElasticBlockStore": {"volumeID": 1234}},
    {"name": "test-volume2", "emptyDir": {}}
]
"""

KERNEL_VOLUME_MOUNT_STR = """
- mountPath: /test-abs
  name: test-volume
- mountPath: /oops
  name: test-volume2
"""

KERNEL_WORK_DIR = '/home/jovyan/workspace'

base_keywords = dict(
    kernel_name='kernel-test',
    kernel_id='kernel-test-1234',
    eg_response_address='127.0.0.1:8080',
    kernel_spark_context_init_mode='False',
    kernel_uid=yaml.safe_load('500'),
    kernel_image='image:dev',
    kernel_pod_name='user-kernel-test-1234',
    kernel_username='user',
    kernel_namespace='enterprise-gateway',
    kernel_language='python'
)
keywords_including_all = dict(
    kernel_volumes=yaml.safe_load(KERNEL_VOLUME_STR),
    kernel_volume_mounts=yaml.safe_load(KERNEL_VOLUME_MOUNT_STR),
    kernel_working_dir=yaml.safe_load(KERNEL_WORK_DIR)
)

keywords = base_keywords.copy()
keywords.update(keywords_including_all)

k8s_yaml = generate_kernel_pod_yaml(keywords)
print(k8s_yaml)
k8s_objs = yaml.load_all(k8s_yaml)
for k8s_obj in k8s_objs:
    with open('test.yaml', 'w+') as f:
        yaml.dump(k8s_obj, f)
```
And resulted as intended:
```
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: enterprise-gateway
    component: kernel
    kernel_id: kernel-test-1234
  name: user-kernel-test-1234
  namespace: enterprise-gateway
spec:
  containers:
  - env:
    - name: EG_RESPONSE_ADDRESS
      value: 127.0.0.1:8080
    - name: KERNEL_LANGUAGE
      value: python
    - name: KERNEL_SPARK_CONTEXT_INIT_MODE
      value: 'False'
    - name: KERNEL_NAME
      value: kernel-test
    - name: KERNEL_USERNAME
      value: user
    - name: KERNEL_ID
      value: kernel-test-1234
    - name: KERNEL_NAMESPACE
      value: enterprise-gateway
    image: image:dev
    name: user-kernel-test-1234
    volumeMounts:
    - mountPath: /test-abs
      name: test-volume
    - mountPath: /oops
      name: test-volume2
    workingDir: /home/jovyan/workspace
  restartPolicy: Never
  securityContext:
    fsGroup: 100
    runAsUser: 500
  serviceAccountName: ''
  volumes:
  - awsElasticBlockStore:
      volumeID: 1234
    name: test-volume
  - emptyDir: {}
    name: test-volume2
```