### PR TITLE
Add missing files to fix the incorrect links

### DIFF
--- a/etc/docker/enterprise-gateway-docker.sh
+++ b/etc/docker/enterprise-gateway-docker.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This file is used to deploy Enterprise Gateway as a traditional docker container.
+# We should convert this to a Docker Compose file at some point.
+# First a docker overlay network is created and referenced by the service.  This network
+# must also get conveyed to launched kernel containers and that occurs via the env variable: EG_DOCKER_NETWORK
+
+export KG_PORT=${KG_PORT:-8888}
+export EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK:-enterprise-gateway}
+export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"['r_docker','python_docker','python_tf_docker','python_tf_gpu_docker','scala_docker']"}
+export EG_NAME=${EG_NAME:-enterprise-gateway}
+# NOTE: This requires appropriate volume mounts to make notebook dir accessible
+export EG_MIRROR_WORKING_DIRS=False
+
+# It's often helpful to mount the kernelspec files from the host into the container.
+MOUNT_KERNELSPECS=
+#MOUNT_KERNELSPECS="-v /usr/local/share/jupyter/kernels:/usr/local/share/jupyter/kernels"
+
+# Create the overlay network
+docker network create --label app=enterprise-gateway -d overlay --attachable ${EG_DOCKER_NETWORK}
+
+# Notes (FIXMEs):
+# 1. We need to address the need to run as UID 0 (root).  This appears to be required inorder to create containers/services from within.
+
+# Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
+docker run -d -it \
+	--network ${EG_DOCKER_NETWORK} \
+	-l app=enterprise-gateway \
+	-l component=enterprise-gateway \
+	${MOUNT_KERNELSPECS} \
+	-u 0 -v /var/run/docker.sock:/var/run/docker.sock \
+	-p ${KG_PORT}:${KG_PORT} \
+	-e EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK} \
+	-e EG_KERNEL_LAUNCH_TIMEOUT=60 \
+	-e EG_CULL_IDLE_TIMEOUT=3600 \
+	-e EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST} \
+	-e EG_MIRROR_WORKING_DIRS=${EG_MIRROR_WORKING_DIRS} \
+	-e KG_PORT=${KG_PORT} \
+	--name ${EG_NAME} \
+	elyra/enterprise-gateway:VERSION --gateway

--- a/etc/docker/enterprise-gateway-swarm.sh
+++ b/etc/docker/enterprise-gateway-swarm.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This file is used to deploy Enterprise Gateway as a service in a Docker Swarm cluster.
+# We should convert this to a Docker Compose file at some point.
+# First a docker overlay network is created and referenced by the service.  This network
+# must also get conveyed to launched kernel containers and that occurs via the env variable: EG_DOCKER_NETWORK
+
+export KG_PORT=${KG_PORT:-8888}
+export EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK:-enterprise-gateway}
+export EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST:-"['r_docker','python_docker','python_tf_docker','python_tf_gpu_docker','scala_docker']"}
+export EG_NAME=${EG_NAME:-enterprise-gateway}
+# NOTE: This requires appropriate volume mounts to make notebook dir accessible
+export EG_MIRROR_WORKING_DIRS=False
+
+# It's often helpful to mount the kernelspec files from the host into the container.  Since this is a swarm,
+# it is recommended that these be mounted on an NFS volume available to all nodes of the cluster.
+MOUNT_KERNELSPECS=
+#MOUNT_KERNELSPECS="--mount type=bind,src=/usr/local/share/jupyter/kernels,dst=/usr/local/share/jupyter/kernels"
+
+# Create the overlay network
+docker network create --label app=enterprise-gateway -d overlay --attachable ${EG_DOCKER_NETWORK}
+
+# Notes (FIXMEs):
+# 1. We need to address the need to run as UID 0 (root).  This appears to be required inorder to create containers/services from within.
+# 2. Using endpoint-mode dnsrr (which appears to be required inorder for kernel container to send the connection info response back) 
+# also required mode=host on any published ports. :-(
+# 3. We only use one replica since session affinity is another point of investigation in Swarm
+
+# Ensure the following VERSION tag is updated to the version of Enterprise Gateway you wish to run
+docker service create \
+	--endpoint-mode dnsrr --network ${EG_DOCKER_NETWORK} \
+	--replicas 1 \
+	-l app=enterprise-gateway \
+	-l component=enterprise-gateway \
+	${MOUNT_KERNELSPECS} \
+	-u 0 --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+	--publish published=${KG_PORT},target=${KG_PORT},mode=host \
+	-e EG_DOCKER_NETWORK=${EG_DOCKER_NETWORK} \
+	-e EG_KERNEL_LAUNCH_TIMEOUT=60 \
+	-e EG_CULL_IDLE_TIMEOUT=3600 \
+	-e EG_KERNEL_WHITELIST=${EG_KERNEL_WHITELIST} \
+	-e EG_MIRROR_WORKING_DIRS=${EG_MIRROR_WORKING_DIRS} \
+	-e KG_PORT=${KG_PORT} \
+	--name ${EG_NAME} \
+	elyra/enterprise-gateway:VERSION --gateway


### PR DESCRIPTION
Copy files from the branch "remove-python-2.x" to fix the incorrect links in "[/etc/docker/enterprise-gateway/README.md](https://github.com/jupyter/enterprise_gateway/blob/master/etc/docker/enterprise-gateway/README.md)".

Fixes #968