### PR TITLE
docs: remove misleading information on the default k8s in case of lib…

### DIFF
--- a/docs/source/kernel-library.md
+++ b/docs/source/kernel-library.md
@@ -19,4 +19,4 @@ client = NotebookClient(nb=test_notebook, kernel_manager_class=RemoteKernelManag
 client.execute()
 ```
 
-The above code will execute the notebook on a kernel using the configured `ProcessProxy` (defaults to Kubernetes).
+The above code will execute the notebook on a kernel using the configured `ProcessProxy`.


### PR DESCRIPTION
Remove misleading information present in the documentation on the default kubernetes in case of library usage.