### PR TITLE
Cleanup kernel shutdown

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -332,7 +332,6 @@ class RemoteKernelManager(KernelGatewayIOLoopKernelManager):
 
     def signal_kernel(self, signum):
         """Sends signal `signum` to the kernel process. """
-        self.log.debug("RemoteKernelManager.signal_kernel({})".format(signum))
         if self.has_kernel:
             if signum == signal.SIGINT:
                 if self.sigint_value is None:

--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -4,6 +4,7 @@
 
 import os
 import json
+import signal
 import time
 
 from subprocess import STDOUT
@@ -148,3 +149,8 @@ class DistributedProcessProxy(RemoteProcessProxy):
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
             self.kill()
             self.log_and_raise(http_status_code=500, reason=timeout_message)
+
+    def shutdown_listener(self):
+        """Ensure that kernel process is terminated."""
+        self.send_signal(signal.SIGTERM)
+        super(DistributedProcessProxy, self).shutdown_listener()

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -966,7 +966,8 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
                 pgid = None
         if pid or pgid:  # if either process ids were updated, update the ip as well and don't use local_proc
             self.ip = self.assigned_ip
-            self.local_proc = None
+            if not BaseProcessProxyABC.ip_is_local(self.ip):  # only unset local_proc if we're remote
+                self.local_proc = None
 
     def handle_timeout(self):
         """Checks to see if the kernel launch timeout has been exceeded while awaiting connection info."""
@@ -982,6 +983,8 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
 
     def cleanup(self):
         """Terminates tunnel processes, if applicable."""
+        self.shutdown_listener()  # Ensure listener has been shutdown
+
         self.assigned_ip = None
 
         for kernel_channel, process in self.tunnel_processes.items():
@@ -991,9 +994,31 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         self.tunnel_processes.clear()
         super(RemoteProcessProxy, self).cleanup()
 
+    def _send_listener_request(self, request, shutdown_socket=False):
+        # Sends the request dictionary to the kernel listener via the comm port.  Caller is responsible for
+        # handling any exceptions.
+
+        if self.comm_port > 0:
+            sock = socket(AF_INET, SOCK_STREAM)
+            try:
+                sock.settimeout(socket_timeout)
+                sock.connect((self.comm_ip, self.comm_port))
+                sock.send(json.dumps(request).encode(encoding='utf-8'))
+            finally:
+                if shutdown_socket:
+                    try:
+                        sock.shutdown(SHUT_WR)
+                    except Exception as e2:
+                        if isinstance(e2, OSError) and e2.errno == errno.ENOTCONN:
+                            pass  # Listener is not connected.  This is probably a follow-on to ECONNREFUSED on connect
+                        else:
+                            self.log.warning("Exception occurred attempting to shutdown communication socket to {}:{} "
+                                             "for KernelID '{}' (ignored): {}".format(self.comm_ip, self.comm_port,
+                                                                                      self.kernel_id, str(e2)))
+                sock.close()
+
     def send_signal(self, signum):
         """Sends `signum` via the communication port.
-
         The kernel launcher listening on its communication port will receive the signum and perform
         the necessary signal operation local to the process.
         """
@@ -1006,23 +1031,20 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
             signal_request = dict()
             signal_request['signum'] = signum
 
-            sock = socket(AF_INET, SOCK_STREAM)
             try:
-                sock.settimeout(socket_timeout)
-                sock.connect((self.comm_ip, self.comm_port))
-                sock.send(json.dumps(signal_request).encode(encoding='utf-8'))
+                self._send_listener_request(signal_request)
+
                 if signum > 0:  # Polling (signum == 0) is too frequent
                     self.log.debug("Signal ({}) sent via gateway communication port.".format(signum))
                 return None
             except Exception as e:
-                if isinstance(e, OSError):
-                    if e.errno == errno.ECONNREFUSED and signum == 0:  # Return False since there's no process.
-                        return False
-                return super(RemoteProcessProxy, self).send_signal(signum)
-            finally:
-                sock.close()
-        else:
-            return super(RemoteProcessProxy, self).send_signal(signum)
+                if isinstance(e, OSError) and e.errno == errno.ECONNREFUSED:  # Return False since there's no process.
+                    return False
+
+                self.log.warning("An unexpected exception occurred sending signal ({}) for KernelID '{}': {}"
+                                 .format(signum, self.kernel_id, str(e)))
+
+        return super(RemoteProcessProxy, self).send_signal(signum)
 
     def shutdown_listener(self):
         """Sends a shutdown request to the kernel launcher listener."""
@@ -1034,24 +1056,14 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
             shutdown_request = dict()
             shutdown_request['shutdown'] = 1
 
-            sock = socket(AF_INET, SOCK_STREAM)
             try:
-                sock.settimeout(socket_timeout)
-                sock.connect((self.comm_ip, self.comm_port))
-                sock.send(json.dumps(shutdown_request).encode(encoding='utf-8'))
+                self._send_listener_request(shutdown_request, shutdown_socket=True)
                 self.log.debug("Shutdown request sent to listener via gateway communication port.")
             except Exception as e:
-                self.log.warning("Exception occurred sending listener shutdown to {}:{} for KernelID '{}' "
-                                 "(using alternate shutdown): {}"
-                                 .format(self.comm_ip, self.comm_port, self.kernel_id, str(e)))
-            finally:
-                try:
-                    sock.shutdown(SHUT_WR)
-                except Exception as e2:
-                    self.log.warning("Exception occurred attempting to shutdown communication socket to {}:{} "
-                                     "for KernelID '{}' (ignored): {}".format(self.comm_ip, self.comm_port,
-                                                                              self.kernel_id, str(e2)))
-                sock.close()
+                if not isinstance(e, OSError) or e.errno != errno.ECONNREFUSED:
+                    self.log.warning("An unexpected exception occurred sending listener shutdown to {}:{} for "
+                                     "KernelID '{}': {}"
+                                     .format(self.comm_ip, self.comm_port, self.kernel_id, str(e)))
 
             # Also terminate the tunnel process for the communication port - if in play.  Failure to terminate
             # this process results in the kernel (launcher) appearing to remain alive following the shutdown

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -119,7 +119,6 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         :param signum
         :return:
         """
-        self.log.debug("YarnClusterProcessProxy.send_signal {}".format(signum))
         if signum == 0:
             return self.poll()
         elif signum == signal.SIGKILL:
@@ -137,11 +136,8 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
         state = None
         result = False
         if self._get_application_id():
-            resp = self._kill_app_by_id(self.application_id)
-            self.log.debug(
-                "YarnClusterProcessProxy.kill: kill_app_by_id({}) response: {}, confirming app state is not RUNNING"
-                    .format(self.application_id, resp))
-
+            self._kill_app_by_id(self.application_id)
+            # Check that state has moved to a final state (most likely KILLED)
             i = 1
             state = self._query_app_state_by_id(self.application_id)
             while state not in YarnClusterProcessProxy.final_states and i <= max_poll_attempts:
@@ -152,10 +148,11 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
             if state in YarnClusterProcessProxy.final_states:
                 result = None
 
-        super(YarnClusterProcessProxy, self).kill()
+        if result is False:  # We couldn't terminate via Yarn, try remote signal
+            result = super(YarnClusterProcessProxy, self).kill()
 
-        self.log.debug("YarnClusterProcessProxy.kill, application ID: {}, kernel ID: {}, state: {}"
-                       .format(self.application_id, self.kernel_id, state))
+        self.log.debug("YarnClusterProcessProxy.kill, application ID: {}, kernel ID: {}, state: {}, result: {}"
+                       .format(self.application_id, self.kernel_id, state, result))
         return result
 
     def cleanup(self):

--- a/etc/kernel-launchers/R/scripts/gateway_listener.py
+++ b/etc/kernel-launchers/R/scripts/gateway_listener.py
@@ -100,8 +100,8 @@ def gateway_listener(sock, parent_pid):
             if request.get('signum') is not None:
                 signum = int(request.get('signum'))
                 os.kill(int(parent_pid), signum)
-            elif request.get('shutdown') is not None:
-                    shutdown = bool(request.get('shutdown'))
+            if request.get('shutdown') is not None:
+                shutdown = bool(request.get('shutdown'))
             if signum != 0:
                 logger.debug("gateway_listener got request: {}".format(request))
         else:  # check parent

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -314,8 +314,8 @@ def gateway_listener(sock, parent_pid):
             if request.get('signum') is not None:
                 signum = int(request.get('signum'))
                 os.kill(parent_pid, signum)
-            elif request.get('shutdown') is not None:
-                    shutdown = bool(request.get('shutdown'))
+            if request.get('shutdown') is not None:
+                shutdown = bool(request.get('shutdown'))
             if signum != 0:
                 logger.info("gateway_listener got request: {}".format(request))
 

--- a/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
+++ b/etc/kernel-launchers/scala/toree-launcher/src/main/scala/launcher/ToreeLauncher.scala
@@ -184,7 +184,7 @@ object ToreeLauncher extends LogLike {
     initArguments(args)
 
     if (profilePath == null && kernelId == null){
-      logger.error("At least one of '--profile' or '--RemoteProcessProxy.kernel_id' " +
+      logger.error("At least one of '--profile' or '--RemoteProcessProxy.kernel-id' " +
         "must be provided - exiting!")
       sys.exit(-1)
     }
@@ -235,14 +235,14 @@ object ToreeLauncher extends LogLike {
   private def getReconciledSignalName(sigNum: Int): String = {
     // To raise the signal, we must map the signal number back to the appropriate
     // name as follows:  Take the common case and assume interrupt and check if an
-    // alternate interrupt signal has been given. If sigNum = 9, use "KILL", else
+    // alternate interrupt signal has been given. If sigNum = 9, use "TERM", else
     // if no alternate has been provided use "INT".  Note that use of SIGINT won't
     // get received because the JVM won't propagate to background threads, buy it's
     // the best we can do.  We'll still issue a warning in the log.
 
     require(sigNum > 0, "sigNum must be greater than zero")
 
-    if (sigNum == 9) "KILL"
+    if (sigNum == 9) "TERM"
     else {
       if (alternateSigint == null) {
         logger.warn("--alternate-sigint is not defined and signum %d has been " +


### PR DESCRIPTION
While looking into #701, I noticed that kernels where not being shutdown
in a graceful manner, sometimes leaving orphaned processes and running
YARN applications.  These issues would occur in normal shutdowns and as
the result of EG termination.  This commit includes the following changes:

1. Added call to shutdown listener from cleanup to account for EG termination
since the SIGTERM handler uses an immediate kill code path.
2. DistributedProcessProxy now sends additional SIGTERM to listener prior
to its shutdown.  This addresses the orphaned kernel processes.
3. Refactored methods to send listener commands.
4. Updated launchers to handle multiple commands in a single request.
5. Removed or cleaned up log statements.