### PR TITLE
Changes necessary to get itest-docker passing

### DIFF
--- a/enterprise_gateway/itests/test_python_kernel.py
+++ b/enterprise_gateway/itests/test_python_kernel.py
@@ -11,11 +11,11 @@ class PythonKernelBaseTestCase(TestBase):
 
     def test_get_hostname(self):
         result = self.kernel.execute("import subprocess; subprocess.check_output(['hostname'])")
-        self.assertRegexpMatches(result, self.get_expected_hostname())
+        self.assertRegex(result, self.get_expected_hostname())
 
     def test_hello_world(self):
         result = self.kernel.execute("print('Hello World')")
-        self.assertRegexpMatches(result, 'Hello World')
+        self.assertRegex(result, 'Hello World')
 
     def test_restart(self):
 
@@ -30,7 +30,7 @@ class PythonKernelBaseTestCase(TestBase):
         self.assertTrue(self.kernel.restart())
 
         error_result = self.kernel.execute("y = x + 1")
-        self.assertRegexpMatches(error_result, 'NameError')
+        self.assertRegex(error_result, 'NameError')
 
     def test_interrupt(self):
 
@@ -58,7 +58,7 @@ class PythonKernelBaseTestCase(TestBase):
         interrupted_result = self.kernel.execute(interrupted_code)
 
         # Ensure the result indicates an interrupt occurred
-        self.assertRegexpMatches(interrupted_result, 'KeyboardInterrupt')
+        self.assertRegex(interrupted_result, 'KeyboardInterrupt')
 
         # Wait for thread to terminate - should be terminated already
         self.kernel.terminate_interrupt_thread()
@@ -89,19 +89,19 @@ class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
 
     def test_get_application_id(self):
         result = self.kernel.execute("sc.getConf().get('spark.app.id')")
-        self.assertRegexpMatches(result, self.get_expected_application_id())
+        self.assertRegex(result, self.get_expected_application_id())
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute("sc.getConf().get('spark.submit.deployMode')")
-        self.assertRegexpMatches(result, self.get_expected_deploy_mode())
+        self.assertRegex(result, self.get_expected_deploy_mode())
 
     def test_get_resource_manager(self):
         result = self.kernel.execute("sc.getConf().get('spark.master')")
-        self.assertRegexpMatches(result, self.get_expected_spark_master())
+        self.assertRegex(result, self.get_expected_spark_master())
 
     def test_get_spark_version(self):
         result = self.kernel.execute("sc.version")
-        self.assertRegexpMatches(result, self.get_expected_spark_version())
+        self.assertRegex(result, self.get_expected_spark_version())
 
     def test_run_pi_example(self):
         # Build the example code...
@@ -117,7 +117,7 @@ class PythonKernelBaseSparkTestCase(PythonKernelBaseTestCase):
         pi_code.append("count = sc.parallelize(range(1, n + 1), partitions).map(f).reduce(add)\n")
         pi_code.append("print(\"Pi is roughly %f\" % (4.0 * count / n))\n")
         result = self.kernel.execute(pi_code)
-        self.assertRegexpMatches(result, 'Pi is roughly 3.14*')
+        self.assertRegex(result, 'Pi is roughly 3.14*')
 
 
 class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
