### PR TITLE
Remove python 3.5 from requirements, add 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.5', '3.6', '3.7', '3.8' ]
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/requirements.yml
+++ b/requirements.yml
@@ -17,6 +17,7 @@ dependencies:
   - requests>=2.7,<3.0
   - tornado>=4.2.0
   - traitlets>=4.2.0
+  - watchdog
   - yarn-api-client>=1.0
 
   # Test Requirements
@@ -24,7 +25,6 @@ dependencies:
   - nose
   - pytest
   - websocket-client
-  - watchdog
 
   # Code Style
   - flake8

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import setup
 here = os.path.abspath(os.path.dirname(__file__))
 
 v = sys.version_info
-if v[:2] < (3, 5):
-    error = "ERROR: Jupyter Enterprise Gateway requires Python version 3.5 or above."
+if v[:2] < (3, 6):
+    error = "ERROR: Jupyter Enterprise Gateway requires Python version 3.6 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 
@@ -64,7 +64,7 @@ Apache Spark, Kubernetes and others..
         'watchdog==0.10.3',  # 0.10.4 (latest) is broken on MacOS
         'yarn-api-client>=1.0',
     ],
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',


### PR DESCRIPTION
It's time to drop python 3.5.  