### PR TITLE
Update Apache Spark download URL with official archive instead of mirror

### DIFF
--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -35,7 +35,7 @@ RUN chown jovyan:users /usr/local/bin/bootstrap-enterprise-gateway.sh && \
 	rm -f /usr/local/bin/bootstrap-kernel.sh
 
 # Download and install Spark
-RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
+RUN curl -s https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
     tar -xz -C /opt && \
     ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME && \
     mkdir -p /usr/hdp/current && \

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 # Download and install Spark
-RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
+RUN curl -s https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
     tar -xz -C /opt && \
     ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME
 

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 # Download and install Spark
-RUN curl -s http://apache.cs.utah.edu/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
+RUN curl -s https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SPARK_VER}-bin-hadoop2.7.tgz | \
     tar -xz -C /opt && \
     ln -s ${SPARK_HOME}-${SPARK_VER}-bin-hadoop2.7 $SPARK_HOME
 


### PR DESCRIPTION
Downloading from mirrors causing problems when they update too frequently and delete older distributions.