### PR TITLE
Allow kernel listings by default for EG containers

### DIFF
--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -21,6 +21,7 @@ export KG_PORT_RETRIES=${KG_PORT_RETRIES:-${EG_PORT_RETRIES}}
 # To use tunneling set this variable to 'True' (may need to run as root).
 export EG_ENABLE_TUNNELING=${EG_ENABLE_TUNNELING:-False}
 
+export EG_LIST_KERNELS=${EG_LIST_KERNELS:-True}
 export EG_LOG_LEVEL=${EG_LOG_LEVEL:-DEBUG}
 export EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-43200}  # default to 12 hours
 export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-60}


### PR DESCRIPTION
While testing the fix released in #833, I found that `GET` requests against `/api/kernels` were throwing `403` because the listing of kernels was not enabled.  This change defaults the corresponding env (`EG_LIST_KERNELS`) to true for containerized uses.  It can still be disabled via the env for users not wishing to expose that information.