### PR TITLE
Add option to use global ZMQ context

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -6,6 +6,7 @@ import os
 import signal
 import re
 import uuid
+import zmq
 
 from tornado import gen, web
 from ipython_genutils.py3compat import unicode_type
@@ -13,7 +14,7 @@ from ipython_genutils.importstring import import_item
 from notebook.services.kernels.kernelmanager import MappingKernelManager
 from notebook.utils import maybe_future
 from jupyter_client.ioloop.manager import IOLoopKernelManager
-from traitlets import directional_link, log as traitlets_log
+from traitlets import directional_link, default, Bool, log as traitlets_log
 
 from ..processproxies.processproxy import LocalProcessProxy, RemoteProcessProxy
 from ..sessions.kernelsessionmanager import KernelSessionManager
@@ -216,6 +217,23 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, IOLoopKernelManager):
     appropriate class (previously pulled from the kernel spec).  The process 'proxy' is
     returned - upon which methods of poll(), wait(), send_signal(), and kill() can be called.
     """
+
+    use_global_zmq_context_env = 'EG_USE_GLOBAL_ZMQ_CONTEXT'
+    use_global_zmq_context = Bool(False, config=True,
+                                  help="""Indicates whether a global ZMQ context should be used.
+                                  (EG_USE_GLOBAL_ZMQ_CONTEXT env var)""")
+
+    @default('use_global_zmq_context')
+    def use_global_zmq_context_default(self):
+        return bool(os.getenv(self.use_global_zmq_context_env, 'false').lower() == 'true')
+
+    # Override _context_default and create a GLOBAL ZMQ context.  This prevents leaks, but could break
+    # down the road, thus it doesn't occur by default.
+    def _context_default(self):
+        if self.use_global_zmq_context:
+            self.log.info("Using global ZMQ context via configuration override (use_global_zmq_context=True).")
+            return zmq.Context.instance()
+        return super(RemoteKernelManager, self)._context_default()
 
     def __init__(self, **kwargs):
         super(RemoteKernelManager, self).__init__(**kwargs)


### PR DESCRIPTION
We have found that reverting the context in jupyter_client to its global form (from a year ago) doesn't lead to FD leaks.  The change away from the global context fixed an issue with multi-threaded kernel client applications, which EG probably doesn't need.

This change adds a configurable option (use_global_zmq_context=True) to enable the use of a global (singleton) context.  By default, the current behavior in jupter_client is used.

The reason this is configurable is that jupyter_client may soon release a change that would cause things to break if a global context was in use and we'd need to have a means of using jupyter_client's context directly - which a 'False' value permits.

To enable the use of the global ZMQ context, either of the following options must be taken...

Add to the config file or command line:
`--RemoteKernelManager.use_global_zmq_context=True`

or set the environment variable...
`EG_USE_GLOBAL_ZMQ_CONTEXT=True`

Upon use of the first ZMQ port (for each kernel), you should see the following informational message logged:
```
[I 2020-06-05 15:51:44.324 EnterpriseGatewayApp] Using global ZMQ context via configuration override (use_global_zmq_context=True).
```