### PR TITLE
Cap yarn-api-client at < 1.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -10,7 +10,7 @@ dependencies:
   - tornado>=4.2.0
   - requests>=2.7,<3.0
   - paramiko>=2.1.2
-  - yarn-api-client>=0.3.3
+  - yarn-api-client>=0.3.3,<1.0
   - pexpect>=4.2.0
   - pycrypto>=2.6.1
   - pyzmq>=17.0.0

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ Jupyter Notebooks to share resources across an Apache Spark cluster.
         'requests>=2.7,<3.0',
         'tornado>=4.2.0',
         'traitlets>=4.2.0',
-        'yarn-api-client>=0.3.3',
+        'yarn-api-client>=0.3.3,<1.0',
     ],
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Significant changes are required to move to the 1.x release of yarn-api-client so we should cap it.
Note this change is only for the 1.x branch!