### PR TITLE
Update to new yarn-api-client API release 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ Apache Spark, Kubernetes and others..
         'requests>=2.7,<3.0',
         'tornado>=4.2.0',
         'traitlets>=4.2.0',
-        'yarn-api-client>=0.3.6,<0.4.0',
+        'yarn-api-client>=1.0',
     ],
     python_requires='>=3.5',
     classifiers=[


### PR DESCRIPTION
This release provides the ability to honor the full endpoint set from the command line and include https.

Fixes: #729