### PR TITLE
Fix doc builds

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,8 +1,13 @@
 name: enterprise_gateway_docs
+channels:
+  - conda-forge
+  - defaults
+  - free
 dependencies:
-- python==3.6
-- sphinx_rtd_theme
-- sphinx>=1.8.3
-- pip:
+  - pip
+  - python=3.7
+  - pip:
     - recommonmark
+    - sphinx_rtd_theme
+    - sphinx>=3
     - sphinx-markdown-tables

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ import recommonmark.parser
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.3'
+needs_sphinx = '3.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -33,18 +33,14 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
-    "sphinx.ext.extlinks",
-    "sphinx.ext.viewcode",
-    "sphinx_markdown_tables",
+    'sphinx.ext.extlinks',
+    'sphinx.ext.viewcode',
+    'sphinx_markdown_tables',
+    'recommonmark',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-# Jupyter uses recommonmark's parser to convert markdown
-source_parsers = {
-    '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:

--- a/docs/source/contrib.md
+++ b/docs/source/contrib.md
@@ -5,5 +5,5 @@ project please first take a look at the
 [Project Jupyter Contributor Documentation](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html). 
  
  Prior to your contribution, we strongly recommend getting acquainted with Enterprise Gateway by checking 
- out the [Development Workflow](devinstall.html) and [System Architecture](system-architecture.html) pages.
+ out the [Development Workflow](devinstall.md) and [System Architecture](system-architecture.md) pages.
 

--- a/docs/source/debug.md
+++ b/docs/source/debug.md
@@ -1,6 +1,6 @@
 ## Debugging Jupyter Enterprise Gateway
 This page discusses how to go about debugging Enterprise Gateway.  We also provide troubleshooting information
-on our [Troubleshooting](troubleshooting.html) page.
+on our [Troubleshooting](troubleshooting.md) page.
 
 ### Configuring your IDE for debugging Jupyter Enterprise Gateway
 

--- a/docs/source/devinstall.md
+++ b/docs/source/devinstall.md
@@ -138,7 +138,7 @@ make itest
 
 ### Build the docker images
 
-The following can be used to build all docker images used within the project.  See [docker images](docker.html) for specific details.
+The following can be used to build all docker images used within the project.  See [docker images](docker.md) for specific details.
 
 ```
 make docker-images

--- a/docs/source/getting-started.md
+++ b/docs/source/getting-started.md
@@ -94,15 +94,16 @@ conda uninstall jupyter_enterprise_gateway
 
 To leverage the full distributed capabilities of Spark, Jupyter Enterprise Gateway has provided deep integration with various resource managers. Having said that, Enterprise Gateway also supports running in a pseudo-distributed mode utilizing for example both YARN client or Spark Standalone modes. We've also recently added Kubernetes, Docker Swarm and IBM Spectrum Conductor integrations.
 
-Please follow the links below to learn specific details about how to enable/configure the different modes of depoloying your kernels:
+Please follow the links below to learn specific details about how to enable/configure the different modes of deploying your kernels:
 
-* [Distributed](kernel-distributed.html)
-* [YARN Cluster Mode](kernel-yarn-cluster-mode.html)
-* [YARN Client Mode](kernel-yarn-client-mode.html)
-* [Standalone](kernel-spark-standalone.html)
-* [Kubernetes](kernel-kubernetes.html)
-* [Docker Swarm](kernel-docker.html)
-* [IBM Spectrum Conducto](kernel-conductor.html)
+* [Distributed](kernel-distributed.md)
+* [YARN Cluster Mode](kernel-yarn-cluster-mode.md)
+* [YARN Client Mode](kernel-yarn-client-mode.md)
+* [Spark Standalone](kernel-spark-standalone.md)
+* [Kubernetes](kernel-kubernetes.md)
+* [Docker Swarm](kernel-docker.md)
+* [IBM Spectrum Conductor](kernel-conductor.md)
+* [Standalone Remote Kernel Execution](kernel-library.md)
 
 In each of the resource manager sections, we set the `KERNELS_FOLDER` to `/usr/local/share/jupyter/kernels` since that's one of the default locations searched by the Jupyter framework.  Co-locating kernelspecs hierarchies in the same parent folder is recommended, although not required.
 

--- a/docs/source/kernel-conductor.md
+++ b/docs/source/kernel-conductor.md
@@ -1,6 +1,6 @@
 ## IBM Spectrum Conductor
 
-This information will be added shortly.  The configuration is similar to that of [YARN Cluster mode](kernel-yarn-cluster-mode.html) with the `ConductorClusterProcessProxy` used in place of `YARNClusterProcessProxy`.
+This information will be added shortly.  The configuration is similar to that of [YARN Cluster mode](kernel-yarn-cluster-mode.md) with the `ConductorClusterProcessProxy` used in place of `YARNClusterProcessProxy`.
 
 The following sample kernelspecs are currently available on Conductor:
 

--- a/docs/source/kernel-local.md
+++ b/docs/source/kernel-local.md
@@ -25,7 +25,7 @@ If you just want to try EG in a local setup, you can use the following kernelspe
 
 `process_proxy` is optional (if Enterprise Gateway encounters a kernelspec without the `process_proxy` stanza, it will treat that kernelspec as if it contained `LocalProcessProxy`).
 
-Side note: You can run a Local kernel in [Distributed mode](./kernel-distributed.html) by setting `remote_hosts` to the localhost. Why would you do that?
+Side note: You can run a Local kernel in [Distributed mode](./kernel-distributed.md) by setting `remote_hosts` to the localhost. Why would you do that?
 
 1. One reason is that it decreases the window in which a port conflict can occur since the 5 kernel ports are created by the launcher (within the same process and therefore closer to the actual invocation of the kernel) rather than by the server prior to the launch of the kernel process.
 2. The second reason is that auto-restarted kernels - when an issue occurs - say due to a port conflict - will create a new set of ports rather than try to re-use the same set that produced the failure in the first place. In this case, you'd want to use the [per-kernel configuration](./config-options.html#per-kernel-configuration-overrides) approach and set `remote_hosts` in the config stanza of the `process_proxy` stanza (using the stanza instead of the global `EG_REMOTE_HOSTS` allows you to not interfere with the other resource managers configuration, e.g. Spark Standalone or YARN Client kernels - Those other kernels need to be able to continue leveraging the full cluster nodes).

--- a/docs/source/kernel-yarn-client-mode.md
+++ b/docs/source/kernel-yarn-client-mode.md
@@ -4,7 +4,7 @@ By default, Jupyter Enterprise Gateway provides feature parity with Jupyter Kern
 
 Having said that, even if you are not leveraging the full distributed capabilities of Jupyter Enterprise Gateway, client mode can still help mitigate resource starvation by enabling a pseudo-distributed mode, where kernels are started in different nodes of the cluster utilizing a round-robin algorithm. In this case, you can still experience bottlenecks on a given node that receives requests to start "large" kernels, but otherwise, you will be better off compared to when all kernels are started on a single node or as local processes, which is the default for vanilla Jupyter Notebook.
 
-Please note also the YARN client mode can be considered as a [Distributed](./kernel-distributed.html) mode. It just happen to use spark-submit form different nodes in the cluster but uses `DistributedProcessProxy`.
+Please note also the YARN client mode can be considered as a [Distributed](./kernel-distributed.md) mode. It just happen to use spark-submit form different nodes in the cluster but uses `DistributedProcessProxy`.
 
 The following sample kernelspecs are currently available on YARN client:
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -1,7 +1,7 @@
 ## Troubleshooting
 
 This page identifies scenarios we've encountered when running Enterprise Gateway.  We also provide 
-instructions for setting up a debug environment on our [Debugging Jupyter Enterprise Gateway](debug.html) page.
+instructions for setting up a debug environment on our [Debugging Jupyter Enterprise Gateway](debug.md) page.
 
 - **None of the scenarios on this page match or resolve my issue, what do I do next?**
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -31,9 +31,9 @@ dependencies:
 
   # Documentation Requirements
   - sphinx_rtd_theme
-  - sphinx=1.8.3
+  - sphinx>=3
   - recommonmark
-  #- sphinx-markdown-tables
+  - sphinx-markdown-tables
 
   - pip:
-    - notebook>=6.1.0rc1
+    - notebook>=6.1.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ Apache Spark, Kubernetes and others..
         'jupyter_client>=6.1',
         'jupyter_core>=4.6.0',
         'kubernetes>=4.0.0',
-        'notebook>=6.1.0rc1',
+        'notebook>=6.1.0',
         'paramiko>=2.1.2',
         'pexpect>=4.2.0',
         'pycryptodomex>=3.9.7',


### PR DESCRIPTION
Sphinx 3.0+ was breaking doc builds because we were still using deprecated items (source_parsers) that were deprecated in 1.8 and removed in 3.0.  This change updates those and restores references to .md files where we can (still can reference an anchor w/o .html).

This PR is coming from this repo because I needed to temporarily point at the `fix-doc-build` branch to ensure docs were building correctly.