### PR TITLE
Move images to Spark 2.4.5, other fixups

### DIFF
--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,6 +1,6 @@
 FROM jupyter/minimal-notebook
 
-ENV SPARK_VER 2.4.1
+ENV SPARK_VER 2.4.5
 ENV SPARK_HOME /opt/spark
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 

--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -2,7 +2,7 @@ FROM elyra/spark:v2.4.5
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
-# Craete/setup the jovyan system user
+# Create/setup the jovyan system user
 RUN adduser --system -uid 1000 jovyan --ingroup users && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \

--- a/etc/docker/kernel-scala/Dockerfile
+++ b/etc/docker/kernel-scala/Dockerfile
@@ -1,18 +1,9 @@
-FROM elyra/spark:v2.4.1
-
-# Depending on the version of Kubernetes, some Spark jobs get
-# failures attempting to create executors. These steps update
-# the kubernetes client to 4.4.2 and will not be necessary
-# once Spark 2.4.5 or 3.0 have been released.
-# See https://issues.apache.org/jira/browse/SPARK-28921
-RUN rm -f $SPARK_HOME/jars/kubernetes-*.jar
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar $SPARK_HOME/jars
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model/4.4.2/kubernetes-model-4.4.2.jar $SPARK_HOME/jars
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model-common/4.4.2/kubernetes-model-common-4.4.2.jar $SPARK_HOME/jars
+FROM elyra/spark:v2.4.5
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
-RUN adduser -S -u 1000 -G users jovyan && \
+# Craete/setup the jovyan system user
+RUN adduser --system -uid 1000 jovyan --ingroup users && \
     chown jovyan:users /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0755 /usr/local/bin/bootstrap-kernel.sh && \
 	chmod 0777 /opt/spark/work-dir && \

--- a/etc/docker/kernel-spark-py/Dockerfile
+++ b/etc/docker/kernel-spark-py/Dockerfile
@@ -4,7 +4,7 @@ ARG TAG
 # Ubuntu 18.04.1 LTS Bionic
 FROM $HUB_ORG/kernel-py:$TAG
 
-ENV SPARK_VER 2.4.1
+ENV SPARK_VER 2.4.5
 ENV SPARK_HOME /opt/spark
 ENV KERNEL_LANGUAGE python
 ENV R_LIBS_USER $R_LIBS_USER:${SPARK_HOME}/R/lib
@@ -33,17 +33,7 @@ RUN cd /opt/ && \
     wget https://raw.githubusercontent.com/apache/spark/v${SPARK_VER}/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh && \
     chmod a+x /opt/entrypoint.sh && \
     sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh && \
-    ln -sfn /opt/conda/bin/tini /sbin/tini
-
-# Depending on the version of Kubernetes, some Spark jobs get
-# failures attempting to create executors. These steps update
-# the kubernetes client to 4.4.2 and will not be necessary
-# once Spark 2.4.5 or 3.0 have been released.
-# See https://issues.apache.org/jira/browse/SPARK-28921
-RUN rm -f $SPARK_HOME/jars/kubernetes-*.jar
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar $SPARK_HOME/jars
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model/4.4.2/kubernetes-model-4.4.2.jar $SPARK_HOME/jars
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model-common/4.4.2/kubernetes-model-common-4.4.2.jar $SPARK_HOME/jars
+    ln -sfn /opt/conda/bin/tini /usr/bin/tini
 
 WORKDIR $SPARK_HOME/work-dir
 # Ensure that work-dir is writable by everyone

--- a/etc/docker/kernel-spark-r/Dockerfile
+++ b/etc/docker/kernel-spark-r/Dockerfile
@@ -5,7 +5,7 @@ FROM $HUB_ORG/kernel-r:$TAG
 
 USER root
 
-ENV SPARK_VER 2.4.1
+ENV SPARK_VER 2.4.5
 ENV SPARK_HOME /opt/spark
 ENV KERNEL_LANGUAGE=R
 ENV R_LIBS_USER $R_LIBS_USER:${R_HOME}/library:${SPARK_HOME}/R/lib
@@ -29,17 +29,7 @@ RUN cd /opt/ && \
     wget https://raw.githubusercontent.com/apache/spark/v${SPARK_VER}/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh && \
     chmod a+x /opt/entrypoint.sh && \
     sed -i 's/tini -s/tini -g/g' /opt/entrypoint.sh && \
-    ln -sfn /opt/conda/bin/tini /sbin/tini
-
-# Depending on the version of Kubernetes, some Spark jobs get
-# failures attempting to create executors. These steps update
-# the kubernetes client to 4.4.2 and will not be necessary
-# once Spark 2.4.5 or 3.0 have been released.
-# See https://issues.apache.org/jira/browse/SPARK-28921
-RUN rm -f $SPARK_HOME/jars/kubernetes-*.jar
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-client/4.4.2/kubernetes-client-4.4.2.jar $SPARK_HOME/jars
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model/4.4.2/kubernetes-model-4.4.2.jar $SPARK_HOME/jars
-ADD https://repo1.maven.org/maven2/io/fabric8/kubernetes-model-common/4.4.2/kubernetes-model-common-4.4.2.jar $SPARK_HOME/jars
+    ln -sfn /opt/conda/bin/tini /usr/bin/tini
 
 WORKDIR $SPARK_HOME/work-dir
 # Ensure that work-dir is writable by everyone


### PR DESCRIPTION
- Updated the Spark version to 2.4.5 (and removed previous workaround).
- Fixed user creation commands in kernel-scala image build.
- Updated Kernel Image Puller to check for previously pulled image's existence and perform pull if not found.  This enables installations to use 'if not present' policy more accurately.
- Fixed up the location of `tini` (to /usr/bin) for Python and R spark images.

Fixes #802 
Fixes #804 
Fixes #805 