### PR TITLE
Response port retries

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -440,8 +440,14 @@ The following environment variables can be used to influence functionality and a
     set in cases where the computed (default) is not correct for the current topology.
 
   EG_RESPONSE_PORT=8877
-    The single response port used to receive connection information from launched kernels.
+    The single response port used to receive connection information 
+    from launched kernels.
 
+  EG_RESPONSE_PORT_RETRIES=10
+    The number of retries to attempt when the original response port
+    (EG_RESPONSE_PORT) is found to be in-use.  This value should be 
+    set to 0 (zero) if no port retries are desired.
+    
   EG_SHARED_NAMESPACE=False
     Kubernetes only. This value indicates whether (True) or not (False) all kernel pods
     should reside in the same namespace as Enterprise Gateway.  This is not a recommended


### PR DESCRIPTION
With Enterprise Gateway potentially coexisting with itself and/or remote provisioners (that utilize the same process-proxy framework) it would be a good idea to be able to tolerate port conflicts when the single response address port gets configured (on demand/first use).  This pull request uses logic similar to the various server startups that, when port retries are configured, will tolerate EADDRINUSE errors and retry a different port until a successful socket binding occurs or the retries are exhausted.

The default port number (as was the case when the single response address functionality was introduced) is `8877` and the default number of retries is `10`.  As with the other server startups, the first 5 retries attempt to bind to the next port sequentially, then, when the retry count exceeds 5, determines the port randomly.  This logic can be disabled by configuring the retries to 0 (zero).

These values are configured only via environment variables.  As was previously the case, the environment variable for the response port is named `EG_RESPONSE_PORT` (and defaults to `8877`), while the retry count environment variable is `EG_RESPONSE_PORT_RETRIES` (and defaults to `10`).

When a conflict is encountered, there should be informational messages produced in the log similar to these (note that the first couple of messages apply to the port-retry logic already in existence for server startup):
```
[I 2021-08-10 15:24:01.479 EnterpriseGatewayApp] The port 8888 is already in use, trying another port.
[I 2021-08-10 15:24:01.479 EnterpriseGatewayApp] Jupyter Enterprise Gateway 3.0.0.dev0 is available at http://0.0.0.0:8889
[D 2021-08-10 15:24:11.399 EnterpriseGatewayApp] RemoteMappingKernelManager.start_kernel: spark_python_yarn_cluster, kernel_username: gateway
[D 2021-08-10 15:24:11.678 EnterpriseGatewayApp] Instantiating kernel 'Spark - Python (YARN Cluster Mode)' with process proxy: enterprise_gateway.services.processproxies.yarn.YarnClusterProcessProxy
[I 2021-08-10 15:24:12.089 EnterpriseGatewayApp] Response port 8877 is already in use, trying another port...
[I 2021-08-10 15:24:12.089 EnterpriseGatewayApp] Enterprise Gateway is bound to port 8878 for remote kernel connection information.
```