### PR TITLE
Enable debugger for python-related kernelspecs and add option to mount kernelspecs with pvc

### DIFF
--- a/enterprise_gateway/tests/test_handlers.py
+++ b/enterprise_gateway/tests/test_handlers.py
@@ -395,9 +395,12 @@ class TestDefaults(TestHandlers):
         }))
 
         # Assert the reply comes back. Test will timeout if this hangs.
-        for _ in range(4):
+        # Note that this range may be side-effected by upstream changes,
+        # so we will add a print (and increase its length to 8).
+        for _ in range(8):
             msg = yield ws.read_message()
             msg = json_decode(msg)
+            print(f"test_kernel_comm, msg_type: {msg['msg_type']}")
             if(msg['msg_type'] == 'kernel_info_reply'):
                 break
         else:

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_CONTAINER=jupyter/minimal-notebook:703d8b2dcb88
+ARG BASE_CONTAINER=jupyter/minimal-notebook:8e693aad7dcc
 
 FROM $BASE_CONTAINER
 

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/scipy-notebook:04f7f60d34a6
+ARG BASE_CONTAINER=jupyter/scipy-notebook:8e693aad7dcc
 FROM $BASE_CONTAINER
 
 ENV PATH=$PATH:$CONDA_DIR/bin

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/r-notebook:04f7f60d34a6
+ARG BASE_CONTAINER=jupyter/r-notebook:8e693aad7dcc
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -yq \
     tzdata \
     unzip && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install future pycryptodomex
+    pip install --upgrade future pycryptodomex ipykernel>=6.0
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -9,6 +9,7 @@ ENV KERNEL_LANGUAGE python
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 RUN conda install --quiet --yes \
+    ipykernel \
     pillow \
     future \
     pycryptodomex && \

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -1,6 +1,6 @@
 # Ubuntu:Bionic
 # TensorFlow 2.4.0
-ARG BASE_CONTAINER=jupyter/tensorflow-notebook:703d8b2dcb88
+ARG BASE_CONTAINER=jupyter/tensorflow-notebook:8e693aad7dcc
 
 FROM $BASE_CONTAINER
 

--- a/etc/kernelspecs/dask_python_yarn_remote/kernel.json
+++ b/etc/kernelspecs/dask_python_yarn_remote/kernel.json
@@ -4,7 +4,8 @@
   "metadata": {
     "process_proxy": {
       "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
-    }
+    },
+    "debugger": true
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/python_distributed/kernel.json
+++ b/etc/kernelspecs/python_distributed/kernel.json
@@ -4,7 +4,8 @@
   "metadata": {
     "process_proxy": {
       "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
-    }
+    },
+    "debugger": true
   },
   "argv": [
     "python",

--- a/etc/kernelspecs/python_docker/kernel.json
+++ b/etc/kernelspecs/python_docker/kernel.json
@@ -6,7 +6,8 @@
       "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
       "config": {
         "image_name": "elyra/kernel-py:VERSION"
-      }
+      },
+    "debugger": true
     }
   },
   "env": {

--- a/etc/kernelspecs/python_docker/kernel.json
+++ b/etc/kernelspecs/python_docker/kernel.json
@@ -6,9 +6,9 @@
       "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
       "config": {
         "image_name": "elyra/kernel-py:VERSION"
-      },
+      }
+    },
     "debugger": true
-    }
   },
   "env": {
   },

--- a/etc/kernelspecs/python_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_kubernetes/kernel.json
@@ -6,7 +6,8 @@
       "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
       "config": {
         "image_name": "elyra/kernel-py:VERSION"
-      }
+      },
+    "debugger": true
     }
   },
   "env": {

--- a/etc/kernelspecs/python_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_kubernetes/kernel.json
@@ -6,9 +6,9 @@
       "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
       "config": {
         "image_name": "elyra/kernel-py:VERSION"
-      },
+      }
+    },
     "debugger": true
-    }
   },
   "env": {
   },

--- a/etc/kernelspecs/python_tf_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_docker/kernel.json
@@ -6,7 +6,8 @@
       "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
       "config": {
         "image_name": "elyra/kernel-tf-py:VERSION"
-      }
+      },
+    "debugger": true
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_docker/kernel.json
@@ -6,9 +6,9 @@
       "class_name": "enterprise_gateway.services.processproxies.docker_swarm.DockerSwarmProcessProxy",
       "config": {
         "image_name": "elyra/kernel-tf-py:VERSION"
-      },
+      }
+    },
     "debugger": true
-    }
   },
   "env": {
   },

--- a/etc/kernelspecs/python_tf_gpu_docker/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_docker/kernel.json
@@ -7,7 +7,8 @@
       "config": {
         "image_name": "elyra/kernel-tf-gpu-py:VERSION"
       }
-    }
+    },
+    "debugger": true
   },
   "env": {
   },

