### PR TITLE
Replace pycrypto with pycryptodomex

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -26,7 +26,7 @@ from jupyter_client import launch_kernel, localinterfaces
 from notebook import _tz
 from zmq.ssh import tunnel
 from enum import Enum
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
 
 from ..sessions.kernelsessionmanager import KernelSessionManager
 
@@ -819,7 +819,7 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
     def _decrypt(self, data):
         """Decrypts `data` using the kernel_id as the key."""
         key = self.kernel_id[0:16]
-        cipher = AES.new(key)
+        cipher = AES.new(key.encode('utf-8'), AES.MODE_ECB)
         payload = cipher.decrypt(base64.b64decode(data))
         payload = "".join([payload.decode("utf-8").rsplit("}", 1)[0], "}"])  # Get rid of padding after the '}'.
         return payload

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -10,8 +10,7 @@ from multiprocessing import Process
 from random import random
 from threading import Thread
 
-from Crypto.Cipher import AES
-from IPython import embed_kernel
+from Cryptodome.Cipher import AES
 from ipython_genutils.py3compat import str_to_bytes
 from jupyter_client.connect import write_connection_file
 
@@ -26,6 +25,7 @@ logging.basicConfig(format='[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s]
 logger = logging.getLogger('launch_ipykernel')
 logger.setLevel(log_level)
 
+
 class ExceptionThread(Thread):
     # Wrap thread to handle the exception
     def __init__(self, target):
@@ -38,6 +38,7 @@ class ExceptionThread(Thread):
             self.target()
         except Exception as exc:
             self.exc = exc
+
 
 def initialize_namespace(namespace, cluster_type='spark'):
     """Initialize the kernel namespace.
@@ -159,7 +160,7 @@ def _encrypt(connection_info, conn_file):
 
     # Encrypt connection_info whose length is a multiple of BLOCK_SIZE using
     # AES cipher and then encode the resulting byte array using Base64.
-    encryptAES = lambda c, s: base64.b64encode(c.encrypt(pad(s)))
+    encryptAES = lambda c, s: base64.b64encode(c.encrypt(pad(s).encode('utf-8')))
 
     # Create a key using first 16 chars of the kernel-id that is burnt in
     # the name of the connection file.
@@ -174,8 +175,7 @@ def _encrypt(connection_info, conn_file):
     # print("AES Encryption Key '{}'".format(key))
 
     # Creates the cipher obj using the key.
-    cipher = AES.new(key)
-
+    cipher = AES.new(key.encode('utf-8'), AES.MODE_ECB)
     payload = encryptAES(cipher, connection_info)
     return payload
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,13 +10,13 @@ dependencies:
   - paramiko>=2.1.2
   - pexpect>=4.2.0
   - pip
-  - pycrypto>=2.6.1
+  - pycryptodomex>=3.9.7
   - python-kubernetes>=4.0.0
   - pyzmq>=17.0.0
   - requests>=2.7,<3.0
   - tornado>=4.2.0
   - traitlets>=4.2.0
-  - yarn-api-client>=0.3.6,<0.4.0
+  - yarn-api-client>=1.0
 
   # Test Requirements
   - nose

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ Apache Spark, Kubernetes and others..
         'notebook>=5.7.6,<7.0',
         'paramiko>=2.1.2',
         'pexpect>=4.2.0',
-        'pycrypto>=2.6.1',
+        'pycryptodomex>=3.9.7',
         'pyzmq>=17.0.0',
         'requests>=2.7,<3.0',
         'tornado>=4.2.0',


### PR DESCRIPTION
The pycrypto package has fallen out of maintenance, so this change
replaces it with pycryptdomex.  This package was chosen over pycryptodome
because it can co-exist with pycrypto, while pycryptodome cannot, and
we felt other applications may be using pycrypto.  If the remote kernel
launchers are not updated, the two are compatible since we use
the same mode.