### PR TITLE
[K8S HELM DEPENDENCY][WIP] Mount kernelspecs via Helm without NFS

### DIFF
--- a/etc/kubernetes/helm/templates/configmap.yaml
+++ b/etc/kubernetes/helm/templates/configmap.yaml
@@ -1,0 +1,21 @@
+{{- if (len .Values.kernelspecs) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: enterprise-gateway-kernelspecs
+  labels:
+    name: enterprise-gateway-kernelspecs
+    app: enterprise-gateway
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- range $kernel_name, $kernelspec := .Values.kernelspecs }}
+  {{ $kernel_name }}.kernel.json: |
+{{ index $kernelspec "kernel.json" | indent 4 }}
+  {{ $kernel_name }}.run.sh: |
+  {{- if hasKey $kernelspec "run.sh" }}
+{{ index $kernelspec "run.sh" | indent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/etc/kubernetes/helm/templates/deployment.yaml
+++ b/etc/kubernetes/helm/templates/deployment.yaml
@@ -57,4 +57,22 @@ spec:
         nfs:
           server: {{ .Values.nfs.internal_server_ip_address }}
           path: "/usr/local/share/jupyter/kernels"
+{{- else if (len .Values.kernelspecs) }}
+        volumeMounts:
+        - name: kernelspecs
+          mountPath: "/usr/local/share/jupyter/kernels"
+      volumes:
+      - name: kernelspecs
+        configMap:
+          name: enterprise-gateway-kernelspecs
+          {{- range $kernel_name, $kernelspec := .Values.kernelspecs }}
+          items:
+          - key: {{ $kernel_name }}.kernel.json
+            path: {{ $kernel_name }}/kernel.json
+          {{- if hasKey $kernelspec "run.sh" }}
+          - key: {{ $kernel_name }}.run.sh
+            path: {{ $kernel_name }}/bin/run.sh
+            mode: 0755
+          {{- end }}
+          {{- end }}
 {{- end }}

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -16,6 +16,7 @@ kernel_whitelist:
   - spark_r_kubernetes
   - spark_python_kubernetes
   - spark_scala_kubernetes
+kernelspecs: {}
 
 nfs:
   enabled: false


### PR DESCRIPTION
### Overview

This PR provides a way to mount kernelspecs into an Enterprise Gateway Kubernetes pod directly at [Helm](https://helm.sh/) deployment time if using Helm. This is an alternative to mounting kernelspecs into an Enterprise Gateway K8s pod via an NFS server. The motivation is twofold:

* Setting up, maintaining, and deploying kernelspecs to an NFS server is kind of a pain, especially within Kubernetes.
* It'd be super nice for usability if a Helm "release" (Helm's terminology for a deployment) included everything necessary to get Enterprise Gateway up and running.. including kernelspecs. No multiple-step deploys. This works today with the stock kernelspecs (just deploy EG and go), but it'd also be nice if this worked for custom kernelspecs.

### Usage

So the general approach is as follows. The user puts their kernelspecs in a local Helm values file like `kernelspecs.yaml` as follows:

```yaml
kernelspecs:
  spark_python_kubernetes:
    kernel.json: |
      {
        "language": "python",
        "display_name": "Spark - Python (Kubernetes Mode)",
        "metadata": {
          "process_proxy": {
            ...
          }
        }
      }
    run.sh: |
      #!/usr/bin/env bash

      if [ "${EG_IMPERSONATION_ENABLED}" = "True" ]; then
      ...
```

In other words, the files are pasted directly into the YAML. Then, to deploy:

```bash
$ helm upgrade --install --namespace enterprise-gateway enterprise-gateway --values kernelspecs.yaml etc/kubernetes/helm
```

Note the `--values kernelspecs.yaml` part. This passes the kernelspecs into the Helm chart, resulting in the given kernelspecs showing up in the Enterprise Gateway pod, very similar to how they'd show up if mounted from NFS.

### Changes

* Add a K8s ConfigMap containing the kernelspecs provided from the command-line values.
* Consume that ConfigMap within the K8s Deployment, mounting the expected `kernel.json` and `run.sh` (if given) as a volume in the Enterprise Gateway pod.

### Testing

See usage above. I tried:

 * Deploy the given `kernelspecs.yaml`. The files showed up as expected within the EG pod in the kernelspecs directory.
 * Deploy `kernelspecs.yaml` with the `run.sh` entry removed. Just the kernelspec showed up in the pod without any `run.sh`.
 * Deploy without any `--values kernelspecs.yaml` at all. The stock kernespecs showed up in the pod.

### Still to do

* Docs updates, including examples.
* More testing. Specifically, consuming one of these mounted kernels in an actual Jupyter notebook.

### Looking for

Thoughts/reactions? Would you entertain this sort of feature?