--- a/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
@@ -6,7 +6,8 @@
       "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
       "config": {
         "image_name": "elyra/kernel-tf-gpu-py:VERSION"
-      }
+      },
+    "debugger": true
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_gpu_kubernetes/kernel.json
@@ -6,9 +6,9 @@
       "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
       "config": {
         "image_name": "elyra/kernel-tf-gpu-py:VERSION"
-      },
+      }
+    },
     "debugger": true
-    }
   },
   "env": {
   },

--- a/etc/kernelspecs/python_tf_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_kubernetes/kernel.json
@@ -6,7 +6,8 @@
       "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
       "config": {
         "image_name": "elyra/kernel-tf-py:VERSION"
-      }
+      },
+    "debugger": true
     }
   },
   "env": {

--- a/etc/kernelspecs/python_tf_kubernetes/kernel.json
+++ b/etc/kernelspecs/python_tf_kubernetes/kernel.json
@@ -6,9 +6,9 @@
       "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
       "config": {
         "image_name": "elyra/kernel-tf-py:VERSION"
-      },
+      }
+    },
     "debugger": true
-    }
   },
   "env": {
   },

--- a/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_conductor_cluster/kernel.json
@@ -4,7 +4,8 @@
   "metadata": {
     "process_proxy": {
       "class_name": "enterprise_gateway.services.processproxies.conductor.ConductorClusterProcessProxy"
-    }
+    },
+    "debugger": true
   },
   "env": { 
     "SPARK_OPTS": "--name ${KERNEL_ID:-ERROR__NO__KERNEL_ID} ${KERNEL_EXTRA_SPARK_OPTS}",

--- a/etc/kernelspecs/spark_python_kubernetes/kernel.json
+++ b/etc/kernelspecs/spark_python_kubernetes/kernel.json
@@ -8,7 +8,8 @@
         "image_name": "elyra/kernel-spark-py:VERSION",
         "executor_image_name": "elyra/kernel-spark-py:VERSION"
       }
-    }
+    },
+    "debugger": true
   },
   "env": {
     "SPARK_HOME": "/opt/spark",

--- a/etc/kernelspecs/spark_python_yarn_client/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_client/kernel.json
@@ -4,7 +4,8 @@
   "metadata": {
     "process_proxy": {
       "class_name": "enterprise_gateway.services.processproxies.distributed.DistributedProcessProxy"
-    }
+    },
+    "debugger": true
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
+++ b/etc/kernelspecs/spark_python_yarn_cluster/kernel.json
@@ -4,7 +4,8 @@
   "metadata": {
     "process_proxy": {
       "class_name": "enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy"
-    }
+    },
+    "debugger": true
   },
   "env": {
     "SPARK_HOME": "/usr/hdp/current/spark2-client",

--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -78,6 +78,14 @@ spec:
         nfs:
           server: {{ .Values.nfs.internalServerIPAddress }}
           path: "/usr/local/share/jupyter/kernels"
+{{- else if .Values.kernelpvc.enabled }}
+        volumeMounts:
+        - name: pvc-kernelspecs
+          mountPath: "/usr/local/share/jupyter/kernels"
+      volumes:
+      - name: pvc-kernelspecs
+        persistentVolumeClaim:
+          claimName: {{ .Values.kernelpvc.name }}
 {{- else if .Values.kernelspecs.image }}
         volumeMounts:
         - name: image-kernelspecs

--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
         nfs:
           server: {{ .Values.nfs.internalServerIPAddress }}
           path: "/usr/local/share/jupyter/kernels"
-{{- else if .Values.kernelpvc.enabled }}
+{{- else if .Values.kernelspecsPvc.enabled }}
         volumeMounts:
         - name: pvc-kernelspecs
           mountPath: "/usr/local/share/jupyter/kernels"

--- a/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
       volumes:
       - name: pvc-kernelspecs
         persistentVolumeClaim:
-          claimName: {{ .Values.kernelpvc.name }}
+          claimName: {{ .Values.kernelspecsPvc.name }}
 {{- else if .Values.kernelspecs.image }}
         volumeMounts:
         - name: image-kernelspecs

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -50,6 +50,11 @@ nfs:
   # IP address of NFS server. Required if enabled.
   internalServerIPAddress:
 
+kernelpvc:
+  enabled: false
+  # PVC name. Required if want mount kernelspecs without nfs. PVC should create in the same namespace before EG deployed. 
+  name: 
+
 ingress:
   enabled: false
 

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -50,7 +50,7 @@ nfs:
   # IP address of NFS server. Required if enabled.
   internalServerIPAddress:
 
-kernelpvc:
+kernelspecsPvc:
   enabled: false
   # PVC name. Required if want mount kernelspecs without nfs. PVC should create in the same namespace before EG deployed. 
   name: 


### PR DESCRIPTION
Kernel-debugger enablement - which starts here: #980 .
And I add pvc options to mount kernelspecs, I guess It's simpler than nfs. 