### PR TITLE
Fix interrupts on intensive operations

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -50,10 +50,11 @@ class PythonKernelBaseTestCase(TestBase):
 
         # Build the code list to interrupt, in this case, its a sleep call.
         interrupted_code = list()
-        interrupted_code.append("import time\n")
-        interrupted_code.append("print('begin')\n")
-        interrupted_code.append("time.sleep(30)\n")
-        interrupted_code.append("print('end')\n")
+        interrupted_code.append("i = 2\n")
+        interrupted_code.append("while i > 0:\n")
+        interrupted_code.append("    i *= i\n")
+        interrupted_code.append("    print(i)\n")
+
         interrupted_result = self.kernel.execute(interrupted_code)
 
         # Ensure the result indicates an interrupt occurred


### PR DESCRIPTION
When performing CPU-intensive operations within a cell, remote python
kernels can have their interrupt capabilities stop working due to
thread starvation.  This is because the gateway-listener thread is
unable to signal the kernel.  This change uses a `Process` rather
than a `Thread` in which to run the gateway-listener - which results
in it not being starved.  As a result, the signal can be sent to the
kernel and the cell's operation interrupted.

Fixes #682