### PR TITLE
Prepare for next notebook release, pin to current

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -958,7 +958,6 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         if pid:
             try:
                 self.pid = int(pid)
-                self.log.debug("Updated pid to: {}".format(self.pid))
             except ValueError:
                 self.log.warning("pid returned from kernel launcher is not an integer: {} - ignoring.".format(pid))
                 pid = None
@@ -966,7 +965,6 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
         if pgid:
             try:
                 self.pgid = int(pgid)
-                self.log.debug("Updated pgid to: {}".format(self.pgid))
             except ValueError:
                 self.log.warning("pgid returned from kernel launcher is not an integer: {} - ignoring.".format(pgid))
                 pgid = None

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ Apache Spark, Kubernetes and others..
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',
         'kubernetes>=4.0.0',
-        'notebook>=5.7.6,<7.0',
+        'notebook>=5.7.6,<6.1',
         'paramiko>=2.1.2',
         'pexpect>=4.2.0',
         'pycryptodomex>=3.9.7',


### PR DESCRIPTION
Due to the complexities involving mixing async/await and gen.coroutine/yield
constructs, it's best to keep EG pinned to the pre-async notebook releases (6.0.*)
until EG can adopt async kernel management.

Removed a couple of redundant debug statements.

Resolves #806