### PR TITLE
Pin jupyter-stack images to known working version

### DIFF
--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/minimal-notebook
+FROM jupyter/minimal-notebook:04f7f60d34a6
 
 ENV SPARK_VER 2.4.5
 ENV SPARK_HOME /opt/spark

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-FROM jupyter/scipy-notebook
+FROM jupyter/scipy-notebook:04f7f60d34a6
 
 ENV PATH=$PATH:$CONDA_DIR/bin
 

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-FROM jupyter/r-notebook
+FROM jupyter/r-notebook:04f7f60d34a6
 
 RUN conda install --quiet --yes \
     'r-argparse' && \

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu:Bionic
-FROM jupyter/tensorflow-notebook
+FROM jupyter/tensorflow-notebook:04f7f60d34a6
 
 ENV KERNEL_LANGUAGE python
 


### PR DESCRIPTION
It was found that more recent base images (from [jupyter stacks](https://github.com/jupyter/docker-stacks)) are breaking the spark-based images that derive from them.  It is suspected that the move from conda 4.8.2 to 4.8.3 is side-effecting Spark in some manner.  

This change pins ALL jupyter-stack images to the same tag (commit) for consistency even though some images are not used in a Spark context.