### PR TITLE
Update Watchdog dependency to version 2.1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ Apache Spark, Kubernetes and others..
         'requests>=2.7,<3.0',
         'tornado>=6.1',
         'traitlets>=4.3.3',
-        'watchdog==0.10.3',  # 0.10.4 (latest) is broken on MacOS
+        'watchdog>=2.1.3',
         'yarn-api-client>=1.0',
     ],
     extras_require = {


### PR DESCRIPTION
Update WatchDog dependency version to avoid issues while installing other projects such as Elyra:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
jupyter-enterprise-gateway 2.5.0 requires watchdog==0.10.3, but you have watchdog 2.1.3 which is incompatible.
```