### PR TITLE
Makefiles: change publish targets to push, use --no-cache on new publish-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@
 .PHONY: help build clean nuke dev dev-http docs install sdist test release clean-images clean-enterprise-gateway \
     clean-nb2kg clean-demo-base clean-kernel-images clean-enterprise-gateway \
     clean-kernel-py clean-kernel-spark-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala clean-kernel-tf-py \
-    clean-kernel-tf-gpu-py clean-kernel-image-puller publish-images
+    clean-kernel-tf-gpu-py clean-kernel-image-puller push-images push-enterprise-gateway-demo push-nb2kg push-demo-base \
+    push-kernel-images push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-r push-kernel-spark-r \
+    push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller publish
 
 SA:=source activate
 ENV:=enterprise-gateway-dev
@@ -111,7 +113,7 @@ kernel-images: ## Build kernel-based docker images
 
 # Actual working targets...
 docker-images enterprise-gateway-demo demo-base nb2kg kernel-images enterprise-gateway kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py kernel-image-puller:
-	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) TAG=$(TAG) -C etc $@
+	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) NO_CACHE=$(NO_CACHE) TAG=$(TAG) -C etc $@
 
 # Here for doc purposes
 clean-images: ## Remove docker images (includes kernel-based images)
@@ -120,8 +122,11 @@ clean-kernel-images: ## Remove kernel-based images
 clean-images clean-enterprise-gateway-demo clean-nb2kg clean-demo-base clean-kernel-images clean-enterprise-gateway clean-kernel-py clean-kernel-spark-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala clean-kernel-tf-py clean-kernel-tf-gpu-py clean-kernel-image-puller:
 	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) TAG=$(TAG) -C etc $@
 
-publish-images: ## Push docker images to docker hub
+push-images push-enterprise-gateway-demo push-nb2kg push-demo-base push-kernel-images push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-r push-kernel-spark-r push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller:
 	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) TAG=$(TAG) -C etc $@
+
+publish: NO_CACHE=--no-cache
+publish: clean clean-images dist docker-images push-images
 
 # itest should have these targets up to date: bdist kernelspecs docker-enterprise-gateway
 

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -12,7 +12,8 @@ SHELL:=/bin/bash
 # Docker attributes - hub organization and tag.  Modify accordingly
 HUB_ORG:=elyra
 
-NO_CACHE?=--no-cache
+# Set NO_CACHE=--no-cache to force docker build to not use cached layers
+NO_CACHE?=
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -101,12 +102,12 @@ kernel_image_files: ../build/kernel_image_files
 
 KERNEL_IMAGES := kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py
 DOCKER_IMAGES := demo-base enterprise-gateway-demo nb2kg enterprise-gateway kernel-image-puller $(KERNEL_IMAGES)
-PUBLISHED_IMAGES := enterprise-gateway-demo nb2kg enterprise-gateway kernel-image-puller $(KERNEL_IMAGES)
+PUSHED_IMAGES := enterprise-gateway-demo nb2kg enterprise-gateway kernel-image-puller $(KERNEL_IMAGES)
 
 docker-images: $(DOCKER_IMAGES)
 kernel-images: $(KERNEL_IMAGES)
 
-publish-images: publish-enterprise-gateway-demo publish-nb2kg publish-enterprise-gateway publish-kernel-py publish-kernel-spark-py publish-kernel-tf-py publish-kernel-r publish-kernel-spark-r publish-kernel-scala publish-kernel-image-puller
+push-images: push-enterprise-gateway-demo push-nb2kg push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-tf-py push-kernel-r push-kernel-spark-r push-kernel-scala push-kernel-image-puller
 
 clean-images: clean-enterprise-gateway-demo clean-nb2kg clean-demo-base clean-enterprise-gateway clean-kernel-image-puller clean-kernel-images
 clean-kernel-images: clean-kernel-py clean-kernel-spark-py clean-kernel-tf-py clean-kernel-tf-gpu-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala
@@ -148,7 +149,7 @@ $1: ../.image-$1
 	@make clean-$1 TARGETS_$1
 	@mkdir -p ../build/docker/$1
 	@cp -r docker/$1/* $$(FILES_$1) ../build/docker/$1
-	@(cd ../build/docker/$1; docker build --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} -t $(HUB_ORG)/$1:$(TAG) .)
+	(cd ../build/docker/$1; docker build ${NO_CACHE} --build-arg HUB_ORG=${HUB_ORG} --build-arg TAG=${TAG} -t $(HUB_ORG)/$1:$(TAG) .)
 	@touch ../.image-$1
 	@-docker images $(HUB_ORG)/$1:$(TAG)
 endef
@@ -162,10 +163,10 @@ clean-$1:
 endef
 $(foreach image,$(DOCKER_IMAGES),$(eval $(call CLEAN_IMAGE,$(image))))
 
-# Publish each publish image on $(PUBLISHED_IMAGES) to DockerHub.  Switch 'eval' to 'info' to see what is produced.
-define PUBLISH_IMAGE
-publish-$1:
-	@docker push $(HUB_ORG)/$1:$(TAG)
+# Publish each publish image on $(PUSHED_IMAGES) to DockerHub.  Switch 'eval' to 'info' to see what is produced.
+define PUSH_IMAGE
+push-$1:
+	docker push $(HUB_ORG)/$1:$(TAG)
 endef
-$(foreach image,$(PUBLISHED_IMAGES),$(eval $(call PUBLISH_IMAGE,$(image))))
+$(foreach image,$(PUSHED_IMAGES),$(eval $(call PUSH_IMAGE,$(image))))
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -32,4 +32,4 @@ dependencies:
   - sphinx_rtd_theme
   - sphinx=1.8.3
   - recommonmark
-  - sphinx-markdown-tables
+  #- sphinx-markdown-tables


### PR DESCRIPTION
Since we should build our published images from scratch (and not rely
on anything in the docker-cache), the following changes were made:

1. Added proper support to set the NO_CACHE macro.  Previously, this
was set to `--no-cache` but then not referenced in the docker build
rules. Instead, the default should be an empty value (`NO_CACHE?=`)
and have this "empty variable" referenced by the docker build target.
2. Changed the publish-* targets to push-* since all publish-* did was
push existing images.
3. Created a publish-images target that is responsible for performing
the full builds and pushes of all images. This target will set
NO_CACHE=--no-cache.
4. Unrelated. Found that sphinx-markdown-tables was preventing the
creation of new conda environments.  Since this is only for docs and
present in the docs environment.yml file, I commented it out of the
requirements.yml file at the project level.