### PR TITLE
Retrieve Toree jar from maven repository

### DIFF
--- a/etc/kernel-launchers/scala/toree-launcher/build.sbt
+++ b/etc/kernel-launchers/scala/toree-launcher/build.sbt
@@ -16,5 +16,5 @@ val sparkVersion = "2.4.1"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion % "provided"
 libraryDependencies += "com.typesafe.play" %% "play-json" % "2.3.10" // Apache v2
-libraryDependencies += "org.apache.toree" %% "toree-assembly" % "0.3.0-incubating" from "https://repository.apache.org/content/repositories/releases/org/apache/toree/toree-assembly/0.3.0-incubating/toree-assembly-0.3.0-incubating.jar"
+libraryDependencies += "org.apache.toree" % "toree-assembly" % "0.3.0-incubating" /*from "http://archive.apache.org/dist/incubator/toree/0.3.0-incubating/toree/toree-assembly-0.3.0-incubating.jar"*/
 


### PR DESCRIPTION
Moves to use the official maven artifact from maven central where the
artifact pom with the list of dependencies and transient dependencies
is available.

