### PR TITLE
Handle supporting using both pycryptdome and pycryptodomex

### DIFF
--- a/enterprise_gateway/services/processproxies/processproxy.py
+++ b/enterprise_gateway/services/processproxies/processproxy.py
@@ -27,7 +27,11 @@ from ipython_genutils.py3compat import with_metaclass
 from jupyter_client import launch_kernel, localinterfaces
 from notebook import _tz
 from zmq.ssh import tunnel
-from Cryptodome.Cipher import AES
+
+try:
+    from Cryptodome.Cipher import AES
+except ImportError:
+    from Crypto.Cipher import AES
 
 from ..sessions.kernelsessionmanager import KernelSessionManager
 

--- a/etc/kernel-launchers/python/scripts/launch_ipykernel.py
+++ b/etc/kernel-launchers/python/scripts/launch_ipykernel.py
@@ -11,7 +11,11 @@ from multiprocessing import Process
 from random import random
 from threading import Thread
 
-from Cryptodome.Cipher import AES
+try:
+    from Cryptodome.Cipher import AES
+except ImportError:
+    from Crypto.Cipher import AES
+
 from ipython_genutils.py3compat import str_to_bytes
 from jupyter_client.connect import write_connection_file
 


### PR DESCRIPTION
In some environment pycryptodome is being used instead of pycryptodomex and can't be easily changed. This try/catch handles supporting using both pycryptdome and pycryptodomex.