### PR TITLE
Force Python 3.7 to avoid PySpark 2.4.x limitation

### DIFF
--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -247,7 +247,7 @@ but it failed with a "Kernel error" and a SSHException.**
 - **PySpark 2.4.x fails on Python 3.8**
 
    PySpark 2.4.x fails on Python 3.8 as described in [SPARK-29536](https://issues.apache.org/jira/browse/SPARK-29536).
-   Use Python 3.7.x as the issue only seem to have been resolved on Spark 3.0.
+   Use Python 3.7.x as the issue only seems to have been resolved on Spark 3.0.
 
 - **I'm trying to use a notebook with user impersonation on a Kerberos enabled cluster but it fails to authenticate.**
 

--- a/docs/source/troubleshooting.md
+++ b/docs/source/troubleshooting.md
@@ -244,6 +244,11 @@ but it failed with a "Kernel error" and a SSHException.**
    To address this issue, increase the amount of memory available for your YARN application or another
    Resource Manager managing the kernel.
 
+- **PySpark 2.4.x fails on Python 3.8**
+
+   PySpark 2.4.x fails on Python 3.8 as described in [SPARK-29536](https://issues.apache.org/jira/browse/SPARK-29536).
+   Use Python 3.7.x as the issue only seem to have been resolved on Spark 3.0.
+
 - **I'm trying to use a notebook with user impersonation on a Kerberos enabled cluster but it fails to authenticate.**
 
     When using user impersonation in a YARN cluster with Kerberos authentication, if Kerberos is not

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -92,13 +92,11 @@ RUN curl -sL https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SP
 RUN cd /usr/hdp/current && ln -s ./hadoop-$HADOOP_VER hadoop && ln -s ./spark-${SPARK_VER}-bin-hadoop2.7 spark2-client
 
 # INSTALL MINI-CONDA AND PYTHON PACKAGES
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O ~/miniconda.sh && \
     /bin/bash ~/miniconda.sh -f -b -p $ANACONDA_HOME && \
     rm ~/miniconda.sh && \
     conda clean -tipsy && \
-    rm -rf /home/$NB_USER/.cache/yarn && \
-    fix-permissions $ANACONDA_HOME && \
-    fix-permissions /home/$NB_USER
+    rm -rf /home/$NB_USER/.cache/yarn
 
 USER root
 


### PR DESCRIPTION
Spark/PySpark 2.4.x dependency cloudpickle.py has an issue with
Python 3.8 which is described in SPARK-29536 and is only fixed
on Spark 3.0.
    
Fixes #859
