### PR TITLE
Fix build to produce correctly tagged image of demo-base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,9 @@ docker-images:  ## Build docker images (includes kernel-based images)
 kernel-images: ## Build kernel-based docker images
 
 # Actual working targets...
-docker-images enterprise-gateway-demo nb2kg kernel-images enterprise-gateway kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py kernel-image-puller:
+docker-images: demo-base enterprise-gateway-demo nb2kg kernel-images enterprise-gateway kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py kernel-image-puller
+
+enterprise-gateway-demo nb2kg kernel-images enterprise-gateway kernel-py kernel-spark-py kernel-r kernel-spark-r kernel-scala kernel-tf-py kernel-tf-gpu-py kernel-image-puller:
 	make WHEEL_FILE=$(WHEEL_FILE) VERSION=$(VERSION) NO_CACHE=$(NO_CACHE) TAG=$(TAG) SPARK_VERSION=$(SPARK_VERSION) -C etc $@
 
 demo-base:


### PR DESCRIPTION
The recent changes to tag demo-base with the SPARK_VERSION rather than the release didn't quite handle the case where `make docker-images` is used - which produces a release-based tag for demo-base.  This minor change fixes that.  Here's the output of `make -n docker-images` (note the different TAG value for demo-base and the rest):
```
$ make -n docker-images
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=2.4.6 SPARK_VERSION=2.4.6 -C etc demo-base
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc enterprise-gateway-demo
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc nb2kg
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-images
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc enterprise-gateway
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-py
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-spark-py
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-r
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-spark-r
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-scala
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-tf-py
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-tf-gpu-py
make WHEEL_FILE=dist/jupyter_enterprise_gateway-2.3.0.dev1-py2.py3-none-any.whl VERSION=2.3.0.dev1 NO_CACHE= TAG=dev SPARK_VERSION=2.4.6 -C etc kernel-image-puller
```