### PR TITLE
Default the SparkR app name to kernel id if not provided

### DIFF
--- a/etc/kernel-launchers/R/scripts/launch_IRkernel.R
+++ b/etc/kernel-launchers/R/scripts/launch_IRkernel.R
@@ -182,8 +182,7 @@ parser$add_argument("--RemoteProcessProxy.response-address", nargs='?', metavar=
       help="the IP:port address of the system hosting Enterprise Gateway and expecting response")
 parser$add_argument("--RemoteProcessProxy.spark-context-initialization-mode", nargs='?', default="none",
       help="the initialization mode of the spark context: lazy, eager or none")
-parser$add_argument("--customAppName", nargs='?', default="SparkR",
-       help="the custom application name to be set")
+parser$add_argument("--customAppName", nargs='?', help="the custom application name to be set")
 
 argv <- parser$parse_args()
 
@@ -253,9 +252,11 @@ if (!is.null(argv$RemoteProcessProxy.response_address) && str_length(argv$Remote
 # Otherwise, skip spark context creation if set to none or not provided
 if (!is.na(argv$RemoteProcessProxy.spark_context_initialization_mode)){
     if (!identical(argv$RemoteProcessProxy.spark_context_initialization_mode, "none")){
-        # Add custom application name (spark.app.name) spark config if available
-        if (!is.na(argv$customAppName)){
+        # Add custom application name (spark.app.name) spark config if available, else default to kernel_id
+        if (!is.null(argv$customAppName) && str_length(argv$customAppName) > 0){
             sparkConfigList[['spark.app.name']] <- argv$customAppName
+        } else {
+            sparkConfigList[['spark.app.name']] <- argv$RemoteProcessProxy.kernel_id
         }
         initialize_spark_session(argv$RemoteProcessProxy.spark_context_initialization_mode)
     }


### PR DESCRIPTION
Previously, the customAppName parameter defaulted to 'SparkR'.  This
resulted in it always being set.  This change removes the default, then
only if a parameter was not provided, does it default to the kernel_id
parameter.