### PR TITLE
Make python launcher compatible with python 2

### DIFF
--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -6,6 +6,7 @@ import os
 import socket
 import tempfile
 import uuid
+from future.utils import raise_from
 from multiprocessing import Process
 from random import random
 from threading import Thread
@@ -136,7 +137,7 @@ class WaitingForSparkSessionToBeInitialized(object):
             self._init_thread.join(timeout=None)
             exc = self._init_thread.exc
             if exc:
-                raise RuntimeError("Variable: {} was not initialized properly.".format(self._spark_session_variable)) from exc
+                raise_from(RuntimeError("Variable: {} was not initialized properly.".format(self._spark_session_variable)), exc)
             # now return attribute/function reference from actual Spark object
             return getattr(self._namespace[self._spark_session_variable], name)
 

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ Apache Spark, Kubernetes and others..
     ],
     install_requires=[
         'docker>=3.5.0',
+        'future',
         'jinja2>=2.10',
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',


### PR DESCRIPTION
Since many Hadoop YARN envs still run Python 2, we should continue
to make launchers compatible with Python 2 for the time being.

Resolves #807