### PR TITLE
Update k8s client in spark-based images

### DIFF
--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -1,5 +1,15 @@
 FROM elyra/spark:v2.4.1
 
+# Depending on the version of Kubernetes, some Spark jobs get
+# failures attempting to create executors. These steps update
+# the kubernetes client to 4.4.2 and will not be necessary
+# once Spark 2.4.5 or 3.0 have been released.
+# See https://issues.apache.org/jira/browse/SPARK-28921
+RUN rm -f $SPARK_HOME/jars/kubernetes-*.jar
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model/4.4.2/kubernetes-model-4.4.2.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model-common/4.4.2/kubernetes-model-common-4.4.2.jar $SPARK_HOME/jars
+
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 RUN adduser -S -u 1000 -G users jovyan && \
@@ -11,5 +21,3 @@ RUN adduser -S -u 1000 -G users jovyan && \
 USER jovyan
 ENV KERNEL_LANGUAGE scala
 CMD /usr/local/bin/bootstrap-kernel.sh
-
-

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -35,6 +35,16 @@ RUN cd /opt/ && \
     sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh && \
     ln -sfn /opt/conda/bin/tini /sbin/tini
 
+# Depending on the version of Kubernetes, some Spark jobs get
+# failures attempting to create executors. These steps update
+# the kubernetes client to 4.4.2 and will not be necessary
+# once Spark 2.4.5 or 3.0 have been released.
+# See https://issues.apache.org/jira/browse/SPARK-28921
+RUN rm -f $SPARK_HOME/jars/kubernetes-*.jar
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model/4.4.2/kubernetes-model-4.4.2.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model-common/4.4.2/kubernetes-model-common-4.4.2.jar $SPARK_HOME/jars
+
 WORKDIR $SPARK_HOME/work-dir
 # Ensure that work-dir is writable by everyone
 RUN chmod 0777 $SPARK_HOME/work-dir
@@ -42,5 +52,3 @@ RUN chmod 0777 $SPARK_HOME/work-dir
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
 USER jovyan
-
-

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -31,6 +31,16 @@ RUN cd /opt/ && \
     sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh && \
     ln -sfn /opt/conda/bin/tini /sbin/tini
 
+# Depending on the version of Kubernetes, some Spark jobs get
+# failures attempting to create executors. These steps update
+# the kubernetes client to 4.4.2 and will not be necessary
+# once Spark 2.4.5 or 3.0 have been released.
+# See https://issues.apache.org/jira/browse/SPARK-28921
+RUN rm -f $SPARK_HOME/jars/kubernetes-*.jar
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model/4.4.2/kubernetes-model-4.4.2.jar $SPARK_HOME/jars
+ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model-common/4.4.2/kubernetes-model-common-4.4.2.jar $SPARK_HOME/jars
+
 WORKDIR $SPARK_HOME/work-dir
 # Ensure that work-dir is writable by everyone
 RUN chmod 0777 $SPARK_HOME/work-dir
@@ -38,4 +48,3 @@ RUN chmod 0777 $SPARK_HOME/work-dir
 ENTRYPOINT [ "/opt/entrypoint.sh" ]
 
 USER jovyan
-


### PR DESCRIPTION
On more recent versions of Kubernetes with Spark installed (prior to
2.4.5 or 3.0.0), the spark driver will request additional executors
and that request will fail (with 403).  These changes update the
spark-based images with an updated kubernetes client version that
addresses this issue.  See https://issues.apache.org/jira/browse/SPARK-28921
for more information.