### PR TITLE
Use a custom image as an init container to copy in kernelspecs.

### DIFF
--- a/etc/kubernetes/helm/Chart.yaml
+++ b/etc/kubernetes/helm/Chart.yaml
@@ -1,3 +1,3 @@
 name: enterprise-gateway
-version: 0.8.0
+version: 0.8.1
 

--- a/etc/kubernetes/helm/templates/deployment.yaml
+++ b/etc/kubernetes/helm/templates/deployment.yaml
@@ -24,10 +24,20 @@ spec:
     spec:
       # Created by this chart.
       serviceAccountName: enterprise-gateway-sa
+{{- if .Values.kernelspecs_image }}
+      initContainers:
+      - name: kernelspecs
+        image: {{ .Values.kernelspecs_image }}
+        imagePullPolicy: {{ .Values.kernelspecs_image_pull_policy }}
+        args: ["cp", "-r", "/kernels", "/usr/local/share/jupyter"]
+        volumeMounts:
+        - name: image-kernelspecs
+          mountPath: "/usr/local/share/jupyter/kernels"
+{{- end }}
       containers:
       - name: enterprise-gateway
         image: {{ .Values.image }}
-        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        imagePullPolicy: {{ .Values.image_pull_policy }}
         args: ["--gateway"]
         env:
         - name: EG_NAMESPACE
@@ -50,11 +60,19 @@ spec:
         - containerPort: 8888
 {{- if .Values.nfs.enabled }}
         volumeMounts:
-        - name: kernelspecs
+        - name: nfs-kernelspecs
           mountPath: "/usr/local/share/jupyter/kernels"
       volumes:
-      - name: kernelspecs
+      - name: nfs-kernelspecs
         nfs:
           server: {{ .Values.nfs.internal_server_ip_address }}
           path: "/usr/local/share/jupyter/kernels"
+{{- else if .Values.kernelspecs_image }}
+        volumeMounts:
+        - name: image-kernelspecs
+          mountPath: "/usr/local/share/jupyter/kernels"
+      volumes:
+      - name: image-kernelspecs
+        emptydir:
+          medium: Memory
 {{- end }}

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -1,5 +1,7 @@
 image: elyra/enterprise-gateway:dev
-imagePullPolicy: IfNotPresent
+image_pull_policy: IfNotPresent
+kernelspecs_image:
+kernelspecs_image_pull_policy: Always
 replicas: 1
 kernel_cluster_role: kernel-controller
 shared_namespace: false


### PR DESCRIPTION
### Overview

This PR provides a way to mount kernelspecs into an Enterprise Gateway Kubernetes pod from a custom kernelspecs Docker image. This is an alternative to mounting kernelspecs into an Enterprise Gateway K8s pod via an NFS server. The motivation is twofold:

* Setting up, maintaining, and deploying kernelspecs to an NFS server is kind of a pain, especially within Kubernetes.
* It'd be super nice for usability if a Helm "release" (Helm's terminology for a deployment) included everything necessary to get Enterprise Gateway up and running.. including kernelspecs. No multiple-step deploys. This works today with the stock kernelspecs (just deploy EG and go), but it'd also be nice if this worked for custom kernelspecs.

See https://github.com/jupyter/enterprise_gateway/pull/635 for more background.

### Usage

First, I built and published a custom Docker image with this Dockerfile:

```dockerfile
FROM alpine:3.9

COPY kernels /kernels
```

The `kernels/` sub-directory contained my custom kernel:

```bash
$ ls -R kernels/
kernels/:
spark_python_kubernetes/

kernels/spark_python_kubernetes:
bin/  kernel.json

kernels/spark_python_kubernetes/bin:
```

Then, with that custom image in place, I deployed Enterprise Gateway with Helm:

```bash
$ helm upgrade --atomic --install --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm/ --set kernelspecs_image=my-custom-jupyter-kernelspecs:example
```

Note that the `kernelspecs_image` value refers to the name of the kernelspecs image built above. (Image name is fake; the actual one is on a private registry.)

This resulted in the Enterprise Gateway pod coming up with its kernelspecs path containing the custom kernelspecs!

### Changes

1. Rather than a sidecar container, I went with a K8s Init Container. That seemed more appropriate, because you can't directly mount a container into another container in the same pod; you have to share data over a volume of some sort. In this case, I opted for an in-memory `emptyDir`. And the kernelspecs Init Container simply spins up, copies its data into the shared volume, and spins down. This copying is done in the Helm chart, so the end-user doesn't have to worry about it. All they need to do is abide by the convention of putting their kernelspecs into `/kernels` in their container.
2. Add appropriate values to the chart's `values.yaml`.
3. Documentation.

### Tesing

Did the deploy above. Observed that Enterprise Gateway spun up, and the kernelspecs appeared in the expected location in the running pod. Connected to Enterprise Gateway from a local Jupyter notebook. Confirmed that I could connect to the custom kernel and get notebook output.

Confirmed that I could still deploy NFS with the Helm chart without this new custom container image. Did not confirm anything about NFS actually functioning (no NFS server here).

Tried deploying both NFS and a custom container image together (which is not supported). Observed that Helm failed spectacularly on a template error, as expected. At some point it might be nicer to make it fail in a more friendly fashion.