### PR TITLE
Kubernetes Deployment Typo

### DIFF
--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -76,6 +76,6 @@ spec:
           mountPath: "/usr/local/share/jupyter/kernels"
       volumes:
       - name: image-kernelspecs
-        emptydir:
+        emptyDir:
           medium: Memory
 {{- end }}


### PR DESCRIPTION
Specifically when a kernel spec image is specified, emptydir get generated which is not valid, emtyDir is. 