### PR TITLE
Add support for dynamic configurations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ Apache Spark, Kubernetes and others..
         'pyzmq>=17.0.0',
         'requests>=2.7,<3.0',
         'tornado>=4.2.0',
-        'traitlets>=4.2.0',
+        'traitlets>=4.3.3',
         'yarn-api-client>=1.0',
     ],
     python_requires='>=3.5',


### PR DESCRIPTION
This change leverages a recent update to the traitlets library
that exposes an application's loaded configuration files.  When enabled
(via a positive value for `dynamic_config_interval`) it periodically
checks the loaded configuration files for updates (via file modification
times).  If updates are detected, the registered configurables are
updated with the contents of the files.  See documentation for more details.

Fixes #647