### PR TITLE
fix 'jinja2_env' if kernel does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ _site/
 
 # Debug-related
 .kube/
+
+# vscode
+.vscode/

--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -123,8 +123,5 @@ for path, cls in notebook_handlers.default_handlers:
         default_handlers.append((path, globals()[cls.__name__]))
     else:
         # Gen a new type with CORS and token auth
-        bases = (TokenAuthorizationMixin, CORSMixin, cls)
-        if cls.__name__ == 'ZMQChannelsHandler':
-            from notebook.base.handlers import APIHandler
-            cls.write_error = APIHandler.write_error
+        bases = (TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, cls)
         default_handlers.append((path, type(cls.__name__, bases, {})))

--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -124,4 +124,7 @@ for path, cls in notebook_handlers.default_handlers:
     else:
         # Gen a new type with CORS and token auth
         bases = (TokenAuthorizationMixin, CORSMixin, cls)
+        if cls.__name__ == 'ZMQChannelsHandler':
+            from notebook.base.handlers import APIHandler
+            cls.write_error = APIHandler.write_error
         default_handlers.append((path, type(cls.__name__, bases, {})))


### PR DESCRIPTION
Use APIHandler write_error routine for ZMQChannelsHandler and avoid jinja2 templates.
Added .vscode folder to .gitignore.

Fixes: #797 .

Tested manually.

Not the most elegant of fixes. In an ideal world perhaps ZMQChannelsHandler (from another package) might be subclassed rather than monkey patched.
