### PR TITLE
Termination of EG in SIGTERM

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -342,7 +342,7 @@ class EnterpriseGatewayApp(KernelGatewayApp):
 
     def _signal_stop(self, sig, frame):
         self.log.info("Received signal to terminate Enterprise Gateway.")
-        self.io_loop.stop()
+        self.io_loop.add_callback_from_signal(self.io_loop.stop)
 
 
 launch_instance = EnterpriseGatewayApp.launch_instance


### PR DESCRIPTION
In Current code, EG is not terminating gateway server process when handling SIGTERM signal. It is killing any running kernels correctly but the main process is not being killed.

In this fix, sending SIGTERM will kill any running kernels and will shutdown the gateway server as well.


**Closing issues**

Fixes #701 
Closes #701 