@@ -126,8 +126,7 @@ class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestPythonKernelLocal, cls).setUpClass()
-        print('>>>')
-        print('Starting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -136,7 +135,7 @@ class TestPythonKernelLocal(unittest.TestCase, PythonKernelBaseTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestPythonKernelLocal, cls).tearDownClass()
-        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
@@ -148,8 +147,7 @@ class TestPythonKernelDistributed(unittest.TestCase, PythonKernelBaseTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestPythonKernelDistributed, cls).setUpClass()
-        print('>>>')
-        print('Starting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -158,7 +156,7 @@ class TestPythonKernelDistributed(unittest.TestCase, PythonKernelBaseTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestPythonKernelDistributed, cls).tearDownClass()
-        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
@@ -170,8 +168,7 @@ class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseSparkTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestPythonKernelClient, cls).setUpClass()
-        print('>>>')
-        print('Starting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -180,7 +177,7 @@ class TestPythonKernelClient(unittest.TestCase, PythonKernelBaseSparkTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestPythonKernelClient, cls).tearDownClass()
-        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
@@ -192,8 +189,7 @@ class TestPythonKernelCluster(unittest.TestCase, PythonKernelBaseSparkTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestPythonKernelCluster, cls).setUpClass()
-        print('>>>')
-        print('Starting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -202,7 +198,8 @@ class TestPythonKernelCluster(unittest.TestCase, PythonKernelBaseSparkTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestPythonKernelCluster, cls).tearDownClass()
-        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 

--- a/enterprise_gateway/itests/test_r_kernel.py
+++ b/enterprise_gateway/itests/test_r_kernel.py
@@ -11,11 +11,11 @@ class RKernelBaseTestCase(TestBase):
 
     def test_get_hostname(self):
         result = self.kernel.execute('system("hostname", intern=TRUE)')
-        self.assertRegexpMatches(result, self.get_expected_hostname())
+        self.assertRegex(result, self.get_expected_hostname())
 
     def test_hello_world(self):
         result = self.kernel.execute('print("Hello World", quote = FALSE)')
-        self.assertRegexpMatches(result, 'Hello World')
+        self.assertRegex(result, 'Hello World')
 
     def test_restart(self):
 
@@ -30,7 +30,7 @@ class RKernelBaseTestCase(TestBase):
         self.assertTrue(self.kernel.restart())
 
         error_result = self.kernel.execute("y = x + 1")
-        self.assertRegexpMatches(error_result, 'Error in eval')
+        self.assertRegex(error_result, 'Error in eval')
 
     def test_interrupt(self):
 
@@ -74,19 +74,19 @@ class RKernelBaseSparkTestCase(RKernelBaseTestCase):
 
     def test_get_application_id(self):
         result = self.kernel.execute('SparkR:::callJMethod(SparkR:::callJMethod(sc, "sc"), "applicationId")')
-        self.assertRegexpMatches(result, self.get_expected_application_id())
+        self.assertRegex(result, self.get_expected_application_id())
 
     def test_get_spark_version(self):
         result = self.kernel.execute("sparkR.version()")
-        self.assertRegexpMatches(result, self.get_expected_spark_version())
+        self.assertRegex(result, self.get_expected_spark_version())
 
     def test_get_resource_manager(self):
         result = self.kernel.execute('unlist(sparkR.conf("spark.master"))')
-        self.assertRegexpMatches(result, self.get_expected_spark_master())
+        self.assertRegex(result, self.get_expected_spark_master())
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute('unlist(sparkR.conf("spark.submit.deployMode"))')
-        self.assertRegexpMatches(result, self.get_expected_deploy_mode())
+        self.assertRegex(result, self.get_expected_deploy_mode())
 
 
 class TestRKernelLocal(unittest.TestCase, RKernelBaseTestCase):
@@ -95,8 +95,7 @@ class TestRKernelLocal(unittest.TestCase, RKernelBaseTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestRKernelLocal, cls).setUpClass()
-        print('>>>')
-        print('Starting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -105,7 +104,8 @@ class TestRKernelLocal(unittest.TestCase, RKernelBaseTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestRKernelLocal, cls).tearDownClass()
-        print('Shutting down R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 
@@ -115,9 +115,7 @@ class TestRKernelClient(unittest.TestCase, RKernelBaseSparkTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestRKernelClient, cls).setUpClass()
-        print('>>>')
-        print('Starting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -126,7 +124,8 @@ class TestRKernelClient(unittest.TestCase, RKernelBaseSparkTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestRKernelClient, cls).tearDownClass()
-        print('Shutting down R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 
@@ -137,8 +136,7 @@ class TestRKernelCluster(unittest.TestCase, RKernelBaseSparkTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestRKernelCluster, cls).setUpClass()
-        print('>>>')
-        print('Starting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting R kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -147,7 +145,8 @@ class TestRKernelCluster(unittest.TestCase, RKernelBaseSparkTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestRKernelCluster, cls).tearDownClass()
-        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 

--- a/enterprise_gateway/itests/test_scala_kernel.py
+++ b/enterprise_gateway/itests/test_scala_kernel.py
@@ -13,11 +13,11 @@ class ScalaKernelBaseTestCase(TestBase):
         result = self.kernel.execute('import java.net._; \
                                       val localhost: InetAddress = InetAddress.getLocalHost; \
                                       val localIpAddress: String = localhost.getHostName')
-        self.assertRegexpMatches(result, self.get_expected_hostname())
+        self.assertRegex(result, self.get_expected_hostname())
 
     def test_hello_world(self):
         result = self.kernel.execute('println("Hello World")')
-        self.assertRegexpMatches(result, 'Hello World')
+        self.assertRegex(result, 'Hello World')
 
     def test_restart(self):
 
@@ -32,7 +32,7 @@ class ScalaKernelBaseTestCase(TestBase):
         self.assertTrue(self.kernel.restart())
 
         error_result = self.kernel.execute("var y = x + 1")
-        self.assertRegexpMatches(error_result, 'Compile Error')
+        self.assertRegex(error_result, 'Compile Error')
 
     def test_interrupt(self):
 
@@ -58,7 +58,7 @@ class ScalaKernelBaseTestCase(TestBase):
         interrupted_result = self.kernel.execute(interrupted_code)
 
         # Ensure the result indicates an interrupt occurred
-        self.assertRegexpMatches(interrupted_result, 'java.lang.InterruptedException')
+        self.assertRegex(interrupted_result, 'java.lang.InterruptedException')
 
         # Wait for thread to terminate - should be terminated already
         self.kernel.terminate_interrupt_thread()
@@ -76,19 +76,19 @@ class ScalaKernelBaseSparkTestCase(ScalaKernelBaseTestCase):
 
     def test_get_application_id(self):
         result = self.kernel.execute('sc.applicationId')
-        self.assertRegexpMatches(result, self.get_expected_application_id())
+        self.assertRegex(result, self.get_expected_application_id())
 
     def test_get_spark_version(self):
         result = self.kernel.execute("sc.version")
-        self.assertRegexpMatches(result, self.get_expected_spark_version())
+        self.assertRegex(result, self.get_expected_spark_version())
 
     def test_get_resource_manager(self):
         result = self.kernel.execute('sc.getConf.get("spark.master")')
-        self.assertRegexpMatches(result, self.get_expected_spark_master())
+        self.assertRegex(result, self.get_expected_spark_master())
 
     def test_get_deploy_mode(self):
         result = self.kernel.execute('sc.getConf.get("spark.submit.deployMode")')
-        self.assertRegexpMatches(result, self.get_expected_deploy_mode())
+        self.assertRegex(result, self.get_expected_deploy_mode())
 
 
 class TestScalaKernelLocal(unittest.TestCase, ScalaKernelBaseTestCase):
@@ -99,8 +99,7 @@ class TestScalaKernelLocal(unittest.TestCase, ScalaKernelBaseTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestScalaKernelLocal, cls).setUpClass()
-        print('>>>')
-        print('Starting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -109,7 +108,8 @@ class TestScalaKernelLocal(unittest.TestCase, ScalaKernelBaseTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestScalaKernelLocal, cls).tearDownClass()
-        print('Shutting down Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 
@@ -120,8 +120,7 @@ class TestScalaKernelClient(unittest.TestCase, ScalaKernelBaseSparkTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestScalaKernelClient, cls).setUpClass()
-        print('>>>')
-        print('Starting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -130,7 +129,8 @@ class TestScalaKernelClient(unittest.TestCase, ScalaKernelBaseSparkTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestScalaKernelClient, cls).tearDownClass()
-        print('Shutting down Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 
@@ -141,8 +141,7 @@ class TestScalaKernelCluster(unittest.TestCase, ScalaKernelBaseSparkTestCase):
     @classmethod
     def setUpClass(cls):
         super(TestScalaKernelCluster, cls).setUpClass()
-        print('>>>')
-        print('Starting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nStarting Scala kernel using {} kernelspec'.format(cls.KERNELSPEC))
 
         # initialize environment
         cls.gatewayClient = GatewayClient()
@@ -151,7 +150,8 @@ class TestScalaKernelCluster(unittest.TestCase, ScalaKernelBaseSparkTestCase):
     @classmethod
     def tearDownClass(cls):
         super(TestScalaKernelCluster, cls).tearDownClass()
-        print('Shutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+        print('\nShutting down Python kernel using {} kernelspec'.format(cls.KERNELSPEC))
+
         # shutdown environment
         cls.gatewayClient.shutdown_kernel(cls.kernel)
 

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -3,7 +3,9 @@ ARG BASE_CONTAINER=jupyter/r-notebook:04f7f60d34a6
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \
-    'r-argparse' && \
+    'r-argparse' \
+    jupyter_client \
+    pycryptodomex && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 

--- a/etc/kernel-launchers/docker/scripts/launch_docker.py
+++ b/etc/kernel-launchers/docker/scripts/launch_docker.py
@@ -50,6 +50,7 @@ def launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark
     # setup common args
     kwargs = dict()
     kwargs['name'] = container_name
+    kwargs['hostname'] = container_name
     kwargs['user'] = user
     kwargs['labels'] = labels
 
@@ -78,7 +79,6 @@ def launch_docker_kernel(kernel_id, port_range, response_addr, public_key, spark
         volumes = {'/usr/local/share/jupyter/kernels': {'bind': '/usr/local/share/jupyter/kernels', 'mode': 'ro'}}
 
         # finish args setup
-        kwargs['hostname'] = container_name
         kwargs['environment'] = param_env
         kwargs['remove'] = remove_container
         kwargs['network'] = docker_network


### PR DESCRIPTION
The `enterprise-gateway-swarm.sh` script was removed in pull request #633 but we didn't catch its reference in the `itest-docker` tag in `Makefile` - which resulted in the following failure:
```
make itest-docker-prep
Error: No such service: itest-docker
make[1]: [itest-docker-prep] Error 1 (ignored)
# Check if swarm mode is active, if not attempt to create the swarm
Starting enterprise-gateway swarm service (run `docker service logs itest-docker` to see service log)...
/bin/bash: etc/docker/enterprise-gateway-swarm.sh: No such file or directory
make[1]: *** [itest-docker-prep] Error 127
make: *** [itest-docker] Error 2
```

These changes fix that issue and also address:
- an issue with conveying the network name, set at command launch
- the R kernel image (didn't have adequate packages - probably was an issue on k8s as well)
- the hostname wasn't being properly set in swarm launches
- replacement of the deprecated `assertRegexMatches` with `assertRegex` - in addition to some print statement cleanup.

<details>
  <summary>`make itest-docker` output</summary>

```
$ make itest-docker
make itest-docker-prep
enterprise-gateway_enterprise-gateway
enterprise-gateway_enterprise-gateway-proxy
Node left the swarm.
# Check if swarm mode is active, if not attempt to create the swarm
Swarm initialized: current node (qmoqpuu0r1g6j9xelw6mf1pzq) is now a manager.

To add a worker to this swarm, run the following command:

    docker swarm join --token SWMTKN-1-24gnjrufef7me6b2k7uexrjy6abmx2k1owml179fth2igg57y0-cf4c96ywvtkezfq1a06nnv6zn 192.168.65.3:2377

To add a manager to this swarm, run 'docker swarm join-token manager' and follow the instructions.

Starting enterprise-gateway swarm service (run `docker service logs enterprise-gateway_enterprise-gateway` to see service log)...
Creating network enterprise-gateway
Creating service enterprise-gateway_enterprise-gateway
Creating service enterprise-gateway_enterprise-gateway-proxy
Waiting for enterprise-gateway to start...
enterprise-gateway_enterprise-gateway.1.l7u364l9u9ef@docker-desktop    | [I 2021-05-03 22:13:32.097 EnterpriseGatewayApp] Jupyter Enterprise Gateway 3.0.0.dev0 is available at http://0.0.0.0:8888
(source activate enterprise-gateway-dev && GATEWAY_HOST=localhost:8889 LOG_LEVEL=INFO KERNEL_USERNAME=bob KERNEL_LAUNCH_TIMEOUT=120 PYTHON_KERNEL_LOCAL_NAME=python_docker SCALA_KERNEL_LOCAL_NAME=scala_docker R_KERNEL_LOCAL_NAME=R_docker ITEST_HOSTNAME_PREFIX=bob pytest -v -s  enterprise_gateway/itests/test_r_kernel.py::TestRKernelLocal enterprise_gateway/itests/test_python_kernel.py::TestPythonKernelLocal enterprise_gateway/itests/test_scala_kernel.py::TestScalaKernelLocal)
/opt/anaconda3/envs/enterprise-gateway-dev/lib/python3.8/site-packages/requests/__init__.py:89: RequestsDependencyWarning: urllib3 (1.26.3) or chardet (3.0.4) doesn't match a supported version!
  warnings.warn("urllib3 ({}) or chardet ({}) doesn't match a supported "
================================================================================= test session starts =================================================================================
platform darwin -- Python 3.8.5, pytest-6.1.0, py-1.9.0, pluggy-0.13.1 -- /opt/anaconda3/envs/enterprise-gateway-dev/bin/python
cachedir: .pytest_cache
rootdir: /Users/kbates/repos/oss/jupyter/enterprise_gateway
plugins: tornasync-0.6.0.post2, console-scripts-1.1.0, jupyter-server-1.0.11, shutil-1.7.0, anyio-2.0.2, jupyterlab-3.0.0rc10, virtualenv-1.7.0, jupyterlab-server-2.0.0rc3
collected 13 items                                                                                                                                                                    

enterprise_gateway/itests/test_r_kernel.py::TestRKernelLocal::test_get_hostname 
Starting R kernel using R_docker kernelspec
Starting a R_docker kernel ....
Started kernel with id 4f5bc891-93f6-489d-9ea2-63dc56d396cc
PASSED
enterprise_gateway/itests/test_r_kernel.py::TestRKernelLocal::test_hello_world PASSED
enterprise_gateway/itests/test_r_kernel.py::TestRKernelLocal::test_interrupt PASSED
enterprise_gateway/itests/test_r_kernel.py::TestRKernelLocal::test_restart PASSED
Shutting down R kernel using R_docker kernelspec
Shutting down kernel : 4f5bc891-93f6-489d-9ea2-63dc56d396cc ....

enterprise_gateway/itests/test_python_kernel.py::TestPythonKernelLocal::test_get_hostname 
Starting Python kernel using python_docker kernelspec
Starting a python_docker kernel ....
Started kernel with id 04d8c6aa-3b4a-41a8-b086-b7e60ef16025
PASSED
enterprise_gateway/itests/test_python_kernel.py::TestPythonKernelLocal::test_hello_world PASSED
enterprise_gateway/itests/test_python_kernel.py::TestPythonKernelLocal::test_interrupt PASSED
enterprise_gateway/itests/test_python_kernel.py::TestPythonKernelLocal::test_restart PASSED
enterprise_gateway/itests/test_python_kernel.py::TestPythonKernelLocal::test_scope PASSED
Shutting down Python kernel using python_docker kernelspec
Shutting down kernel : 04d8c6aa-3b4a-41a8-b086-b7e60ef16025 ....

enterprise_gateway/itests/test_scala_kernel.py::TestScalaKernelLocal::test_get_hostname 
Starting Scala kernel using scala_docker kernelspec
Starting a scala_docker kernel ....
Started kernel with id a79ac4fb-f7d7-4af7-800f-00b4fae07bf5
PASSED
enterprise_gateway/itests/test_scala_kernel.py::TestScalaKernelLocal::test_hello_world PASSED
enterprise_gateway/itests/test_scala_kernel.py::TestScalaKernelLocal::test_interrupt PASSED
enterprise_gateway/itests/test_scala_kernel.py::TestScalaKernelLocal::test_restart ^[PASSED
Shutting down Scala kernel using scala_docker kernelspec
Shutting down kernel : a79ac4fb-f7d7-4af7-800f-00b4fae07bf5 ....


============================================================================ 13 passed in 76.78s (0:01:16) ============================================================================
Run `docker service logs itest-docker` to see enterprise-gateway log.
```

</details>