### PR TITLE
Make kill() a sync method

### DIFF
--- a/enterprise_gateway/services/processproxies/conductor.py
+++ b/enterprise_gateway/services/processproxies/conductor.py
@@ -9,6 +9,7 @@ import re
 import signal
 import socket
 import subprocess
+import time
 
 from jupyter_client import launch_kernel, localinterfaces
 
@@ -113,7 +114,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
         else:
             return super(ConductorClusterProcessProxy, self).send_signal(signum)
 
-    async def kill(self):
+    def kill(self):
         """Kill a kernel.
         :return: None if the application existed and is not in RUNNING state, False otherwise.
         """
@@ -126,7 +127,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
             i = 1
             state = self._query_app_state_by_driver_id(self.driver_id)
             while state not in ConductorClusterProcessProxy.final_states and i <= max_poll_attempts:
-                await asyncio.sleep(poll_interval)
+                time.sleep(poll_interval)
                 state = self._query_app_state_by_driver_id(self.driver_id)
                 i = i + 1
 
@@ -239,7 +240,7 @@ class ConductorClusterProcessProxy(RemoteProcessProxy):
                 else:
                     reason = "App {} is WAITING, but waited too long ({} secs) to get connection file". \
                         format(self.application_id, self.kernel_launch_timeout)
-            await self.kill()
+            await asyncio.get_event_loop().run_in_executor(None, self.kill)
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
             self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)
 

--- a/enterprise_gateway/services/processproxies/distributed.py
+++ b/enterprise_gateway/services/processproxies/distributed.py
@@ -146,7 +146,7 @@ class DistributedProcessProxy(RemoteProcessProxy):
                      "log ({}:{}) for more information.".\
                 format(self.kernel_launch_timeout, self.assigned_host, self.kernel_log)
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
-            self.kill()
+            await asyncio.get_event_loop().run_in_executor(None, self.kill)
             self.log_and_raise(http_status_code=500, reason=timeout_message)
 
     def cleanup(self):

--- a/enterprise_gateway/services/processproxies/yarn.py
+++ b/enterprise_gateway/services/processproxies/yarn.py
@@ -326,7 +326,7 @@ class YarnClusterProcessProxy(RemoteProcessProxy):
                     reason = "App {} is RUNNING, but waited too long ({} secs) to get connection file.  " \
                              "Check YARN logs for more information.".format(self.application_id,
                                                                             self.kernel_launch_timeout)
-            self.kill()
+            await asyncio.get_event_loop().run_in_executor(None, self.kill)
             timeout_message = "KernelID: '{}' launch timeout due to: {}".format(self.kernel_id, reason)
             self.log_and_raise(http_status_code=error_http_code, reason=timeout_message)
 


### PR DESCRIPTION
Turns out we cannot convert the EG process-proxy process-based methods (e.g., `kill()`, `poll()`) because they are not async to begin with, nor are the `jupyter_client` methods (e.g., `send_signal()`, `cleanup()`) that call them.  Since the "mishmash" of `kill()` methods were constrained to just that method, it's best to make it synchronous and use `time.sleep()` for its polling - where needed.  However, when the process-proxy `kill()` is called from an async method - like `handle_timeout()`, we will wrap its call in `asyncio.get_event_loop().run_in_executor()`, which can be awaited, thereby retaining async behavior where it's really necessary.

Fixes #882