### PR TITLE
Fix scoping issues relative to python kernels on Spark

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -68,6 +68,19 @@ class PythonKernelBaseTestCase(TestBase):
         interrupted_value = int(self.kernel.execute("print(y)"))  # This will only return the value.
         self.assertEquals(interrupted_value, 124)
 
+    def test_scope(self):
+        # Ensure global variable is accessible in function.
+        # See https://github.com/jupyter/enterprise_gateway/issues/687
+        # Build the example code...
+        scope_code = list()
+        scope_code.append("a = 42\n")
+        scope_code.append("def scope():\n")
+        scope_code.append("    return a\n")
+        scope_code.append("\n")
+        scope_code.append("scope()\n")
+        result = self.kernel.execute(scope_code)
+        self.assertEquals(result, str(42))
+
 
 class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
     """
@@ -93,7 +106,7 @@ class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
     def test_run_pi_example(self):
         # Build the example code...
         pi_code = list()
-        pi_code.append("import random\n")
+        pi_code.append("from random import random\n")
         pi_code.append("from operator import add\n")
         pi_code.append("partitions = 20\n")
         pi_code.append("n = 100000 * partitions\n")

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -1,5 +1,4 @@
 import argparse
-import atexit
 import base64
 import json
 import logging
@@ -45,7 +44,45 @@ def initialize_namespace(namespace, cluster_type='spark'):
                         "Spark context creation will not occur.")
             return {}
 
+        # Note: this is intentionally defined in this block of initialize_namespace()
+        # so that it does not get included in the user namespace
+        class WaitingForSparkSessionToBeInitialized(object):
+            """Wrapper object for SparkContext and other Spark session variables while the real Spark session is being
+            initialized in a background thread. The class name is intentionally worded verbosely explicit as it will show up
+            when executing a cell that contains only a Spark session variable like ``sc`` or ``sqlContext``.
+            """
+
+            # private and public attributes that show up for tab completion,
+            # to indicate pending initialization of Spark session
+            _WAITING_FOR_SPARK_SESSION_TO_BE_INITIALIZED = 'Spark Session not yet initialized ...'
+            WAITING_FOR_SPARK_SESSION_TO_BE_INITIALIZED = 'Spark Session not yet initialized ...'
+
+            # the same wrapper class is used for all Spark session variables, so we need to record the name of the variable
+            def __init__(self, global_variable_name, init_thread, namespace):
+                self._spark_session_variable = global_variable_name
+                self._init_thread = init_thread
+                self._namespace = namespace
+
+            # we intercept all method and attribute references on our temporary Spark session variable,
+            # wait for the thread to complete initializing the Spark sessions and then we forward the
+            # call to the real Spark objects
+            def __getattr__(self, name):
+                # ignore tab-completion request for __members__ or __methods__ and ignore meta property requests
+                if name.startswith("__"):
+                    pass
+                elif name.startswith("_ipython_"):
+                    pass
+                elif name.startswith("_repr_"):
+                    pass
+                else:
+                    # wait on thread to initialize the Spark session variables in global variable scope
+                    self._init_thread.join(timeout=None)
+                    # now return attribute/function reference from actual Spark object
+                    return getattr(self._namespace[self._spark_session_variable], name)
+
         def initialize_spark_session():
+            import atexit
+
             """Initialize Spark session and replace global variable
             placeholders with real Spark session object references."""
             spark = SparkSession.builder.getOrCreate()
@@ -87,39 +124,6 @@ def initialize_namespace(namespace, cluster_type='spark'):
         namespace.update({'cluster': cluster})
     elif cluster_type != 'none':
         raise RuntimeError("Unknown cluster_type: %r" % cluster_type)
-
-
-class WaitingForSparkSessionToBeInitialized(object):
-    """Wrapper object for SparkContext and other Spark session variables while the real Spark session is being
-    initialized in a background thread. The class name is intentionally worded verbosely explicit as it will show up
-    when executing a cell that contains only a Spark session variable like ``sc`` or ``sqlContext``.
-    """
-
-    # private and public attributes that show up for tab completion, to indicate pending initialization of Spark session
-    _WAITING_FOR_SPARK_SESSION_TO_BE_INITIALIZED = 'Spark Session not yet initialized ...'
-    WAITING_FOR_SPARK_SESSION_TO_BE_INITIALIZED = 'Spark Session not yet initialized ...'
-
-    # the same wrapper class is used for all Spark session variables, so we need to record the name of the variable
-    def __init__(self, global_variable_name, init_thread, namespace):
-        self._spark_session_variable = global_variable_name
-        self._init_thread = init_thread
-        self._namespace = namespace
-
-    # we intercept all method and attribute references on our temporary Spark session variable, wait for the thread to
-    # complete initializing the Spark sessions and then we forward the call to the real Spark objects
-    def __getattr__(self, name):
-        # ignore tab-completion request for __members__ or __methods__ and ignore meta property requests
-        if name.startswith("__"):
-            pass
-        elif name.startswith("_ipython_"):
-            pass
-        elif name.startswith("_repr_"):
-            pass
-        else:
-            # wait on thread to initialize the Spark session variables in global variable scope
-            self._init_thread.join(timeout=None)
-            # now return attribute/function reference from actual Spark object
-            return getattr(self._namespace[self._spark_session_variable], name)
 
 
 def prepare_gateway_socket(lower_port, upper_port):
@@ -323,8 +327,7 @@ def start_ipython(namespace, cluster_type="spark", **kwargs):
     # create an initial list of variables to clear
     # we do this without deleting to preserve the locals so that
     # initialize_namespace isn't affected by this mutation
-    protected_vars = ['WaitingForSparkSessionToBeInitialized', 'atexit']
-    to_delete = [k for k in namespace if not k.startswith('__') and k not in protected_vars]
+    to_delete = [k for k in namespace if not k.startswith('__')]
 
     # initialize the namespace with the proper variables
     initialize_namespace(namespace, cluster_type=cluster_type)


### PR DESCRIPTION
The python kernel launcher was not initializing the namespace used
in the embed_kernel properly.  This change reverts an earlier change
to use the spark context variables from the global scope, instead
moving them to the local namespace.

Thanks to @jcrist for significant insight and guidance!

Fixes #687 