### PR TITLE
Consider global authorization lists when filtering kernelspecs

### DIFF
--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -189,6 +189,8 @@ class EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp):
             eg_env_process_whitelist=self.env_process_whitelist,
             eg_env_whitelist=self.env_whitelist,
             eg_list_kernels=self.list_kernels,
+            eg_authorized_users=self.authorized_users,
+            eg_unauthorized_users=self.unauthorized_users,
             # Also set the allow_origin setting used by notebook so that the
             # check_origin method used everywhere respects the value
             allow_origin=self.allow_origin,


### PR DESCRIPTION
This change takes into consideration the globally-defined authorization lists that span kernelspecs.  It is a follow-on PR to #800.

Unauthorized users from both kernelspecs and globally-defined are treated as a union, while authorized users defined in a kernelspec can only use those kernels unless there are no globally-defined authorized users or they also appear in the global list as well.  As such, kernelspec authorization is considered before global authorization.

Here are some examples from a recent run...

### Configuration:
Global Authorized Users = "bob, angel"
Global Unauthorized Users = "badguy"

Kernelspecs spark_python_yarn_* and spark_r_yarn_* have configured authorization lists.

User 'alice' is specifically authorized for spark_python_yarn_*
User 'angel' is not specifically listed in any kernelspecs
User 'badguy' is not specifically listed in any kernelspecs

### Trials:
User 'alice' only has authorization to use spark_python_yarn_* and is then denied all other kernels...
```
[D 2020-05-29 16:51:14.491 EnterpriseGatewayApp] Searching kernels for user 'alice' 
[D 2020-05-29 16:51:15.041 EnterpriseGatewayApp] Found kernel python3 in /opt/anaconda2/envs/py3/share/jupyter/kernels
[D 2020-05-29 16:51:15.043 EnterpriseGatewayApp] Found kernel spark_r_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:51:15.043 EnterpriseGatewayApp] Found kernel spark_r_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:51:15.043 EnterpriseGatewayApp] Found kernel spark_python_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:51:15.044 EnterpriseGatewayApp] Found kernel spark_python_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:51:15.044 EnterpriseGatewayApp] Found kernel spark_scala_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:51:15.044 EnterpriseGatewayApp] Found kernel spark_scala_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:51:15.057 EnterpriseGatewayApp] User alice is not authorized to use kernel spec python3
[D 2020-05-29 16:51:15.074 EnterpriseGatewayApp] User alice is not authorized to use kernel spec spark_r_yarn_client
[D 2020-05-29 16:51:15.074 EnterpriseGatewayApp] User alice is not authorized to use kernel spec spark_r_yarn_cluster
[D 2020-05-29 16:51:15.074 EnterpriseGatewayApp] User alice is not authorized to use kernel spec spark_scala_yarn_client
[D 2020-05-29 16:51:15.075 EnterpriseGatewayApp] User alice is not authorized to use kernel spec spark_scala_yarn_cluster
```
User 'angel'. Because spark_r_yarn_* and spark_python_yarn_* have authorized user lists and 'angel' is NOT in any of those, user 'angel' is denied access to those kernels...
```
[D 2020-05-29 16:53:48.217 EnterpriseGatewayApp] Searching kernels for user 'angel' 
[D 2020-05-29 16:53:48.218 EnterpriseGatewayApp] Found kernel python3 in /opt/anaconda2/envs/py3/share/jupyter/kernels
[D 2020-05-29 16:53:48.219 EnterpriseGatewayApp] Found kernel spark_r_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:53:48.219 EnterpriseGatewayApp] Found kernel spark_r_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:53:48.219 EnterpriseGatewayApp] Found kernel spark_python_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:53:48.219 EnterpriseGatewayApp] Found kernel spark_python_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:53:48.220 EnterpriseGatewayApp] Found kernel spark_scala_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:53:48.220 EnterpriseGatewayApp] Found kernel spark_scala_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:53:48.227 EnterpriseGatewayApp] User angel is not authorized to use kernel spec spark_r_yarn_client
[D 2020-05-29 16:53:48.228 EnterpriseGatewayApp] User angel is not authorized to use kernel spec spark_r_yarn_cluster
[D 2020-05-29 16:53:48.228 EnterpriseGatewayApp] User angel is not authorized to use kernel spec spark_python_yarn_client
[D 2020-05-29 16:53:48.229 EnterpriseGatewayApp] User angel is not authorized to use kernel spec spark_python_yarn_cluster
```
User 'badguy'.  Because he is in the global unauthorized users list, he is denied access to all kernels...
```
[D 2020-05-29 16:55:25.862 EnterpriseGatewayApp] Searching kernels for user 'badguy' 
[D 2020-05-29 16:55:25.863 EnterpriseGatewayApp] Found kernel python3 in /opt/anaconda2/envs/py3/share/jupyter/kernels
[D 2020-05-29 16:55:25.863 EnterpriseGatewayApp] Found kernel spark_r_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:55:25.864 EnterpriseGatewayApp] Found kernel spark_r_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:55:25.864 EnterpriseGatewayApp] Found kernel spark_python_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:55:25.864 EnterpriseGatewayApp] Found kernel spark_python_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:55:25.864 EnterpriseGatewayApp] Found kernel spark_scala_yarn_client in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:55:25.864 EnterpriseGatewayApp] Found kernel spark_scala_yarn_cluster in /usr/local/share/jupyter/kernels
[D 2020-05-29 16:55:25.873 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec python3
[D 2020-05-29 16:55:25.874 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec spark_r_yarn_client
[D 2020-05-29 16:55:25.875 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec spark_r_yarn_cluster
[D 2020-05-29 16:55:25.876 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec spark_python_yarn_client
[D 2020-05-29 16:55:25.878 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec spark_python_yarn_cluster
[D 2020-05-29 16:55:25.879 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec spark_scala_yarn_client
[D 2020-05-29 16:55:25.880 EnterpriseGatewayApp] User badguy is not authorized to use kernel spec spark_scala_yarn_cluster
```
Resolves #816