### PR TITLE
Fix python-based images relative to recent changes

### DIFF
--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -8,7 +8,8 @@ RUN conda install --quiet --yes \
     cffi \
     send2trash \
     requests \
-    pycrypto && \
+    future \
+    pycryptodomex && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -8,7 +8,8 @@ RUN conda install --quiet --yes \
     ipykernel \
     ipython \
     jupyter_client \
-    pycrypto && \
+    future \
+    pycryptodomex && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR && \
     fix-permissions /home/$NB_USER

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -yq \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install pycrypto
+RUN pip install future pycryptodomex
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -7,7 +7,8 @@ ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 RUN conda install --quiet --yes \
     pillow \
-    pycrypto && \
+    future \
+    pycryptodomex && \
     fix-permissions $CONDA_DIR
 
 USER root


### PR DESCRIPTION
This commit addresses some recent changes and ensures the `future`
package is installed and replaces `pycrypto` with `pycryptodomex`.

Once merged, I think we can move forward with cutting 2.1.1.