### PR TITLE
Add ingress resource to helm chart

### DIFF
--- a/etc/kubernetes/helm/templates/ingress.yaml
+++ b/etc/kubernetes/helm/templates/ingress.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: {{ .Values.ingress.namespace }}
+  name: enterprise-gateway-ingress
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- if .Values.ingress.hostName }}
+  - host: {{ .Values.ingress.hostName }}
+    http:
+  {{- else }}
+  - http:
+  {{- end }}
+      paths:
+      - path: {{ .Values.ingress.path }}
+        backend:
+          serviceName: enterprise-gateway
+          servicePort: {{ .Values.ingress.port }}
+{{ end }}

--- a/etc/kubernetes/helm/templates/ingress.yaml
+++ b/etc/kubernetes/helm/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  namespace: {{ .Values.ingress.namespace }}
+  namespace: {{ .Release.Namespace }}
   name: enterprise-gateway-ingress
 {{- with .Values.ingress.annotations }}
   annotations:

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -25,7 +25,6 @@ nfs:
 
 ingress:
   enabled: false
-  namespace: enterprise-gateway
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /$1

--- a/etc/kubernetes/helm/values.yaml
+++ b/etc/kubernetes/helm/values.yaml
@@ -23,4 +23,16 @@ nfs:
   enabled: false
   internal_server_ip_address:
 
+ingress:
+  enabled: false
+  namespace: enterprise-gateway
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+  hostName: ""
+  path: /gateway/?(.*)
+  port: 8888
+
 k8s_master_public_ip:


### PR DESCRIPTION
My stab at #626. 
- Ingress template is parameterized with a boolean to enable/disable. 
- Default is set to assume user is using nginx as ingress controller.

Working on including Istio as well.

