### PR TITLE
Allow port overrides in Kubernetes deployments

### DIFF
--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -7,9 +7,16 @@
 
 # Enterprise Gateway variables
 export EG_SSH_PORT=${EG_SSH_PORT:-2122}
-export KG_IP=${KG_IP:-0.0.0.0}
-export KG_PORT=${KG_PORT:-8888}
-export KG_PORT_RETRIES=${KG_PORT_RETRIES:-0}
+
+# Kernel Gateway looks for KG_ for the following.  For the sake of consistency
+# we want to use EG_.  The following produces the default value in EG_ (unless
+# set in the env), with the ultimate override of KG_ from the env.
+export EG_IP=${EG_IP:-0.0.0.0}
+export KG_IP=${KG_IP:-${EG_IP}}
+export EG_PORT=${EG_PORT:-8888}
+export KG_PORT=${KG_PORT:-${EG_PORT}}
+export EG_PORT_RETRIES=${EG_PORT_RETRIES:-0}
+export KG_PORT_RETRIES=${KG_PORT_RETRIES:-${EG_PORT_RETRIES}}
 
 # To use tunneling set this variable to 'True' (may need to run as root).
 export EG_ENABLE_TUNNELING=${EG_ENABLE_TUNNELING:-False}

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -107,6 +107,9 @@ spec:
       serviceAccountName: enterprise-gateway-sa
       containers:
       - env:
+        - name: EG_PORT
+          value: "8888"
+
           # Created above.
         - name: EG_NAMESPACE
           value: "enterprise-gateway"

--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
         image: {{ .Values.image }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
+        - name: EG_PORT
+          value: !!str {{ .Values.port }}
         - name: EG_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: EG_KERNEL_CLUSTER_ROLE

--- a/etc/kubernetes/helm/enterprise-gateway/templates/ingress.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/ingress.yaml
@@ -20,5 +20,6 @@ spec:
       - path: {{ .Values.ingress.path }}
         backend:
           serviceName: enterprise-gateway
-          servicePort: {{ .Values.ingress.port }}
+          servicePort: {{ .Values.port }}
 {{ end }}
+

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -56,8 +56,6 @@ ingress:
   hostName: ""
   # URL context to be used in addition to the hostname to access Enterprise Gateway.
   path: /gateway/?(.*)
-  # The port where enterprise gateway service is running
-  port: 8888
 
 # Kernel Image Puller (daemonset)
 kip:


### PR DESCRIPTION
Add ability to specify value for `EG_PORT` env variable
from its default value (`8888`) to another value. This
can be done via the eg yaml file or helm charts.

Also removed the port field from the ingress stanza in
the helm values and updated ingress to use `Values.port`
since that's the service port anyway.

Fixes #684