### PR TITLE
fix: AttributeError: module 'signal' has no attribute 'SIGHUP'

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -3,6 +3,7 @@
 """Enterprise Gateway Jupyter application."""
 
 import os
+import sys
 import signal
 import getpass
 
@@ -316,7 +317,8 @@ class EnterpriseGatewayApp(KernelGatewayApp):
 
         self.io_loop = ioloop.IOLoop.current()
 
-        signal.signal(signal.SIGHUP, signal.SIG_IGN)
+        if sys.platform != 'win32':
+            signal.signal(signal.SIGHUP, signal.SIG_IGN)
 
         signal.signal(signal.SIGTERM, self._signal_stop)
 


### PR DESCRIPTION
Fix to resolve startup error on Windows:

(base) v:\bin>jupyter enterprisegateway
[I 2019-08-31 16:45:22.305 EnterpriseGatewayApp] Jupyter Enterprise Gateway 1.2.0 is available at http://127.0.0.1:8888
Traceback (most recent call last):
  File "C:\Anaconda3\Scripts\jupyter-enterprisegateway-script.py", line 9, in <module>
    sys.exit(launch_instance())
  File "C:\Anaconda3\lib\site-packages\jupyter_core\application.py", line 267, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "C:\Anaconda3\lib\site-packages\traitlets\config\application.py", line 658, in launch_instance
    app.start()
  File "C:\Anaconda3\lib\site-packages\enterprise_gateway\enterprisegatewayapp.py", line 278, in start
    signal.signal(signal.SIGHUP, signal.SIG_IGN)
AttributeError: module 'signal' has no attribute 'SIGHUP'

