### PR TITLE
Multiple fixes to enable EG on OpenShift Kubernetes Environment

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -256,3 +256,12 @@ but it failed with a "Kernel error" and a SSHException.**
 
     The most common cause for this WARN is when the user that started Enterprise Gateway is not authenticated
     with Kerberos. This can happen when the user has either not run `kinit` or their previous ticket has expired.
+
+- **Running Jupyter Enterprise Gateway on OpenShift Kubernetes Environment fails trying to create /home/jovyan/.local**
+
+    As described [in the OpenShift Admin Guide](https://docs.openshift.com/container-platform/3.6/admin_guide/manage_scc.html#enable-images-to-run-with-user-in-the-dockerfile)
+    there is a need to issue the following command to enable running  with `USER` in Dockerfile.
+    
+    ```bash
+    oc adm policy add-scc-to-group anyuid system:authenticated
+    ```

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -55,9 +55,8 @@ max_keep_alive_interval = 100 * 365 * 24 * 60 * 60
 # exist just in case we find them necessary in some configurations (where the service user
 # must be different).  However, tests show that that configuration doesn't work - so there
 # might be more to do.  At any rate, we'll use these variables for now.
-remote_user = os.getenv('EG_REMOTE_USER', getpass.getuser())
-remote_pwd = os.getenv('EG_REMOTE_PWD')  # this should use password-less ssh
-
+remote_user = None
+remote_pwd = None
 
 # Allow users to specify local ips (regular expressions can be used) that should not be included
 # when determining the response address.  For example, on systems with many network interfaces,
@@ -312,6 +311,13 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
         :return: ssh client instance
         """
         ssh = None
+
+        global remote_user
+        global remote_pwd
+        if remote_user is None:
+            remote_user = os.getenv('EG_REMOTE_USER', getpass.getuser())
+            remote_pwd = os.getenv('EG_REMOTE_PWD')  # this should use password-less ssh
+
         try:
             ssh = paramiko.SSHClient()
             ssh.load_system_host_keys()


### PR DESCRIPTION
* Retrieve user credentials only when using ssh
* Document troubleshooting steps for OpenShift Kubernetes environment

Fixes #705 

**Waiting user validation before pushing to master**