### PR TITLE
Converted connection_info key to string for json dump after loading a…

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -52,6 +52,10 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
         # Load connection info into member vars - no need to write out connection file
         km.load_connection_info(connection_info)
 
+        info_key = connection_info.get('key')
+        if info_key:
+            connection_info['key'] = bytes_to_str(info_key)
+
         km._launch_args = launch_args
 
         # Construct a process-proxy

--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -52,6 +52,7 @@ class RemoteMappingKernelManager(SeedingMappingKernelManager):
         # Load connection info into member vars - no need to write out connection file
         km.load_connection_info(connection_info)
 
+        # Converting `connection_info['key']` back to string so that json operations work properly
         info_key = connection_info.get('key')
         if info_key:
             connection_info['key'] = bytes_to_str(info_key)


### PR DESCRIPTION
In Current Code of 1.x, Persistent kernels have a small bug, where it is changing kernel's connection_info key to ***bytes*** for loading the kernel but it's not converting back it to ***String*** for json dumping and tht's why it is failing.
I have added corresponding code for that. Please look into this -

Closing issues -
Closes #711 

