### PR TITLE
Prepare for next notebook release

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -11,6 +11,7 @@ from tornado import gen, web
 from ipython_genutils.py3compat import unicode_type
 from ipython_genutils.importstring import import_item
 from notebook.services.kernels.kernelmanager import MappingKernelManager
+from notebook.utils import maybe_future
 from jupyter_client.ioloop.manager import IOLoopKernelManager
 
 from ..processproxies.processproxy import LocalProcessProxy, RemoteProcessProxy
@@ -74,7 +75,7 @@ class RemoteMappingKernelManager(MappingKernelManager):
         username = KernelSessionManager.get_kernel_username(**kwargs)
         self.log.debug("RemoteMappingKernelManager.start_kernel: {kernel_name}, kernel_username: {username}".
                        format(kernel_name=kwargs['kernel_name'], username=username))
-        kernel_id = yield gen.maybe_future(super(RemoteMappingKernelManager, self).start_kernel(*args, **kwargs))
+        kernel_id = yield maybe_future(super(RemoteMappingKernelManager, self).start_kernel(*args, **kwargs))
         self.parent.kernel_session_manager.create_session(kernel_id, **kwargs)
         raise gen.Return(kernel_id)
 

--- a/enterprise_gateway/services/sessions/sessionmanager.py
+++ b/enterprise_gateway/services/sessions/sessionmanager.py
@@ -3,6 +3,7 @@
 """Session manager that keeps all its metadata in memory."""
 
 import uuid
+from notebook.utils import maybe_future
 from tornado import web, gen
 from traitlets.config.configurable import LoggingConfigurable
 from ipython_genutils.py3compat import unicode_type
@@ -72,8 +73,8 @@ class SessionManager(LoggingConfigurable):
         """
         session_id = self.new_session_id()
         # allow nbm to specify kernels cwd
-        kernel_id = yield gen.maybe_future(self.kernel_manager.start_kernel(path=path,
-                                                                            kernel_name=kernel_name))
+        kernel_id = yield maybe_future(self.kernel_manager.start_kernel(path=path,
+                                                                        kernel_name=kernel_name))
         raise gen.Return(self.save_session(session_id, path=path,
                                            kernel_id=kernel_id))
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ Apache Spark, Kubernetes and others..
         'jupyter_client>=5.2.0',
         'jupyter_core>=4.4.0',
         'kubernetes>=4.0.0',
-        'notebook>=5.7.6,<6.1',
+        'notebook>=5.7.6,<7.0',
         'paramiko>=2.1.2',
         'pexpect>=4.2.0',
         'pycryptodomex>=3.9.7',


### PR DESCRIPTION
This commit supersedes the commit from PR #809.  The real issue
was that the `maybe_future` wrappers didn't account for the case
that they could be wrapping async/await-based methods and not
just gen.coroutines.  Updating to use the wrapper from the notebook
utilities allows EG to work with current and future notebook releases.

Resolves #806