### PR TITLE
Perform clean on each build attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 
 install:
     - pip install --upgrade setuptools pip websocket-client flake8
-    - travis_retry make dist enterprise-gateway-demo
+    - travis_retry make clean dist enterprise-gateway-demo
     - pip install dist/*.whl coverage
     - pip freeze
 


### PR DESCRIPTION
Our builds are currently failing on the integration tests that use the `spark_scala_yarn_client` and `spark_scala_yarn_cluster` kernels.  The reason is that the toree-launcher jar file build fails, but because we don't issue `make clean`, the subsequent build attempts "pass" because of a dependency issue (which we should figure out).  However, because each build should be like the first, we should add the `clean` target when building the distribution and docker image.

Once this is done, the builds should fail early (after 3 failed build attempts), rather than continue only to fail 25 minutes later.