### PR TITLE
Add ability to allow all envs in kernel request body

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -149,6 +149,7 @@ EnterpriseGatewayApp options
 --EnterpriseGatewayApp.env_whitelist=<List>
     Default: []
     Environment variables allowed to be set when a client requests a new kernel.
+    Use '*' to allow all environment variables sent in the request.
     (EG_ENV_WHITELIST env var)
 --EnterpriseGatewayApp.expose_headers=<Unicode>
     Default: ''

--- a/enterprise_gateway/mixins.py
+++ b/enterprise_gateway/mixins.py
@@ -312,7 +312,8 @@ class EnterpriseGatewayConfigMixin(Configurable):
     env_whitelist_env = 'EG_ENV_WHITELIST'
     env_whitelist = List(config=True,
                          help="""Environment variables allowed to be set when a client requests a
-                         new kernel. (EG_ENV_WHITELIST env var)""")
+                         new kernel. Use '*' to allow all environment variables sent in the request.
+                         (EG_ENV_WHITELIST env var)""")
 
     @default('env_whitelist')
     def env_whitelist_default(self):

--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -57,9 +57,13 @@ class MainKernelHandler(TokenAuthorizationMixin,
             # Whitelist environment variables from current process environment
             env.update({key: value for key, value in os.environ.items()
                         if key in self.env_process_whitelist})
-            # Whitelist KERNEL_* args and those allowed by configuration from client
+            # Whitelist KERNEL_* args and those allowed by configuration from client.  If all
+            # envs are requested, just use the keys from the payload.
+            env_whitelist = self.env_whitelist
+            if env_whitelist == ['*']:
+                env_whitelist = model['env'].keys()
             env.update({key: value for key, value in model['env'].items()
-                        if key.startswith('KERNEL_') or key in self.env_whitelist})
+                        if key.startswith('KERNEL_') or key in env_whitelist})
 
             # If kernel_headers are configured, fetch each of those and include in start request
             kernel_headers = {}

--- a/enterprise_gateway/tests/test_handlers.py
+++ b/enterprise_gateway/tests/test_handlers.py
@@ -662,3 +662,43 @@ class TestRelativeBaseURL(TestHandlers):
             method='GET'
         )
         self.assertEqual(response.code, 200)
+
+
+class TestWildcardEnvs(TestHandlers):
+    """Base class for jupyter-websocket mode tests that spawn kernels."""
+
+    def setup_app(self):
+        """Configure JUPYTER_PATH so that we can use local kernelspec files for testing.
+        """
+        super().setup_app()
+        # overwrite env_whitelist
+        self.app.env_whitelist = ['*']
+
+    @gen_test
+    def test_kernel_wildcard_env(self):
+        """Kernel should start with environment vars defined in the request."""
+        # Note: Since env_whitelist == '*', all values should be present.
+        kernel_body = json.dumps({
+            'name': 'python',
+            'env': {
+                'KERNEL_FOO': 'kernel-foo-value',
+                'OTHER_VAR1': 'other-var1-value',
+                'OTHER_VAR2': 'other-var2-value',
+                'TEST_VAR': 'test-var-value'
+            }
+        })
+        ws = yield self.spawn_kernel(kernel_body)
+        req = self.execute_request('import os; '
+                                   'print(os.getenv("KERNEL_FOO"), '
+                                   'os.getenv("OTHER_VAR1"), '
+                                   'os.getenv("OTHER_VAR2"), '
+                                   'os.getenv("TEST_VAR"))')
+        ws.write_message(json_encode(req))
+        content = yield self.await_stream(ws)
+        self.assertEqual(content['name'], 'stdout')
+        self.assertIn('kernel-foo-value', content['text'])
+        self.assertIn('other-var1-value', content['text'])
+        self.assertIn('other-var2-value', content['text'])
+        self.assertIn('test-var-value', content['text'])
+
+        ws.close()


### PR DESCRIPTION
This change enables the ability to allow all envs specified in the kernel start request body to be passed to the kernel.  Previously only those envs specified in the KernelManager.env_whitelist were permitted (in addition to all those prefixed with `KERNEL_`).  With this change, setting `c.KernelManagert.env_whitelist = ['*']` or `EG_ENV_WHITELIST = "*"` will result in all envs specified in the request body _flowing_ to the kernel.  This will be helpful when parameterization becomes more prevalent.