### PR TITLE
Fix Markdown table rendering in documentation. (#631).

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,3 +5,4 @@ dependencies:
 - sphinx>=1.8.3
 - pip:
     - recommonmark
+    - sphinx-markdown-tables

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.napoleon',
     "sphinx.ext.extlinks",
     "sphinx.ext.viewcode",
+    "sphinx_markdown_tables",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.yml
+++ b/requirements.yml
@@ -32,3 +32,4 @@ dependencies:
   - sphinx_rtd_theme
   - sphinx=1.8.3
   - recommonmark
+  - sphinx-markdown-tables


### PR DESCRIPTION
##### Changes

While the recently added (#625) Helm configuration documentation table renders [just fine on GitHub](https://github.com/jupyter/enterprise_gateway/blob/master/docs/source/getting-started-kubernetes.md#configuration), it [does not appear to render correctly on Read the Docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/getting-started-kubernetes.html#configuration). (My bad for not testing it there.)

This change adds a Sphinx extension called `sphinx-markdown-tables` that turns the pile of unrendered table Markdown into a nicely rendered table with no other changes to the Markdown.

Fixes #631.

##### Testing

Manually installed `sphinx-markdown-tables` into an existing Enterprise Gateway virtualenv, activated the virtualenv, and then ran `sphinx-markdown-tables`. Observed that the table now renders correctly.