### PR TITLE
Add helm chart tarball to distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
     clean-kernel-py clean-kernel-spark-py clean-kernel-r clean-kernel-spark-r clean-kernel-scala clean-kernel-tf-py \
     clean-kernel-tf-gpu-py clean-kernel-image-puller push-images push-enterprise-gateway-demo push-nb2kg push-demo-base \
     push-kernel-images push-enterprise-gateway push-kernel-py push-kernel-spark-py push-kernel-r push-kernel-spark-r \
-    push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller publish
+    push-kernel-scala push-kernel-tf-py push-kernel-tf-gpu-py push-kernel-image-puller publish helm-chart
 
 SA:=source activate
 ENV:=enterprise-gateway-dev
@@ -23,6 +23,9 @@ endif
 
 WHEEL_FILE:=dist/jupyter_enterprise_gateway-$(VERSION)-py2.py3-none-any.whl
 WHEEL_FILES:=$(shell find . -type f ! -path "./build/*" ! -path "./etc/*" ! -path "./docs/*" ! -path "./.git/*" ! -path "./.idea/*" ! -path "./dist/*" ! -path "./.image-*" )
+
+HELM_CHART:=dist/jupyter_enterprise_gateway_helm-$(VERSION).tgz
+HELM_CHART_FILES:=$(shell find etc/kubernetes/helm -type f)
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -88,7 +91,13 @@ sdist:
 	$(SA) $(ENV) && python setup.py sdist $(POST_SDIST) \
 		&& rm -rf *.egg-info
 
-dist: lint bdist sdist kernelspecs ## Make source, binary and kernelspecs distribution to dist folder
+helm-chart:
+	make $(HELM_CHART)
+
+$(HELM_CHART): $(HELM_CHART_FILES)
+	(mkdir -p dist; cd etc/kubernetes/helm; tar -cvzf ../../../$(HELM_CHART) enterprise-gateway)
+
+dist: lint bdist sdist kernelspecs helm-chart ## Make source, binary and kernelspecs distribution to dist folder
 
 TEST_DEBUG_OPTS:=
 

--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,13 @@ sdist:
 	$(SA) $(ENV) && python setup.py sdist $(POST_SDIST) \
 		&& rm -rf *.egg-info
 
-helm-chart:
+helm-chart: ## Make helm chart distribution
 	make $(HELM_CHART)
 
 $(HELM_CHART): $(HELM_CHART_FILES)
 	(mkdir -p dist; cd etc/kubernetes/helm; tar -cvzf ../../../$(HELM_CHART) enterprise-gateway)
 
-dist: lint bdist sdist kernelspecs helm-chart ## Make source, binary and kernelspecs distribution to dist folder
+dist: lint bdist sdist kernelspecs helm-chart ## Make source, binary, kernelspecs and helm chart distributions to dist folder
 
 TEST_DEBUG_OPTS:=
 

--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -502,9 +502,11 @@ From anywhere with Helm cluster access, create the service and deployment by run
 
 ```bash
 helm upgrade --install --atomic --namespace enterprise-gateway enterprise-gateway etc/kubernetes/helm/enterprise-gateway
-
 ```
