### PR TITLE
More build adjustments - use travis_retry to reduce intermittency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,14 @@ before_install:
 
 install:
     - pip install --upgrade setuptools pip websocket-client flake8
-    - make dist enterprise-gateway-demo
+    - travis_retry make dist enterprise-gateway-demo
     - pip install dist/*.whl coverage
     - pip freeze
 
 script:
     - jupyter enterprisegateway --help
     - flake8 enterprise_gateway
-    - travis_wait 3 nosetests -x --process-restartworker --with-coverage --cover-package=enterprise_gateway enterprise_gateway.tests
+    - travis_retry travis_wait 3 nosetests -x --process-restartworker --with-coverage --cover-package=enterprise_gateway enterprise_gateway.tests
     - echo "Starting integration tests ..."
     - make itest-yarn
     - pip uninstall -y jupyter_enterprise_gateway


### PR DESCRIPTION
Add travis_retry prior to nosetests.  This will retry any iteration
that returns non-zero up to 3 times.  This will hopefully eliminate
intermittency issues and only propagate true failures.

Added travis_retry for building the demo image since that's another
area that has a tendency to be flakey.

Here's a travis log that performed one retry of the nosetests (that originally were successful, but travis_wait timed out). https://travis-ci.org/kevin-bates/enterprise_gateway/jobs/547483362