### PR TITLE
Flow KERNEL_IMAGE value for kernel launch

### DIFF
--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -26,6 +26,10 @@ prohibited_gids = os.getenv("EG_PROHIBITED_GIDS", "0").split(',')
 
 mirror_working_dirs = bool((os.getenv('EG_MIRROR_WORKING_DIRS', 'false').lower() == 'true'))
 
+# Get the globally-configured default images.  Defaulting to None if not set.
+default_kernel_image = os.getenv('EG_KERNEL_IMAGE')
+default_kernel_executor_image = os.getenv('EG_KERNEL_EXECUTOR_IMAGE')
+
 
 class ContainerProcessProxy(RemoteProcessProxy):
     """Kernel lifecycle management for container-based kernels."""
@@ -33,27 +37,31 @@ class ContainerProcessProxy(RemoteProcessProxy):
         super(ContainerProcessProxy, self).__init__(kernel_manager, proxy_config)
         self.container_name = ''
         self.assigned_node_ip = None
-        self._determine_kernel_images(proxy_config)
 
-    def _determine_kernel_images(self, proxy_config):
+    def _determine_kernel_images(self, **kwargs):
         """Determine which kernel images to use.
 
         Initialize to any defined in the process proxy override that then let those provided
         by client via env override.
         """
-        if proxy_config.get('image_name'):
-            self.kernel_image = proxy_config.get('image_name')
-        self.kernel_image = os.environ.get('KERNEL_IMAGE', self.kernel_image)
+        kernel_image = self.proxy_config.get('image_name', default_kernel_image)
+        self.kernel_image = kwargs['env'].get('KERNEL_IMAGE', kernel_image)
 
-        self.kernel_executor_image = self.kernel_image  # Default the executor image to current image
-        if proxy_config.get('executor_image_name'):
-            self.kernel_executor_image = proxy_config.get('executor_image_name')
-        self.kernel_executor_image = os.environ.get('KERNEL_EXECUTOR_IMAGE', self.kernel_executor_image)
+        if self.kernel_image is None:
+            self.log_and_raise(http_status_code=500,
+                               reason="No kernel image could be determined! Set the `image_name` in the "
+                                      "process_proxy.config stanza of the corresponding kernel.json file.")
+
+        # If no default executor image is configured, default it to current image
+        kernel_executor_image = self.proxy_config.get('executor_image_name',
+                                                      default_kernel_executor_image or self.kernel_image)
+        self.kernel_executor_image = kwargs['env'].get('KERNEL_EXECUTOR_IMAGE', kernel_executor_image)
 
     async def launch_process(self, kernel_cmd, **kwargs):
         """Launches the specified process within the container environment."""
         # Set env before superclass call so we see these in the debug output
 
+        self._determine_kernel_images(**kwargs)
         kwargs['env']['KERNEL_IMAGE'] = self.kernel_image
         kwargs['env']['KERNEL_EXECUTOR_IMAGE'] = self.kernel_executor_image
 

--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -113,6 +113,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
             The dictionary of per-kernel config settings.  If none are specified, this will be an empty dict.
         """
         self.kernel_manager = kernel_manager
+        self.proxy_config = proxy_config
         # Initialize to 0 IP primarily so restarts of remote kernels don't encounter local-only enforcement during
         # relaunch (see jupyter_client.manager.start_kernel().
         self.kernel_manager.ip = '0.0.0.0'
@@ -127,7 +128,7 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
         self.kernel_launch_timeout = default_kernel_launch_timeout
         self.lower_port = 0
         self.upper_port = 0
-        self._validate_port_range(proxy_config)
+        self._validate_port_range()
 
         # Handle authorization sets...
         # Take union of unauthorized users...
@@ -489,12 +490,12 @@ class BaseProcessProxyABC(with_metaclass(abc.ABCMeta, object)):
         self.ip = process_info['ip']
         self.kernel_manager.ip = process_info['ip']
 
-    def _validate_port_range(self, proxy_config):
+    def _validate_port_range(self):
         """Validates the port range configuration option to ensure appropriate values."""
         # Let port_range override global value - if set on kernelspec...
         port_range = self.kernel_manager.port_range
-        if proxy_config.get('port_range'):
-            port_range = proxy_config.get('port_range')
+        if self.proxy_config.get('port_range'):
+            port_range = self.proxy_config.get('port_range')
 
         try:
             port_ranges = port_range.split("..")


### PR DESCRIPTION
It was recently discovered that `KERNEL_IMAGE` did not flow from the client to be used during the kernel launch. Although this is a limited use case, as it requires the same image be used for a specific client regardless of the selected kernel, there are use cases where it makes sense (see #884).  This pull request makes the necessary changes such that a payload env of `KERNEL_IMAGE` will be used for that request's kernel launch.

The current definition of `KERNEL_IMAGE` is renamed to `EG_KERNEL_IMAGE` and has no default.  This env would be set if an administrator needed to use the same image across all kernel launch requests (again, very limited utility).  The precedence hierarchy, from lowest to highest, is as follows:

1. Use `EG_KERNEL_IMAGE`.
2. Use `image_name` from `process_proxy.config` from the `kernel.json` file.  (Common case)
3. Use `KERNEL_IMAGE` from client.

Fixes: #886 
Closes: #884