### PR TITLE
Persistent Kernel failing fix after loading a kernel session

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -299,6 +299,6 @@ class EnterpriseGatewayApp(KernelGatewayApp):
 
     def _signal_stop(self, sig, frame):
         self.log.info("Received signal to terminate Enterprise Gateway.")
-        self.io_loop.stop()
+        self.io_loop.add_callback_from_signal(self.io_loop.stop)
 
 launch_instance = EnterpriseGatewayApp.launch_instance

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -52,6 +52,10 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
         # Load connection info into member vars - no need to write out connection file
         km.load_connection_info(connection_info)
 
+        info_key = connection_info.get('key')
+        if info_key:
+            connection_info['key'] = bytes_to_str(info_key)
+
         km._launch_args = launch_args
 
         # Construct a process-proxy


### PR DESCRIPTION
In Current Code of 1.x, Persistent kernels have a small bug, where it is changing kernel's connection_info key to ***bytes*** for loading the kernel but it's not converting back it to ***String*** for json dumping and tht's why it is failing.
I have added corresponding code for that. Please look into this -

**Closing issues**
Closes #711 