-
+the helm chart tarball is also accessible as an asset on our [release](https://github.com/jupyter/enterprise_gateway/releases/tag/v2.0.0rc2) page:
+```bash
+helm install --name enterprise-gateway --atomic --namespace enterprise-gateway https://github.com/jupyter/enterprise_gateway/releases/download/v2.0.0rc2/jupyter_enterprise_gateway_helm-2.0.0rc2.tgz
+```
 ##### Configuration
 
 Here are all of the values that you can set when deploying the Helm chart. You

--- a/etc/kubernetes/helm/enterprise-gateway/Chart.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/Chart.yaml
@@ -1,4 +1,11 @@
 name: enterprise-gateway
-version: 0.8.1
+description: A helm chart to deploy Jupyter Enterprise Gateway
+version: 2.0.0.dev3
+apiVersion: v1
 icon: https://avatars1.githubusercontent.com/u/7388996?s=200&v=4
+home: https://jupyter.org/enterprise_gateway
+sources:
+  - https://github.com/jupyter/enterprise_gateway
+kubeVersion: '>=1.11.0-0'
+tillerVersion: '>=2.11.0-0'
 

--- a/release.sh
+++ b/release.sh
@@ -195,20 +195,21 @@ function update_version_to_release {
     # Update Python _version.py
     sed -i .bak "s@^__version__.*@__version__ = '$RELEASE_VERSION'@g" enterprise_gateway/_version.py
 
+    # Update Makefile
+    sed -i .bak "s@$CURRENT_VERSION@$RELEASE_VERSION@g" Makefile
+
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/enterprise-gateway.yaml
     sed -i .bak "s@elyra/kernel-image-puller:dev@elyra/kernel-image-puller:$RELEASE_VERSION@g" etc/kubernetes/enterprise-gateway.yaml
 
-    # Update Kubernetes Helm values
+    # Update Kubernetes Helm chart and values files
+    sed -i .bak "s@version: [0-9,\.,a-z]*@version: $RELEASE_VERSION@g" etc/kubernetes/helm/enterprise-gateway/Chart.yaml
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
     sed -i .bak "s@elyra/kernel-image-puller:dev@elyra/kernel-image-puller:$RELEASE_VERSION@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
 
     # Update Docker compose version
     sed -i .bak "s@elyra/enterprise-gateway:dev@elyra/enterprise-gateway:$RELEASE_VERSION@g" etc/docker/docker-compose.yml
     sed -i .bak "s@elyra/kernel-image-puller:dev@elyra/kernel-image-puller:$RELEASE_VERSION@g" etc/docker/docker-compose.yml
-
-    # Update Makefile
-    sed -i .bak "s@$CURRENT_VERSION@$RELEASE_VERSION@g" Makefile
 
     # Update documentation - this is a one-way change since links will not be valid in dev "releases".
     find docs/source/*.md -type f -exec sed -i .bak "s@$PREVIOUS_VERSION@$RELEASE_VERSION@g" {} \;
@@ -219,20 +220,21 @@ function update_version_to_development {
     # Update Python _version.py
     sed -i .bak "s@^__version__.*@__version__ = '$DEVELOPMENT_VERSION'@g" enterprise_gateway/_version.py
 
+    # Update Makefile
+    sed -i .bak "s@$RELEASE_VERSION@$DEVELOPMENT_VERSION@g" Makefile
+
     # Update Kubernetes deployment descriptor
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/enterprise-gateway.yaml
     sed -i .bak "s@elyra/kernel-image-puller:$RELEASE_VERSION@elyra/kernel-image-puller:dev@g" etc/kubernetes/enterprise-gateway.yaml
 
-    # Update Kubernetes Helm values
+    # Update Kubernetes Helm chart and values files
+    sed -i .bak "s@version: [0-9,\.,a-z]*@version: $DEVELOPMENT_VERSION@g" etc/kubernetes/helm/enterprise-gateway/Chart.yaml
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
     sed -i .bak "s@elyra/kernel-image-puller:$RELEASE_VERSION@elyra/kernel-image-puller:dev@g" etc/kubernetes/helm/enterprise-gateway/values.yaml
 
     # Update Docker compose version
     sed -i .bak "s@elyra/enterprise-gateway:$RELEASE_VERSION@elyra/enterprise-gateway:dev@g" etc/docker/docker-compose.yml
     sed -i .bak "s@elyra/kernel-image-puller:$RELEASE_VERSION@elyra/kernel-image-puller:dev@g" etc/docker/docker-compose.yml
-
-    # Update Makefile
-    sed -i .bak "s@$RELEASE_VERSION@$DEVELOPMENT_VERSION@g" Makefile
 }
 
 if [[ "$RELEASE_PREPARE" == "true" ]]; then


### PR DESCRIPTION
Added more (hopefully useful) metadata to the Chart.yaml file that
includes making the version of the chart match that of the EG release.
Modified the release.sh to update the version information in the chart.
Added `helm-chart` target to Makefile and tied to `dist` target.
Updated docs to reference helm chart tarball on release page.

Fixes #656