### PR TITLE
Enable ability to set default kernel name in container envs

### DIFF
--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -92,6 +92,9 @@ spec:
           value: "60"
         - name: EG_KERNEL_WHITELIST
           value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
+        - name: EG_DEFAULT_KERNEL_NAME
+          value: "python_kubernetes"
+
         # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
         image: elyra/enterprise-gateway:VERSION
         # k8s will only pull :latest all the time.  

--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -26,6 +26,7 @@ export EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-43200}  # default to 12 hour
 export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-60}
 export EG_CULL_CONNECTED=${EG_CULL_CONNECTED:-False}
 export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"['r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker']"}
+export EG_DEFAULT_KERNEL_NAME=${EG_DEFAULT_KERNEL_NAME:-python_docker}
 
 
 echo "Starting Jupyter Enterprise Gateway..."
@@ -33,8 +34,9 @@ echo "Starting Jupyter Enterprise Gateway..."
 exec jupyter enterprisegateway \
 	--log-level=${EG_LOG_LEVEL} \
 	--KernelSpecManager.whitelist=${EG_KERNEL_WHITELIST} \
-	--MappingKernelManager.cull_idle_timeout=${EG_CULL_IDLE_TIMEOUT} \
-	--MappingKernelManager.cull_interval=${EG_CULL_INTERVAL} \
-	--MappingKernelManager.cull_connected=${EG_CULL_CONNECTED}
+	--RemoteMappingKernelManager.cull_idle_timeout=${EG_CULL_IDLE_TIMEOUT} \
+	--RemoteMappingKernelManager.cull_interval=${EG_CULL_INTERVAL} \
+	--RemoteMappingKernelManager.cull_connected=${EG_CULL_CONNECTED} \
+	--RemoteMappingKernelManager.default_kernel_name=${EG_DEFAULT_KERNEL_NAME}
 
 

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -140,6 +140,9 @@ spec:
         - name: EG_KERNEL_WHITELIST
           value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','python_tf_gpu_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
 
+        - name: EG_DEFAULT_KERNEL_NAME
+          value: "python_kubernetes"
+
         # Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
         image: elyra/enterprise-gateway:dev
         # Use IfNotPresent policy so that dev-based systems don't automatically

--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -57,6 +57,8 @@ spec:
           value: !!str {{ .Values.kernel.launchTimeout }}
         - name: EG_KERNEL_WHITELIST
           value: {{ toJson .Values.kernel.whitelist | squote }}
+        - name: EG_DEFAULT_KERNEL_NAME
+          value: {{ .Values.kernel.defaultKernelName }}
         ports:
         - containerPort: {{ .Values.port }}
 {{- if .Values.nfs.enabled }}

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -32,6 +32,8 @@ kernel:
     - spark_r_kubernetes
     - spark_python_kubernetes
     - spark_scala_kubernetes
+  # Default kernel name should be something from the whitelist
+  defaultKernelName: python_kubernetes
 
 kernelspecs:
   # Optional custom data image containing kernelspecs to use.


### PR DESCRIPTION
Adds appropriate plumbing (via environment variable `EG_DEFAULT_KERNEL_NAME`) to adjust the default kernel name in container environments and initializes those configurations with the appropriate python kernel.

Fixes #823
