### PR TITLE
1. Adding yarn application state 'FAILED' into final_states 2. Closes #708

### DIFF
--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -32,7 +32,7 @@ yarn_shutdown_wait_time = float(os.getenv('EG_YARN_SHUTDOWN_WAIT_TIME', '15.0'))
 class YarnClusterProcessProxy(RemoteProcessProxy):
     """Kernel lifecycle management for YARN clusters."""
     initial_states = {'NEW', 'SUBMITTED', 'ACCEPTED', 'RUNNING'}
-    final_states = {'FINISHED', 'KILLED'}  # Don't include FAILED state
+    final_states = {'FINISHED', 'KILLED', 'FAILED'}
 
     def __init__(self, kernel_manager, proxy_config):
         super(YarnClusterProcessProxy, self).__init__(kernel_manager, proxy_config)
@@ -279,7 +279,7 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
 
     def confirm_remote_startup(self):
         """ Confirms the yarn application is in a started state before returning.  Should post-RUNNING states be
-            unexpectedly encountered (FINISHED, KILLED) then we must throw, otherwise the rest of the gateway will
+            unexpectedly encountered (FINISHED, KILLED, FAILED) then we must throw, otherwise the rest of the gateway will
             believe its talking to a valid kernel.
         """
         self.start_time = RemoteProcessProxy.get_current_time()

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -279,8 +279,8 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
 
     def confirm_remote_startup(self):
         """ Confirms the yarn application is in a started state before returning.  Should post-RUNNING states be
-            unexpectedly encountered (FINISHED, KILLED, FAILED) then we must throw, otherwise the rest of the gateway will
-            believe its talking to a valid kernel.
+            unexpectedly encountered (FINISHED, KILLED, FAILED) then we must throw,
+            otherwise the rest of the gateway will believe its talking to a valid kernel.
         """
         self.start_time = RemoteProcessProxy.get_current_time()
         i = 0


### PR DESCRIPTION
Yarn Application's `FAILED` state is not added into final_states for some reason. The user would only see kernel launch getting timed out but not an error related to `FAILED` state. `FAILED` state is pretty common in Yarn and it needs to be handled. 

Closes #708.

