### PR TITLE
Update build status to reflect GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Jupyter Enterprise Gateway Tests
+name: Builds
 on:
   push:
     branches: '*'
@@ -65,12 +65,7 @@ jobs:
     - name: Run integration tests
       run: |
         SA="source $CONDA_HOME/bin/activate" make itest-yarn
-    - name: Code coverage
-      if: success()
-      run: |
-        codecov
     - name: Collect logs
-      if: failure()
       run: |
         python --version
         pip --version

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@
 
 # Jupyter Enterprise Gateway
 
+[![Actions Status](https://github.com/jupyter/enterprise_gateway/workflows/Builds/badge.svg)](https://github.com/jupyter/enterprise_gateway/actions)
 [![PyPI version](https://badge.fury.io/py/jupyter-enterprise-gateway.svg)](https://badge.fury.io/py/jupyter-enterprise-gateway)
 [![Downloads](https://pepy.tech/badge/jupyter-enterprise-gateway/month)](https://pepy.tech/project/jupyter-enterprise-gateway/month)
-[![Build Status](https://travis-ci.org/jupyter/enterprise_gateway.svg?branch=master)](https://travis-ci.org/jupyter/enterprise_gateway)
 [![Documentation Status](https://readthedocs.org/projects/jupyter-enterprise-gateway/badge/?version=latest)](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/?badge=latest)
-[![Coverage Status](https://codecov.io/github/jupyter/enterprise_gateway/coverage.svg?branch=master)](https://codecov.io/github/jupyter/enterprise_gateway?branch=master)
 [![Google Group](https://img.shields.io/badge/google-group-blue.svg)](https://groups.google.com/forum/#!forum/jupyter) [![Join the chat at https://gitter.im/jupyter/enterprise_gateway](https://badges.gitter.im/jupyter/enterprise_gateway.svg)](https://gitter.im/jupyter/enterprise_gateway?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Jupyter Enterprise Gateway enables Jupyter Notebook to launch remote kernels in a distributed cluster,


### PR DESCRIPTION
This updates the build status badge on the README to reflect the GitHub actions results. I've also removed the code coverage badge (and run) since they weren't being used.

I suspect this may need to be merged prior to seeing the final result because the `name` property in the workflow file was updated as well.  This value becomes the label for the badge.