### PR TITLE
Fix doc links and release script

### DIFF
--- a/docs/source/docker.md
+++ b/docs/source/docker.md
@@ -25,13 +25,13 @@ By default, this container will start with enterprise gateway running as a servi
 
 We plan on producing one image per release to the [enterprise-gateway-demo docker repo](https://hub.docker.com/r/elyra/enterprise-gateway-demo/) where the image's tag reflects the corresponding release. 
 
-To build a local image, run `make docker-image-enterprise-gateway-demo`.  Because this is a development build, the tag for this image will reflect the value of the VERSION variable in the root Makefile (e.g. 2.0.0.dev2).
+To build a local image, run `make docker-image-enterprise-gateway-demo`.  Because this is a development build, the tag for this image will not reflect the value of the VERSION variable in the root Makefile but will be 'dev'.
 
 ### elyra/nb2kg
 
 Image [elyra/nb2kg](https://hub.docker.com/r/elyra/nb2kg/) is a simple image built on [jupyterhub/k8s-singleuser-sample](https://hub.docker.com/r/https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/) along with the latest release of [NB2KG](https://github.com/jupyter/nb2kg).  The image also sets some of the new variables that pertain to enterprise gateway (e.g., `KG_REQUEST_TIMEOUT`, `KG_HTTP_USER`, `KERNEL_USERNAME`, etc.).
 
-To build a local image, run `make docker-image-nb2kg`.  Because this is a development build, the tag for this image will reflect the value of the VERSION variable in the root Makefile (e.g. 2.0.0.dev2).
+To build a local image, run `make docker-image-nb2kg`.  Because this is a development build, the tag for this image will not reflect the value of the VERSION variable in the root Makefile but will be 'dev'.
 
 ## Runtime Images
 

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -133,7 +133,7 @@ Note that because the Apache Toree kernel, and its supporting libraries, will be
 
 #### Sample kernelspecs
 
-We provide sample kernel configuration and launcher tar files as part of [each release](https://github.com/jupyter/enterprise_gateway/releases) (e.g. [jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz)) that can be extracted and modified to fit your configuration.
+We provide sample kernel configuration and launcher tar files as part of [each release](https://github.com/jupyter/enterprise_gateway/releases) (e.g. [jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz)) that can be extracted and modified to fit your configuration.
 
 For information about how to build your own kernel-based docker image for use by Enterprise Gateway see [Custom kernel images](docker.html#custom-kernel-images).
 

--- a/docs/source/kernel-distributed.md
+++ b/docs/source/kernel-distributed.md
@@ -11,7 +11,7 @@ Install the `python_distributed` kernelspec on all nodes.
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/python_distributed/ python_distributed/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/python_distributed/ python_distributed/
 ```
 
 The `python_distributed` kernelspec uses `DistributedProcessProxy` which is responsible for the launch and management of kernels distributed across and explicitly defined set of hosts using ssh. Hosts are determined via a round-robin algorithm (that we should make pluggable someday).

--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -93,9 +93,9 @@ spec:
         - name: EG_KERNEL_WHITELIST
           value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
         # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
-        image: elyra/enterprise-gateway:dev
+        image: elyra/enterprise-gateway:VERSION
         # k8s will only pull :latest all the time.  
-        # the following line will make sure that :dev is always pulled
+        # the following line will make sure that :VERSION is always pulled
         # You should remove this if you want to pin EG to a release tag
         imagePullPolicy: Always
         name: enterprise-gateway
@@ -248,7 +248,7 @@ spec:
     spec:
       containers:
       - name: kernel-image-puller 
-        image: elyra/kernel-image-puller:dev
+        image: elyra/kernel-image-puller:VERSION
         env:
           - name: KIP_GATEWAY_HOST
             value: "http://enterprise-gateway.enterprise-gateway:8888"

--- a/docs/source/kernel-spark-standalone.md
+++ b/docs/source/kernel-spark-standalone.md
@@ -23,7 +23,7 @@ EG_REMOTE_HOSTS=elyra-node-1.fyre.ibm.com,elyra-node-2.fyre.ibm.com,elyra-node-3
 Although Enterprise Gateway does not currently provide sample kernelspecs for Spark standalone, here are the steps necessary to convert a yarn_client kernelspec to standalone.
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release
-[jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).
+[jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).
 
 Considering we would like to enable the IPython Kernel that comes pre-installed with Anaconda to run on
 Spark Standalone, we would have to copy the sample configuration folder **spark_python_yarn_client**
@@ -87,7 +87,7 @@ Considering we would like to enable the Scala Kernel to run on YARN Cluster and 
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
 mv $KERNELS_FOLDER/spark_scala_yarn_client $KERNELS_FOLDER/spark_scala_spark_standalone
 ```
 
@@ -104,7 +104,7 @@ Considering we would like to enable the IPython kernel to run on YARN Cluster an
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
 mv $KERNELS_FOLDER/spark_python_yarn_client $KERNELS_FOLDER/spark_python_spark_standalone
 ```
 
@@ -139,7 +139,7 @@ Considering we would like to enable the IRkernel to run on YARN Cluster and Clie
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
 mv $KERNELS_FOLDER/spark_R_yarn_client $KERNELS_FOLDER/spark_R_spark_standalone
 ```
 

--- a/docs/source/kernel-yarn-client-mode.md
+++ b/docs/source/kernel-yarn-client-mode.md
@@ -27,7 +27,7 @@ EG_REMOTE_HOSTS=elyra-node-1.fyre.ibm.com,elyra-node-2.fyre.ibm.com,elyra-node-3
 ```
 
 For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release
-[jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).
+[jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).
 
 Considering we would like to enable the IPython Kernel that comes pre-installed with Anaconda to run on
 Yarn Client mode, we would have to copy the sample configuration folder **spark_python_yarn_client**
@@ -84,7 +84,7 @@ Considering we would like to enable the Scala Kernel to run on YARN Cluster and 
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_client/ spark_scala_yarn_client/
 ```
 
 For more information about the Scala kernel, please visit the [Apache Toree](http://toree.apache.org/) page.
@@ -100,7 +100,7 @@ Considering we would like to enable the IPython kernel to run on YARN Cluster an
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_client/ spark_python_yarn_client/
 ```
 
 For more information about the IPython kernel, please visit the [IPython kernel](http://ipython.readthedocs.io/en/stable/) page.
@@ -134,7 +134,7 @@ Considering we would like to enable the IRkernel to run on YARN Cluster and Clie
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_client/ spark_R_yarn_client/
 ```
 
 For more information about the iR kernel, please visit the [IRkernel](https://irkernel.github.io/) page.

--- a/docs/source/kernel-yarn-cluster-mode.md
+++ b/docs/source/kernel-yarn-cluster-mode.md
@@ -28,7 +28,7 @@ EG_ALT_YARN_ENDPOINT=http://${ALT_YARN_RESOURCE_MANAGER_FQDN}:8088/ws/v1/cluster
 
 ### Configuring Kernels for YARN Cluster mode
 
-For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release [jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).
+For each supported Jupyter Kernel, we have provided sample kernel configurations and launchers as part of the release [jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz](https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz).
 
 Considering we would like to enable the IPython Kernel that comes pre-installed with Anaconda to run on Yarn Cluster mode, we would have to copy the sample configuration folder **spark_python_yarn_cluster** to where the Jupyter kernels are installed (e.g. jupyter kernelspec list)
 
@@ -37,7 +37,7 @@ wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/j
 SCALA_KERNEL_DIR="$(jupyter kernelspec list | grep -w "python3" | awk '{print $2}')"
 KERNELS_FOLDER="$(dirname "${SCALA_KERNEL_DIR}")"
 mkdir $KERNELS_FOLDER/spark_python_yarn_cluster/
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
 ```
   
 After that, you should have a `kernel.json` that looks similar to the one below:
@@ -82,7 +82,7 @@ Considering we would like to enable the Scala Kernel to run on YARN Cluster and 
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_scala_yarn_cluster/ spark_scala_yarn_cluster/
 ```
 
 For more information about the Scala kernel, please visit the [Apache Toree](http://toree.apache.org/) page.
@@ -98,7 +98,7 @@ Considering we would like to enable the IPython kernel to run on YARN Cluster an
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_python_yarn_cluster/ spark_python_yarn_cluster/
 ```
 
 For more information about the IPython kernel, please visit the [IPython kernel](http://ipython.readthedocs.io/en/stable/) page.
@@ -132,7 +132,7 @@ Considering we would like to enable the IRkernel to run on YARN Cluster and Clie
 ``` Bash
 wget https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc1/jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz
 KERNELS_FOLDER=/usr/local/share/jupyter/kernels
-tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0.dev2.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_cluster/ spark_R_yarn_cluster/
+tar -zxvf jupyter_enterprise_gateway_kernelspecs-2.0.0rc1.tar.gz --strip 1 --directory $KERNELS_FOLDER/spark_R_yarn_cluster/ spark_R_yarn_cluster/
 ```
 
 For more information about the iR kernel, please visit the [IRkernel](https://irkernel.github.io/) page.


### PR DESCRIPTION
The release.sh script leaves doc links in an odd state where a
non-existent dev version will refer to the latest release version.
Instead, it would be better to just let the latest docs always
reference the last published release.  Then all links work and
there's no confusion.

Introduced notion of 'previous version' to release.sh so that
such links can be updated to the new release.  In addition, there
is no 'reset to development' in the docs - otherwise invalid
links will get produced.