### PR TITLE
Rollback option to use ZMQ global context

### DIFF
--- a/enterprise_gateway/services/kernels/remotemanager.py
+++ b/enterprise_gateway/services/kernels/remotemanager.py
@@ -6,7 +6,6 @@ import os
 import signal
 import re
 import uuid
-import zmq
 
 from tornado import gen, web
 from ipython_genutils.py3compat import unicode_type
@@ -14,7 +13,7 @@ from ipython_genutils.importstring import import_item
 from notebook.services.kernels.kernelmanager import MappingKernelManager
 from notebook.utils import maybe_future
 from jupyter_client.ioloop.manager import IOLoopKernelManager
-from traitlets import directional_link, default, Bool, log as traitlets_log
+from traitlets import directional_link, log as traitlets_log
 
 from ..processproxies.processproxy import LocalProcessProxy, RemoteProcessProxy
 from ..sessions.kernelsessionmanager import KernelSessionManager
@@ -217,23 +216,6 @@ class RemoteKernelManager(EnterpriseGatewayConfigMixin, IOLoopKernelManager):
     appropriate class (previously pulled from the kernel spec).  The process 'proxy' is
     returned - upon which methods of poll(), wait(), send_signal(), and kill() can be called.
     """
-
-    use_global_zmq_context_env = 'EG_USE_GLOBAL_ZMQ_CONTEXT'
-    use_global_zmq_context = Bool(False, config=True,
-                                  help="""Indicates whether a global ZMQ context should be used.
-                                  (EG_USE_GLOBAL_ZMQ_CONTEXT env var)""")
-
-    @default('use_global_zmq_context')
-    def use_global_zmq_context_default(self):
-        return bool(os.getenv(self.use_global_zmq_context_env, 'false').lower() == 'true')
-
-    # Override _context_default and create a GLOBAL ZMQ context.  This prevents leaks, but could break
-    # down the road, thus it doesn't occur by default.
-    def _context_default(self):
-        if self.use_global_zmq_context:
-            self.log.info("Using global ZMQ context via configuration override (use_global_zmq_context=True).")
-            return zmq.Context.instance()
-        return super(RemoteKernelManager, self)._context_default()
 
     def __init__(self, **kwargs):
         super(RemoteKernelManager, self).__init__(**kwargs)


### PR DESCRIPTION
This is now default behavior in jupyter_client versions 5.3.5 and
6.1.5 and makes the previous change obsolete. This rolls back #820.
