### PR TITLE
Allow Notebook 6.x dependency

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - jupyter_core>=4.4.0
   - jupyter_client>=5.2.0
-  - notebook>=5.7.6,<6.0
+  - notebook>=5.7.6,<7.0
   - jupyter_kernel_gateway>=2.4.0
   - traitlets>=4.2.0
   - tornado>=4.2.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,7 +5,7 @@ dependencies:
   - jupyter_core>=4.4.0
   - jupyter_client>=5.2.0
   - notebook>=5.7.6,<6.0
-  - jupyter_kernel_gateway>=2.3.0
+  - jupyter_kernel_gateway>=2.4.0
   - traitlets>=4.2.0
   - tornado>=4.2.0
   - requests>=2.7,<3.0

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,22 +2,22 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - jupyter_core>=4.4.0
-  - jupyter_client>=5.2.0
-  - notebook>=5.7.6,<7.0
-  - jupyter_kernel_gateway>=2.4.0
-  - traitlets>=4.2.0
-  - tornado>=4.2.0
-  - requests>=2.7,<3.0
-  - paramiko>=2.1.2
-  - yarn-api-client>=0.3.6,<0.4.0
-  - pexpect>=4.2.0
-  - pycrypto>=2.6.1
-  - pyzmq>=17.0.0
-  - python-kubernetes>=4.0.0
   - docker-py>=3.5.0
   - jinja2>=2.10
+  - jupyter_client>=5.2.0
+  - jupyter_core>=4.4.0
+  - jupyter_kernel_gateway>=2.4.0
+  - notebook>=5.7.6,<7.0
+  - paramiko>=2.1.2
+  - pexpect>=4.2.0
   - pip
+  - pycrypto>=2.6.1
+  - python-kubernetes>=4.0.0
+  - pyzmq>=17.0.0
+  - requests>=2.7,<3.0
+  - tornado>=4.2.0
+  - traitlets>=4.2.0
+  - yarn-api-client>=0.3.6,<0.4.0
 
   # Test Requirements
   - nose

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ Apache Spark, Kubernetes and others..
         'jupyter_core>=4.4.0',
         'jupyter_kernel_gateway>=2.4.0',
         'kubernetes>=4.0.0',
-        'notebook>=5.7.6,<6.0',
+        'notebook>=5.7.6,<7.0',
         'paramiko>=2.1.2',
         'pexpect>=4.2.0',
         'pycrypto>=2.6.1',

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ Apache Spark, Kubernetes and others..
     ],
     install_requires=[
         'docker>=3.5.0',
+        'jinja2>=2.10',
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',
         'jupyter_kernel_gateway>=2.4.0',
@@ -58,7 +59,6 @@ Apache Spark, Kubernetes and others..
         'tornado>=4.2.0',
         'traitlets>=4.2.0',
         'yarn-api-client>=0.3.6,<0.4.0',
-        'jinja2>=2.10',
     ],
     python_requires='>=3.5',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ Apache Spark, Kubernetes and others..
         'docker>=3.5.0',
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',
-        'jupyter_kernel_gateway>=2.3.0',
+        'jupyter_kernel_gateway>=2.4.0',
         'kubernetes>=4.0.0',
         'notebook>=5.7.6,<6.0',
         'paramiko>=2.1.2',


### PR DESCRIPTION
In order to allow Notebook 6.x dependencies, there was a need to
fix some compatibility issues in Jupyter Kernel Gateway.