### PR TITLE
Use safe_load_all() to fix deprecation warning

### DIFF
--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -59,7 +59,7 @@ def launch_kubernetes_kernel(kernel_id, response_addr, spark_context_init_mode):
     # https://github.com/jupyter-incubator/enterprise_gateway/blob/master/enterprise_gateway/services/processproxies/k8s.py
     #
     kernel_namespace = keywords['kernel_namespace']
-    k8s_objs = yaml.load_all(k8s_yaml)
+    k8s_objs = yaml.safe_load_all(k8s_yaml)
     for k8s_obj in k8s_objs:
         if k8s_obj.get('kind'):
             if k8s_obj['kind'] == 'Pod':


### PR DESCRIPTION
Using `load_all()` without specifying a loader is unsafe and produces a deprecation warning.  Replacement with `safe_load_all()` satisfies the warning since safe loads prevent certain inherently unsafe operations.

Fixes  #714


