### PR TITLE
Move shutdown_listener call in cleanup to DistributedProcessProxy

### DIFF
--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -150,6 +150,12 @@ class DistributedProcessProxy(RemoteProcessProxy):
             self.kill()
             self.log_and_raise(http_status_code=500, reason=timeout_message)
 
+    def cleanup(self):
+        # DistributedProcessProxy can have a tendency to leave zombies, particularly when EG is
+        # abruptly terminated.  This extra call to shutdown_lister does the trick.
+        self.shutdown_listener()
+        super(RemoteProcessProxy, self).cleanup()
+
     def shutdown_listener(self):
         """Ensure that kernel process is terminated."""
         self.send_signal(signal.SIGTERM)

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -993,8 +993,6 @@ class RemoteProcessProxy(with_metaclass(abc.ABCMeta, BaseProcessProxyABC)):
 
     def cleanup(self):
         """Terminates tunnel processes, if applicable."""
-        self.shutdown_listener()  # Ensure listener has been shutdown
-
         self.assigned_ip = None
 
         for kernel_channel, process in self.tunnel_processes.items():


### PR DESCRIPTION
The original addition of shutdown_listener in RemoteProcessProxy.cleanup() for #707 was overzealous and side-affected container-based platforms.  This change moves that addition to DistributedProcessProxy since that is the only process proxy that needs this.

Fixes #822