### PR TITLE
Attempt to address build flakiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: python
 
 python:
@@ -29,7 +28,8 @@ install:
 script:
     - jupyter enterprisegateway --help
     - flake8 enterprise_gateway
-    - nosetests -x --process-restartworker --with-coverage --cover-package=enterprise_gateway enterprise_gateway.tests
+    - travis_wait 3 nosetests -x --process-restartworker --with-coverage --cover-package=enterprise_gateway enterprise_gateway.tests
+    - echo "Starting integration tests ..."
     - make itest-yarn
     - pip uninstall -y jupyter_enterprise_gateway
 

--- a/etc/Makefile
+++ b/etc/Makefile
@@ -102,12 +102,12 @@ kernel_image_files: ../build/kernel_image_files
 
 KERNEL_IMAGES := kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py
 DOCKER_IMAGES := demo-base enterprise-gateway-demo nb2kg enterprise-gateway kernel-image-puller $(KERNEL_IMAGES)
-PUSHED_IMAGES := enterprise-gateway-demo nb2kg enterprise-gateway kernel-image-puller $(KERNEL_IMAGES)
+PUSHED_IMAGES := demo-base enterprise-gateway-demo nb2kg enterprise-gateway kernel-image-puller $(KERNEL_IMAGES)
 
 docker-images: $(DOCKER_IMAGES)
 kernel-images: $(KERNEL_IMAGES)
 
-push-images: push-enterprise-gateway-demo push-nb2kg push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-tf-py push-kernel-r push-kernel-spark-r push-kernel-scala push-kernel-image-puller
+push-images: push-demo-base push-enterprise-gateway-demo push-nb2kg push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-tf-py push-kernel-r push-kernel-spark-r push-kernel-scala push-kernel-image-puller
 
 clean-images: clean-enterprise-gateway-demo clean-nb2kg clean-demo-base clean-enterprise-gateway clean-kernel-image-puller clean-kernel-images
 clean-kernel-images: clean-kernel-py clean-kernel-spark-py clean-kernel-tf-py clean-kernel-tf-gpu-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala
@@ -115,7 +115,7 @@ clean-kernel-images: clean-kernel-py clean-kernel-spark-py clean-kernel-tf-py cl
 # Extra dependencies for each docker image...
 DEPENDS_nb2kg:
 DEPENDS_demo-base:
-DEPENDS_enterprise-gateway-demo: demo-base
+DEPENDS_enterprise-gateway-demo: $(FILE_kernelspecs_all)
 DEPENDS_enterprise-gateway: $(FILE_kernelspecs_all)
 DEPENDS_kernel-image-puller:
 DEPENDS_kernel-py DEPENDS_kernel-spark-py DEPENDS_kernel-r DEPENDS_kernel-spark-r DEPENDS_kernel-scala DEPENDS_kernel-tf-py DEPENDS_kernel-tf-gpu-py: $(FILE_kernelspecs_kubernetes) $(FILE_kernelspecs_docker)


### PR DESCRIPTION
Ran a series of different trials to try to figure this out.  There were two
primary issues.

1. nosetests were completing, but travis was not detecting that the nosetests
had completed.  So it never produced the green status that the test completed.
2. The build of the demo-base was encountering "github api rate limit" errors
when attempting to install SparkR.

Issue 1 appears to be (more frequently) resolved by using `travis_wait` with
a 3 minute timeout.  After 3 minutes it seems like travis breaks out of its
"coma" and sees that the the nosetests completed OK. Note: Detection of a
succesful nosetest in these "timeout" situations is still intermittent. I will
likely enlist the help of the travis team on this issue.

Issue 2 can be resolved by pushing demo-base to docker hub and NOT depending on
that image as part of the build for enterprise-gateway-demo.  This also trims
5 minutes from the overall travis time - aside from preventing the github rate
limit issue.

Since `sudo:` is deprecated, I've also removed it's setting.

Overall, build times have been trimmed by 6-8 minutes - and a bit more reliable.