### PR TITLE
fixes #960: lazy import of launch_instance in top-level __init__.py

### DIFF
--- a/enterprise_gateway/__init__.py
+++ b/enterprise_gateway/__init__.py
@@ -1,5 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-"""Entrypoint for the enterprise gateway package."""
-from .enterprisegatewayapp import launch_instance
 from ._version import __version__
+
+"""Lazy-loading entrypoint for the enterprise gateway package."""
+def launch_instance(*args, **kwargs):
+    from enterprise_gateway.enterprisegatewayapp import launch_instance
+    launch_instance(*args, **kwargs)

--- a/scripts/jupyter-enterprisegateway
+++ b/scripts/jupyter-enterprisegateway
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-# Copyright (c) Jupyter Development Team.
-# Distributed under the terms of the Modified BSD License.
-import enterprise_gateway
-
-if __name__ == '__main__':
-    enterprise_gateway.launch_instance()

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,6 @@ Apache Spark, Kubernetes and others..
         'enterprise_gateway.services.processproxies',
         'enterprise_gateway.services.sessions'
     ],
-    scripts=[
-        'scripts/jupyter-enterprisegateway'
-    ],
     install_requires=[
         'docker>=3.5.0',
         'future',
@@ -83,7 +80,7 @@ if 'setuptools' in sys.modules:
     # setupstools turns entrypoint scripts into executables on windows
     setup_args['entry_points'] = {
         'console_scripts': [
-            'jupyter-enterprisegateway = enterprise_gateway:launch_instance'
+            'jupyter-enterprisegateway = enterprise_gateway.enterprisegatewayapp:launch_instance'
         ]
     }
     # Don't bother installing the .py scripts if if we're using entrypoints


### PR DESCRIPTION
Fixes #960 by making the problem import lazy. Also removed redundant `"scripts"` field from `setup.py` (noticed that since I had to make a small tweak to both that and `"entry_points"`).

If making the `launch_instance` import lazy seems too convoluted, I think another valid fix would be to remove `launch_instance` from the module top-level entirely. It's sufficient to be able to do:

```python
from enterprise_gateway.enterprisegatewayapp import launch_instance
```