### PR TITLE
Update broken links to Jupyter pages

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -1,7 +1,7 @@
 ## Configuration options
 
-Jupyter Enterprise Gateway adheres to the
-[Jupyter common configuration approach](https://jupyter.readthedocs.io/en/latest/projects/config.html)
+Jupyter Enterprise Gateway adheres to
+[Jupyter's common configuration approach](https://jupyter.readthedocs.io/en/latest/use/config.html)
 . You can configure an instance of Enterprise Gateway using:
 
 1. A configuration file (recommended)

--- a/docs/source/contrib.md
+++ b/docs/source/contrib.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Jupyter Enterprise Gateway!  If you would like to contribute to the 
 project please first take a look at the 
-[Project Jupyter Contributor Documentation](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html). 
+[Project Jupyter Contributor Documentation](https://jupyter.readthedocs.io/en/latest/contributing/content-contributor.html).
  
  Prior to your contribution, we strongly recommend getting acquainted with Enterprise Gateway by checking 
  out the [Development Workflow](devinstall.md) and [System Architecture](system-architecture.md) pages.


### PR DESCRIPTION
Found a couple of broken links related to Jupyter doc refactoring.