### PR TITLE
Extend scala interrupt test timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SA:=source activate
 ENV:=enterprise-gateway-dev
 SHELL:=/bin/bash
 
-VERSION:=2.0.0.dev3
+VERSION?=2.0.0.dev3
 
 ifeq (dev, $(findstring dev, $(VERSION)))
     TAG:=dev

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -53,7 +53,7 @@ class ScalaKernelBaseTestCase(TestBase):
         # Build the code list to interrupt, in this case, its a sleep call.
         interrupted_code = list()
         interrupted_code.append('println("begin")\n')
-        interrupted_code.append("Thread.sleep(30000)\n")
+        interrupted_code.append("Thread.sleep(60000)\n")
         interrupted_code.append('println("end")\n')
         interrupted_result = self.kernel.execute(interrupted_code)
 


### PR DESCRIPTION
The interrupt test timeout for scala was 30 seconds.  Since spark context
initialization can sometimes take longer (on systems with limited resources)
the test was failing - then causing subsequent failures.  Extending to 60
seconds resolves that issue.

Also changed how `VERSION` is set in the Makefile so it can be set outside
the Makefile in order to use different image versions, etc.


<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### PR Checklist
- [x] Have you updated the required documentation based on the current PR, as applicable?
- [x] Have you written new tests for your core changes, as applicable?

**Commit Formatting**

Please follow the **[seven rules of a great commit message](https://chris.beams.io/posts/git-commit/)**

- Separate subject from body with a blank line
- Limit the subject line to 50 characters
- Capitalize the first word of the subject line
- Do not end the subject line with a period
- Use the imperative mood in the subject line
- Wrap the body at 72 characters
- Use the body to explain what and why vs. how

**Closing issues**

- Put `Closes #XXXX`in your commit comment to auto-close this PR when merged.
- Put `Fixes  #XXXX`in your commit comment to auto-close the issue that your PR fixes (if such).


