### PR TITLE
EG_KERNEL_WHITELIST: include brackets in start-enterprise-gateway.sh 

### DIFF
--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -91,7 +91,7 @@ spec:
         - name: EG_KERNEL_LAUNCH_TIMEOUT
           value: "60"
         - name: EG_KERNEL_WHITELIST
-          value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
+          value: "'r_kubernetes','python_kubernetes','python_tf_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes'"
         - name: EG_DEFAULT_KERNEL_NAME
           value: "python_kubernetes"
 
@@ -300,7 +300,7 @@ for the container specification and `volumes` in the pod specification):
         - name: EG_KERNEL_LAUNCH_TIMEOUT
           value: "60"
         - name: EG_KERNEL_WHITELIST
-          value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','python_tf_gpu_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
+          value: "'r_kubernetes','python_kubernetes','python_tf_kubernetes','python_tf_gpu_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes'"
         image: elyra/enterprise-gateway:VERSION
         name: enterprise-gateway
         args: ["--gateway"]

--- a/etc/docker/docker-compose.yml
+++ b/etc/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK:-enterprise-gateway_enterprise-gateway}"
       - "EG_KERNEL_LAUNCH_TIMEOUT=${EG_KERNEL_LAUNCH_TIMEOUT:-60}"
       - "EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-3600}"
-      - "EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-['r_docker','python_docker','python_tf_docker','python_tf_gpu_docker','scala_docker']}"
+      - "EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-'r_docker','python_docker','python_tf_docker','python_tf_gpu_docker','scala_docker'}"
       - "EG_MIRROR_WORKING_DIRS=${EG_MIRROR_WORKING_DIRS:-False}"
       - "KG_PORT=${KG_PORT:-8888}"
     networks:

--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -26,7 +26,8 @@ export EG_LOG_LEVEL=${EG_LOG_LEVEL:-DEBUG}
 export EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-43200}  # default to 12 hours
 export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-60}
 export EG_CULL_CONNECTED=${EG_CULL_CONNECTED:-False}
-export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"'r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker'"}
+EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"'r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker'"}
+export EG_KERNEL_WHITELIST=`echo ${EG_KERNEL_WHITELIST} | sed 's/[][]//g'`
 export EG_DEFAULT_KERNEL_NAME=${EG_DEFAULT_KERNEL_NAME:-python_docker}
 
 

--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -27,7 +27,7 @@ export EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-43200}  # default to 12 hour
 export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-60}
 export EG_CULL_CONNECTED=${EG_CULL_CONNECTED:-False}
 EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"'r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker'"}
-export EG_KERNEL_WHITELIST=`echo ${EG_KERNEL_WHITELIST} | sed 's/[][]//g'`
+export EG_KERNEL_WHITELIST=`echo ${EG_KERNEL_WHITELIST} | sed 's/[][]//g'` # sed is used to strip off surrounding brackets as they should no longer be included.
 export EG_DEFAULT_KERNEL_NAME=${EG_DEFAULT_KERNEL_NAME:-python_docker}
 
 

--- a/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
+++ b/etc/docker/enterprise-gateway/start-enterprise-gateway.sh
@@ -26,7 +26,7 @@ export EG_LOG_LEVEL=${EG_LOG_LEVEL:-DEBUG}
 export EG_CULL_IDLE_TIMEOUT=${EG_CULL_IDLE_TIMEOUT:-43200}  # default to 12 hours
 export EG_CULL_INTERVAL=${EG_CULL_INTERVAL:-60}
 export EG_CULL_CONNECTED=${EG_CULL_CONNECTED:-False}
-export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"['r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker']"}
+export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"'r_docker','python_docker','python_tf_docker','scala_docker','spark_r_docker','spark_python_docker','spark_scala_docker'"}
 export EG_DEFAULT_KERNEL_NAME=${EG_DEFAULT_KERNEL_NAME:-python_docker}
 
 
@@ -34,7 +34,7 @@ echo "Starting Jupyter Enterprise Gateway..."
 
 exec jupyter enterprisegateway \
 	--log-level=${EG_LOG_LEVEL} \
-	--KernelSpecManager.whitelist=${EG_KERNEL_WHITELIST} \
+	--KernelSpecManager.whitelist=[${EG_KERNEL_WHITELIST}] \
 	--RemoteMappingKernelManager.cull_idle_timeout=${EG_CULL_IDLE_TIMEOUT} \
 	--RemoteMappingKernelManager.cull_interval=${EG_CULL_INTERVAL} \
 	--RemoteMappingKernelManager.cull_connected=${EG_CULL_CONNECTED} \

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -138,7 +138,7 @@ spec:
           value: "60"
 
         - name: EG_KERNEL_WHITELIST
-          value: "['r_kubernetes','python_kubernetes','python_tf_kubernetes','python_tf_gpu_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes']"
+          value: "'r_kubernetes','python_kubernetes','python_tf_kubernetes','python_tf_gpu_kubernetes','scala_kubernetes','spark_r_kubernetes','spark_python_kubernetes','spark_scala_kubernetes'"
 
         - name: EG_DEFAULT_KERNEL_NAME
           value: "python_kubernetes"


### PR DESCRIPTION
to make `EG_KERNEL_WHITELIST` consistent with other environment variable lists such as `EG_ENV_PROCESS_WHITELIST`.

Currently `EG_ENV_PROCESS_WHITELIST` is just comma separated: 
`EG_ENV_PROCESS_WHITELIST=A,B,C`

While `EG_KERNEL_WHITELIST` is comma separated and surrounded by square brackets: 
`EG_KERNEL_WHITELIST=['docker_py','docker_r']`

This PR proposes to drop the brackers on `EG_KERNEL_WHITELIST`.
`EG_KERNEL_WHITELIST='docker_py','docker_r'`

I'm not an expert on bash environment variables and thus not sure whether this is the cleanest/safest way to add "[...]" brackets.

@kevin-bates suggested on Gitter to make a PR. Hopefully this can serve as a starting point for a PR, perhaps someone with more familiarity with the EG code base can check whether it's comprehensive. I used code search to find all occurrences of `EG_KERNEL_WHITELIST`.

Note: it should be considered whether consistency is more important than backwards compatibility as with the currently proposed PR existing bracket including values of EG_KERNEL_WHITELIST will break. Adding bash code that will check `start-enterprise-gateway.sh` is possible but feels polluting.

