### PR TITLE
Add support for traefik ingress

### DIFF
--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -530,10 +530,13 @@ can override them with Helm's `--set` or `--values` options.
 | `kernelspecs.imagePullPolicy` | Kernelspecs image pull policy. | `Always` |
 | `nfs.enabled` | Whether NFS-mounted kernelspecs are enabled. Cannot be used with `kernelspecs.image` set. | `false` |
 | `nfs.internalServerIPAddress` | IP address of NFS server. Required if NFS is enabled. | `nil` |
-| `ingress.enabled` | Whether to include an EG ingress resource during deployment. NOTE: A ingress-controller must be installed | `false` |
-| `ingress.annotations` | Ingress annotations to be included. Will depend on the type of ingress controller you have installed | `(nginx-ingress annotations)` |
+| `ingress.enabled` | Whether to include an EG ingress resource during deployment.| `false` |
+| `ingress.traefik.enabled` | Configure the ingress using Traefik as the controller. NOTE: A traefik controller must be installed and `ingress.enabled` must be `true`. | `true` |
+| `ingress.traefik.annotations` | Traefik-relative ingress annotations to be included when `ingress.traefik.enabled` is `true`. | `(traefik-ingress annotations)` |
+| `ingress.nginx.enabled` | Configure the ingress using Nginx as the controller. NOTE: A nginx controller must be installed and `ingress.enabled` must be `true`. | `false` |
+| `ingress.nginx.annotations` | Nginx-relative ingress annotations to be included when `ingress.nginx.enabled` is `true`. | `(nginx-ingress annotations)` |
 | `ingress.hostName` | Ingress resource host  | `nil` |
-| `ingress.path` | URL context to be used in addition to the hostname to access Enterprise Gateway. e.g. http://hostname/(ingress.path) | `/gateway/?(.*)` |
+| `ingress.path` | URL context to be used in addition to the hostname to access Enterprise Gateway. e.g. http://hostname/(ingress.path) | `/gateway` |
 | `ingress.port` | The port where enterprise gateway service is running | `8888` |
 | `kip.image` | Kernel Image Puller image name and tag to use. Ensure the tag is updated to the version of the Enterprise Gateway release you wish to run. | `elyra/kernel-image-puller:VERSION`, where `VERSION` is the release being used |
 | `kip.imagePullPolicy` | Kernel Image Puller image pull policy. Use `IfNotPresent` policy so that dev-based systems don't automatically update. This provides more control.  Since formal tags will be release-specific this policy should be sufficient for them as well. | `IfNotPresent` |

--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -533,10 +533,11 @@ can override them with Helm's `--set` or `--values` options.
 | `ingress.enabled` | Whether to include an EG ingress resource during deployment.| `false` |
 | `ingress.traefik.enabled` | Configure the ingress using Traefik as the controller. NOTE: A traefik controller must be installed and `ingress.enabled` must be `true`. | `true` |
 | `ingress.traefik.annotations` | Traefik-relative ingress annotations to be included when `ingress.traefik.enabled` is `true`. | `(traefik-ingress annotations)` |
+| `ingress.traefik.path` | URL context to be used in addition to the hostname to access Enterprise Gateway when `ingress.traefik.enabled` is `true`. | `/gateway` |
 | `ingress.nginx.enabled` | Configure the ingress using Nginx as the controller. NOTE: A nginx controller must be installed and `ingress.enabled` must be `true`. | `false` |
 | `ingress.nginx.annotations` | Nginx-relative ingress annotations to be included when `ingress.nginx.enabled` is `true`. | `(nginx-ingress annotations)` |
+| `ingress.nginx.path` | URL context to be used in addition to the hostname to access Enterprise Gateway when `ingress.nginx.enabled` is `true`. | `/gateway/?(.*)` |
 | `ingress.hostName` | Ingress resource host  | `nil` |
-| `ingress.path` | URL context to be used in addition to the hostname to access Enterprise Gateway. e.g. http://hostname/(ingress.path) | `/gateway` |
 | `ingress.port` | The port where enterprise gateway service is running | `8888` |
 | `kip.image` | Kernel Image Puller image name and tag to use. Ensure the tag is updated to the version of the Enterprise Gateway release you wish to run. | `elyra/kernel-image-puller:VERSION`, where `VERSION` is the release being used |
 | `kip.imagePullPolicy` | Kernel Image Puller image pull policy. Use `IfNotPresent` policy so that dev-based systems don't automatically update. This provides more control.  Since formal tags will be release-specific this policy should be sufficient for them as well. | `IfNotPresent` |

--- a/etc/kubernetes/helm/enterprise-gateway/templates/ingress.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/ingress.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   name: enterprise-gateway-ingress
   annotations:
-{{ if .Values.ingress.nginx.enabled }}
+{{- if .Values.ingress.nginx.enabled }}
 {{- with .Values.ingress.nginx.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{ else if .Values.ingress.traefik.enabled }}
+{{- else if .Values.ingress.traefik.enabled }}
 {{- with .Values.ingress.traefik.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
@@ -23,7 +23,11 @@ spec:
   - http:
   {{- end }}
       paths:
-      - path: {{ .Values.ingress.path }}
+{{- if .Values.ingress.nginx.enabled }}
+      - path: {{ .Values.ingress.nginx.path }}
+{{- else if .Values.ingress.traefik.enabled }}
+      - path: {{ .Values.ingress.traefik.path }}
+{{- end }}
         backend:
           serviceName: enterprise-gateway
           servicePort: {{ .Values.port }}

--- a/etc/kubernetes/helm/enterprise-gateway/templates/ingress.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/ingress.yaml
@@ -4,9 +4,15 @@ kind: Ingress
 metadata:
   namespace: {{ .Release.Namespace }}
   name: enterprise-gateway-ingress
-{{- with .Values.ingress.annotations }}
   annotations:
+{{ if .Values.ingress.nginx.enabled }}
+{{- with .Values.ingress.nginx.annotations }}
 {{ toYaml . | indent 4 }}
+{{- end }}
+{{ else if .Values.ingress.traefik.enabled }}
+{{- with .Values.ingress.traefik.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   rules:

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -46,16 +46,26 @@ nfs:
 
 ingress:
   enabled: false
-  # Ingress resource annotations to be included depending in ingress controller.
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+
   # Ingress resource host
   hostName: ""
   # URL context to be used in addition to the hostname to access Enterprise Gateway.
-  path: /gateway/?(.*)
+  path: /gateway
+
+  # Ingress resource annotations to be included depending in ingress controller.
+  traefik:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "traefik"
+      traefik.frontend.rule.type: PathPrefixStrip
+
+  nginx:
+    enabled: false
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
 
 # Kernel Image Puller (daemonset)
 kip:

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -49,18 +49,18 @@ ingress:
 
   # Ingress resource host
   hostName: ""
-  # URL context to be used in addition to the hostname to access Enterprise Gateway.
-  path: /gateway
 
   # Ingress resource annotations to be included depending in ingress controller.
   traefik:
     enabled: true
+    path: /gateway
     annotations:
       kubernetes.io/ingress.class: "traefik"
       traefik.frontend.rule.type: PathPrefixStrip
 
   nginx:
     enabled: false
+    path: /gateway/?(.*)
     annotations:
       kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/rewrite-target: /$1


### PR DESCRIPTION
Went ahead and added traefik ingress example to helm charts.  I've also made it the default over nginx since I believe enterprises will likely use traefik (and it works for me).  Found during 2.0 inspection (#723)
