### PR TITLE
Update deprecated reference in rbac apiVersion

### DIFF
--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -140,7 +140,7 @@ metadata:
     app: enterprise-gateway
     component: enterprise-gateway
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: enterprise-gateway-controller
@@ -155,7 +155,7 @@ rules:
     resources: ["rolebindings"]
     verbs: ["get", "list", "create", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: enterprise-gateway-controller
@@ -175,7 +175,7 @@ roleRef:
 The `enterprise-gateway.yaml` file also defines the minimally viable roles for a kernel pod - most of which are required for Spark support.  Since kernels, by default, reside within their own namespace created upon their launch, a cluster role is used within a namespace-scoped role binding created when the kernel's namespace is created. The name of the kernel cluster role is `kernel-controller` and, when Enterprise Gateway creates the namespace and role binding, is also the name of the role binding instance.
 
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kernel-controller
@@ -209,7 +209,7 @@ metadata:
     app: enterprise-gateway
     component: kernel
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kernel-controller

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -16,7 +16,7 @@ metadata:
     app: enterprise-gateway
     component: enterprise-gateway
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: enterprise-gateway-controller
@@ -31,7 +31,7 @@ rules:
     resources: ["rolebindings"]
     verbs: ["get", "list", "create", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   # Referenced by EG_KERNEL_CLUSTER_ROLE below
@@ -44,7 +44,7 @@ rules:
     resources: ["pods"]
     verbs: ["get", "watch", "list", "create", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: enterprise-gateway-controller

--- a/etc/kubernetes/helm/enterprise-gateway/templates/clusterrole.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: enterprise-gateway-controller
@@ -17,7 +17,7 @@ rules:
     resources: ["rolebindings"]
     verbs: ["get", "list", "create", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   # Referenced by EG_KERNEL_CLUSTER_ROLE in the Deployment

--- a/etc/kubernetes/helm/enterprise-gateway/templates/clusterrolebinding.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: enterprise-gateway-controller


### PR DESCRIPTION
Update the reference for apiVersion used in rbac authorization definitions to use the `v1` release and not `v1beta1` which has been deprecated.

Fixes #869