### PR TITLE
Fix kernelspec authorization

### DIFF
--- a/enterprise_gateway/services/kernelspecs/handlers.py
+++ b/enterprise_gateway/services/kernelspecs/handlers.py
@@ -43,10 +43,10 @@ def apply_user_filter(kernelspec_model: Dict[str, object],
         try:
             authorized_list = kernelspec_model["spec"]["metadata"]["process_proxy"]["config"]["authorized_users"]
         except KeyError:
-            if kernel_user not in global_authorized_list:
+            if global_authorized_list and kernel_user not in global_authorized_list:
                 return None
         else:
-            if kernel_user not in authorized_list:
+            if authorized_list and kernel_user not in authorized_list:
                 return None
 
     return kernelspec_model


### PR DESCRIPTION
One of the changes recently made in #982 broke the authorization checks when retrieving kernelspecs.

Since we want to honor NOT specifying/configuring an `authorized_users` list does not prevent the use of the kernel, it is important to only consider `authorized_users` lists that have values when checking if the current user is _not_ in the list.  With the changes in #982, the authorization list could be empty and because the sought user is not in the list, it is considered unauthorized.  This change ensures that _falsey_ values are not considered.