### PR TITLE
add crd process proxy to support some crd based k8s application like spark operator

### DIFF
--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -300,15 +300,24 @@ located.
 See [Enabling IBM Spectrum Conductor Support](kernel-conductor.html#enabling-ibm-spectrum-conductor-support) for details.
 
 ###### CustomResourceProcessProxy
-Enterprise Gateway also provides a implementation of a process proxy derived from KubernetesProcessProxy 
-called CustomResourceProcessProxy. 
+Enterprise Gateway also provides a implementation of a process proxy derived from `KubernetesProcessProxy` 
+called `CustomResourceProcessProxy`. 
 
-Instead of creating kernel based on Kubernetes pod, CustomResourceProcessProxy
-manages kernel by implementation of custom resource definition(CRD), e.g. SparkApplication is a CRD which include
-plenty component of a Spark on Kubernetes application.
+Instead of creating kernels based on a Kubernetes pod, `CustomResourceProcessProxy`
+manages kernels via a custom resource definition (CRD). For example,  `SparkApplication` is a CRD that includes
+many components of a Spark-on-Kubernetes application.
 
-If you want to include a new CRD, just wrt [spark_operator.py](https://github.com/jupyter/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py)
-and [spark_python_operator](https://github.com/abzymeinsjtu/enterprise_gateway/blob/feat_crd_processproxy_support/etc/kernelspecs/spark_python_operator) kernelspec.
+If you are going to extend `CustomResourceProcessProxy`, just follow steps below:
+
+- override custom resource related variables(i.e. `group`, `version` and `plural`
+and `get_container_status` method, wrt [spark_operator.py](https://github.com/jupyter/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py). 
+
+- define a jinja template like
+[sparkoperator.k8s.io-v1beta2.yaml.j2](https://github.com/jupyter/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2).
+As a generic design, the template file should be named as {crd_group}-{crd_version} so that you can reuse
+[launch_custom_resource.py](https://github.com/jupyter/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py) in the kernelspec.
+
+- define a kernelspec like [spark_python_operator/kernel.json](https://github.com/jupyter/enterprise_gateway/blob/master/etc/kernelspecs/spark_python_operator/kernel.json).
 
 
 #### Process Proxy Configuration

--- a/docs/source/system-architecture.md
+++ b/docs/source/system-architecture.md
@@ -112,6 +112,14 @@ within a Docker Swarm cluster.
 within Docker configuration.  Note: because these kernels will always run local to the corresponding Enterprise Gateway instance, these process proxies are of limited use.
 - `ConductorClusterProcessProxy` - is responsible for the discovery and management of kernels hosted
 within an IBM Spectrum Conductor cluster.
+- `SparkOperatorProcessProxy` - is responsible for the descovery and management of kernels hosted 
+within a Kubernetes cluster but created as a SparkApplication instead of a Pod. The SparkApplication is a Kubernetes custom resource 
+defined inside the project [spark-on-k8s-operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator), which 
+makes all kinds of spark on k8s components better organized and easy to configure.
+
+Before you run this kernel, please ensure that spark operator is installed under a certain namespace of your Kubernetes
+cluster.
+
 
 You might notice that the last five process proxies do not necessarily control the *launch* of the kernel.  This is 
 because the native jupyter framework is utilized such that the script that is invoked by the framework is what 
@@ -290,6 +298,18 @@ option or the `EG_CONDUCTOR_ENDPOINT` environment variable to determine where th
 located.  
 
 See [Enabling IBM Spectrum Conductor Support](kernel-conductor.html#enabling-ibm-spectrum-conductor-support) for details.
+
+###### CustomResourceProcessProxy
+Enterprise Gateway also provides a implementation of a process proxy derived from KubernetesProcessProxy 
+called CustomResourceProcessProxy. 
+
+Instead of creating kernel based on Kubernetes pod, CustomResourceProcessProxy
+manages kernel by implementation of custom resource definition(CRD), e.g. SparkApplication is a CRD which include
+plenty component of a Spark on Kubernetes application.
+
+If you want to include a new CRD, just wrt [spark_operator.py](https://github.com/jupyter/enterprise_gateway/blob/master/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py)
+and [spark_python_operator](https://github.com/abzymeinsjtu/enterprise_gateway/blob/feat_crd_processproxy_support/etc/kernelspecs/spark_python_operator) kernelspec.
+
 
 #### Process Proxy Configuration
 Each kernel.json's `process-proxy` stanza can specify an optional `config` stanza that is converted 

--- a/enterprise_gateway/services/processproxies/crd.py
+++ b/enterprise_gateway/services/processproxies/crd.py
@@ -6,13 +6,13 @@ from .k8s import KubernetesProcessProxy
 from kubernetes import client
 
 
-class CustomResourceProxy(KubernetesProcessProxy):
+class CustomResourceProcessProxy(KubernetesProcessProxy):
     group = version = plural = None
     custom_resource_template_name = None
     kernel_resource_name = None
 
     def __init__(self, kernel_manager, proxy_config):
-        super(CustomResourceProxy, self).__init__(kernel_manager, proxy_config)
+        super(CustomResourceProcessProxy, self).__init__(kernel_manager, proxy_config)
 
     async def launch_process(self, kernel_cmd, **kwargs):
         kwargs['env']['KERNEL_RESOURCE_NAME'] = self.kernel_resource_name = self._determine_kernel_pod_name(**kwargs)
@@ -20,7 +20,7 @@ class CustomResourceProxy(KubernetesProcessProxy):
         kwargs['env']['KERNEL_CRD_VERSION'] = self.version
         kwargs['env']['KERNEL_CRD_PLURAL'] = self.plural
 
-        await super(CustomResourceProxy, self).launch_process(kernel_cmd, **kwargs)
+        await super(CustomResourceProcessProxy, self).launch_process(kernel_cmd, **kwargs)
         return self
 
     def kill(self):

--- a/enterprise_gateway/services/processproxies/crd.py
+++ b/enterprise_gateway/services/processproxies/crd.py
@@ -1,0 +1,159 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Code related to managing kernels running in containers."""
+
+import abc
+import signal
+import urllib3  # docker ends up using this and it causes lots of noise, so turn off warnings
+
+from jupyter_client import localinterfaces
+
+from .processproxy import RemoteProcessProxy
+from kubernetes import config, client
+
+urllib3.disable_warnings()
+local_ip = localinterfaces.public_ips()[0]
+config.load_incluster_config()
+
+
+class CustomResourceProxy(RemoteProcessProxy):
+    """
+    Kernel lifecycle management for custom resource based kernels.
+    """
+
+    group = version = plural = None
+    custom_resource_template_name = None
+    kernel_resource_name = None
+
+    def __init__(self, kernel_manager, proxy_config):
+        super(CustomResourceProxy, self).__init__(kernel_manager, proxy_config)
+        self.assigned_node_ip = None
+
+    async def launch_process(self, kernel_cmd, **kwargs):
+        """
+        Launches the specified process within the custom resource environment.
+        """
+        # Set env before superclass call so we see these in the debug output
+
+        kwargs['env']['KERNEL_CRD_NAME'] = self.kernel_resource_name
+        kwargs['env']['KERNEL_CRD_GROUP'] = self.group
+        kwargs['env']['KERNEL_CRD_VERSION'] = self.version
+        kwargs['env']['KERNEL_CRD_PLURAL'] = self.plural
+
+        await super(CustomResourceProxy, self).launch_process(kernel_cmd, **kwargs)
+
+        self.local_proc = self.launch_kernel(kernel_cmd, **kwargs)
+        self.pid = self.local_proc.pid
+        self.ip = local_ip
+
+        self.log.info("{}: kernel launched. KernelID: {}, cmd: '{}'"
+                      .format(self.__class__.__name__, self.kernel_id, kernel_cmd))
+
+        await self.confirm_remote_startup()
+        return self
+
+    def poll(self):
+        """Determines if custom resource is still active.
+
+        Submitting a new kernel to the custom resource manager will take a while to be Running.
+        Thus kernel ID will probably not be available immediately for poll.
+        So will regard the container as active when no status is available or one of the initial
+        phases.
+
+        Returns
+        -------
+        None if the container cannot be found or its in an initial state. Otherwise False.
+        """
+        result = False
+
+        resource_status = self.get_resource_status(None)
+
+        if resource_status in self.get_initial_states():
+            result = None
+
+        return result
+
+    def send_signal(self, signum):
+        """Send signal `signum` to custom resource.
+
+        Parameters
+        ----------
+        signum : int
+            The signal number to send.  Zero is used to determine heartbeat.
+        """
+        if signum == 0:
+            return self.poll()
+        elif signum == signal.SIGKILL:
+            return self.kill()
+        else:
+            return super(CustomResourceProxy, self).send_signal(signum)
+
+    def kill(self):
+        """Kills a custom resource kernel.
+
+        Returns
+        -------
+        None if the container is gracefully terminated, False otherwise.
+        """
+        result = None
+
+        if self.kernel_resource_name:
+            result = self.terminate_custom_resource()
+
+        return result
+
+    def cleanup(self):
+        # Since container objects don't necessarily go away on their own, we need to perform the same
+        # cleanup we'd normally perform on forced kill situations.
+
+        self.kill()
+        super(CustomResourceProxy, self).cleanup()
+
+    async def confirm_remote_startup(self):
+        """Confirms the custom resource has started and returned necessary connection information."""
+        self.start_time = RemoteProcessProxy.get_current_time()
+        i = 0
+        ready_to_connect = False  # we're ready to connect when we have a connection file to use
+        while not ready_to_connect:
+            i += 1
+            await self.handle_timeout()
+
+            resource_status = self.get_resource_status(str(i))
+            if resource_status and self.assigned_host != '':
+                ready_to_connect = await self.receive_connection_info()
+                self.pid = self.pgid = 0  # We won't send process signals for kubernetes lifecycle management
+            else:
+                self.detect_launch_failure()
+
+    def get_process_info(self):
+        """Captures the base information necessary for kernel persistence relative to custom resource."""
+        process_info = super(CustomResourceProxy, self).get_process_info()
+        process_info.update({'assigned_node_ip': self.assigned_node_ip, })
+        return process_info
+
+    def load_process_info(self, process_info):
+        """Loads the base information necessary for kernel persistence relative to custom resource."""
+        super(CustomResourceProxy, self).load_process_info(process_info)
+        self.assigned_node_ip = process_info['assigned_node_ip']
+
+    @abc.abstractmethod
+    def get_initial_states(self):
+        """Return list of states indicating  custom resource is starting (includes running)."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_resource_status(self, iteration):
+        raise NotImplementedError
+
+    def terminate_custom_resource(self):
+        try:
+            delete_status = client.CustomObjectsApi().delete_cluster_custom_object(self.group, self.version,
+                                                                                   self.plurals,
+                                                                                   self.kernel_resource_name)
+
+            result = delete_status and delete_status.get('status', None) == 'Success'
+
+        except Exception as err:
+            result = isinstance(err, client.rest.ApiException) and err.status == 404
+
+        return result

--- a/enterprise_gateway/services/processproxies/crd.py
+++ b/enterprise_gateway/services/processproxies/crd.py
@@ -2,64 +2,26 @@
 # Distributed under the terms of the Modified BSD License.
 """Code related to managing kernels running based on k8s custom resource."""
 
-import abc
-import signal
-import urllib3  # docker ends up using this and it causes lots of noise, so turn off warnings
-
-from jupyter_client import localinterfaces
-
-from .processproxy import RemoteProcessProxy
-from kubernetes import config, client
-
-urllib3.disable_warnings()
-local_ip = localinterfaces.public_ips()[0]
-config.load_incluster_config()
+from .k8s import KubernetesProcessProxy
+from kubernetes import client
 
 
-class CustomResourceProxy(RemoteProcessProxy):
+class CustomResourceProxy(KubernetesProcessProxy):
     group = version = plural = None
     custom_resource_template_name = None
     kernel_resource_name = None
 
     def __init__(self, kernel_manager, proxy_config):
         super(CustomResourceProxy, self).__init__(kernel_manager, proxy_config)
-        self.assigned_node_ip = None
 
     async def launch_process(self, kernel_cmd, **kwargs):
-        kwargs['env']['KERNEL_CRD_NAME'] = self.kernel_resource_name
+        kwargs['env']['KERNEL_RESOURCE_NAME'] = self.kernel_resource_name = self._determine_kernel_pod_name(**kwargs)
         kwargs['env']['KERNEL_CRD_GROUP'] = self.group
         kwargs['env']['KERNEL_CRD_VERSION'] = self.version
         kwargs['env']['KERNEL_CRD_PLURAL'] = self.plural
 
         await super(CustomResourceProxy, self).launch_process(kernel_cmd, **kwargs)
-
-        self.local_proc = self.launch_kernel(kernel_cmd, **kwargs)
-        self.pid = self.local_proc.pid
-        self.ip = local_ip
-
-        self.log.info("{}: kernel launched. KernelID: {}, cmd: '{}'"
-                      .format(self.__class__.__name__, self.kernel_id, kernel_cmd))
-
-        await self.confirm_remote_startup()
         return self
-
-    def poll(self):
-        result = False
-
-        resource_status = self.get_resource_status(None)
-
-        if resource_status in self.get_initial_states():
-            result = None
-
-        return result
-
-    def send_signal(self, signum):
-        if signum == 0:
-            return self.poll()
-        elif signum == signal.SIGKILL:
-            return self.kill()
-        else:
-            return super(CustomResourceProxy, self).send_signal(signum)
 
     def kill(self):
         result = None
@@ -68,45 +30,6 @@ class CustomResourceProxy(RemoteProcessProxy):
             result = self.terminate_custom_resource()
 
         return result
-
-    def cleanup(self):
-        # Since container objects don't necessarily go away on their own, we need to perform the same
-        # cleanup we'd normally perform on forced kill situations.
-
-        self.kill()
-        super(CustomResourceProxy, self).cleanup()
-
-    async def confirm_remote_startup(self):
-        self.start_time = RemoteProcessProxy.get_current_time()
-        i = 0
-        ready_to_connect = False  # we're ready to connect when we have a connection file to use
-        while not ready_to_connect:
-            i += 1
-            await self.handle_timeout()
-
-            resource_status = self.get_resource_status(str(i))
-            if resource_status and self.assigned_host != '':
-                ready_to_connect = await self.receive_connection_info()
-                self.pid = self.pgid = 0  # We won't send process signals for kubernetes lifecycle management
-            else:
-                self.detect_launch_failure()
-
-    def get_process_info(self):
-        process_info = super(CustomResourceProxy, self).get_process_info()
-        process_info.update({'assigned_node_ip': self.assigned_node_ip, })
-        return process_info
-
-    def load_process_info(self, process_info):
-        super(CustomResourceProxy, self).load_process_info(process_info)
-        self.assigned_node_ip = process_info['assigned_node_ip']
-
-    @abc.abstractmethod
-    def get_initial_states(self):
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def get_resource_status(self, iteration):
-        raise NotImplementedError
 
     def terminate_custom_resource(self):
         try:

--- a/enterprise_gateway/services/processproxies/spark_operator.py
+++ b/enterprise_gateway/services/processproxies/spark_operator.py
@@ -1,6 +1,5 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-"""Code related to managing kernels running in Kubernetes clusters."""
 
 import os
 import re
@@ -13,10 +12,6 @@ enterprise_gateway_namespace = os.environ.get('EG_NAMESPACE', 'default')
 
 
 class SparkOperatorProcessProxy(CustomResourceProxy):
-    """
-    Kernel lifecycle management for Kubernetes kernels.
-    """
-
     def __init__(self, kernel_manager, proxy_config):
         super(SparkOperatorProcessProxy, self).__init__(kernel_manager, proxy_config)
         self.kernel_namespace = None
@@ -25,11 +20,6 @@ class SparkOperatorProcessProxy(CustomResourceProxy):
         self.plural = 'sparkapplications'
 
     async def launch_process(self, kernel_cmd, **kwargs):
-        """Launches the specified process within a Kubernetes environment."""
-        # Set env before superclass call so we see these in the debug output
-
-        # Kubernetes relies on many internal env variables.  Since EG is running in a k8s pod, we will
-        # transfer its env to each launched kernel.
         kwargs['env'] = dict(os.environ, **kwargs['env'])  # FIXME: Should probably use process-whitelist in JKG #280
         self.kernel_resource_name = self._determine_kernel_resource_name(**kwargs)
         self.kernel_namespace = self._determine_kernel_namespace(**kwargs)  # will create namespace if not provided
@@ -38,8 +28,6 @@ class SparkOperatorProcessProxy(CustomResourceProxy):
         return self
 
     def get_resource_status(self, iteration):
-        # Locates the kernel pod using the kernel_id selector.  If the phase indicates Running, the pod's IP
-        # is used for the assigned_ip.
         resource_status = None
 
         try:
@@ -73,15 +61,12 @@ class SparkOperatorProcessProxy(CustomResourceProxy):
         return resource_status
 
     def get_initial_states(self):
-        """Return list of states indicating container is starting (includes running)."""
         return {'SUBMITTED', 'RUNNING'}
 
     def _determine_kernel_resource_name(self, **kwargs):
         resource_name = kwargs['env'].get('KERNEL_RESOURCE_NAME',
                                           KernelSessionManager.get_kernel_username(**kwargs) + '-' + self.kernel_id)
 
-        # Rewrite resource_name to be compatible with DNS name convention
-        # And put back into env since kernel needs this
         resource_name = re.sub('[^0-9a-z]+', '-', resource_name.lower())
         while resource_name.startswith('-'):
             resource_name = resource_name[1:]
@@ -92,11 +77,9 @@ class SparkOperatorProcessProxy(CustomResourceProxy):
         return resource_name
 
     def _determine_kernel_namespace(self, **kwargs):
-        # If KERNEL_NAMESPACE was provided, then we assume it already exists.  If not provided, then we'll
-        # create the namespace and record that we'll want to delete it as well.
         namespace = kwargs['env'].get('KERNEL_NAMESPACE')
         if namespace is None:
-            kwargs['env']['KERNEL_NAMESPACE'] = enterprise_gateway_namespace  # record in env since kernel needs this
+            kwargs['env']['KERNEL_NAMESPACE'] = enterprise_gateway_namespace
         else:
             self.log.info("KERNEL_NAMESPACE provided by client: {}".format(namespace))
 

--- a/enterprise_gateway/services/processproxies/spark_operator.py
+++ b/enterprise_gateway/services/processproxies/spark_operator.py
@@ -2,11 +2,7 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-import re
-from kubernetes import client
-
-from .crd import CustomResourceProxy
-from ..sessions.kernelsessionmanager import KernelSessionManager
+from .crd import CustomResourceProxy, client
 
 enterprise_gateway_namespace = os.environ.get('EG_NAMESPACE', 'default')
 
@@ -14,36 +10,27 @@ enterprise_gateway_namespace = os.environ.get('EG_NAMESPACE', 'default')
 class SparkOperatorProcessProxy(CustomResourceProxy):
     def __init__(self, kernel_manager, proxy_config):
         super(SparkOperatorProcessProxy, self).__init__(kernel_manager, proxy_config)
-        self.kernel_namespace = None
         self.group = 'sparkoperator.k8s.io'
         self.version = 'v1beta2'
         self.plural = 'sparkapplications'
 
-    async def launch_process(self, kernel_cmd, **kwargs):
-        kwargs['env'] = dict(os.environ, **kwargs['env'])  # FIXME: Should probably use process-whitelist in JKG #280
-        self.kernel_resource_name = self._determine_kernel_resource_name(**kwargs)
-        self.kernel_namespace = self._determine_kernel_namespace(**kwargs)  # will create namespace if not provided
-
-        await super(SparkOperatorProcessProxy, self).launch_process(kernel_cmd, **kwargs)
-        return self
-
-    def get_resource_status(self, iteration):
-        resource_status = None
+    def get_container_status(self, iteration):
+        pod_status = pod_info = None
 
         try:
-            custom_resource = client.CustomObjectsApi().get_namespaced_custom_object(self.group, self.version,
-                                                                                     self.kernel_namespace,
-                                                                                     self.plural,
-                                                                                     self.kernel_resource_name)
+            custom_resource = client.CustomObjectsApi().get_namespaced_custom_object(
+                self.group,
+                self.version,
+                self.kernel_namespace,
+                self.plural,
+                self.kernel_resource_name
+            )
 
             if custom_resource:
-                resource_status = custom_resource['status']['applicationState']['state']
                 pod_name = custom_resource['status']['driverInfo']['podName']
                 pod_info = client.CoreV1Api().read_namespaced_pod(pod_name, self.kernel_namespace)
-            else:
-                pod_info = None
         except Exception:
-            pod_info = None
+            pass
 
         if pod_info and pod_info.status:
             pod_status = pod_info.status.phase
@@ -52,35 +39,4 @@ class SparkOperatorProcessProxy(CustomResourceProxy):
                 self.assigned_host = pod_info.metadata.name
                 self.assigned_node_ip = pod_info.status.host_ip
 
-        if iteration:
-            self.log.debug("{}: Waiting to connect to k8s custom resource in namespace '{}'. "
-                           "Name: '{}', Status: '{}', Pod IP: '{}', KernelID: '{}'".
-                           format(iteration, self.kernel_namespace, self.kernel_resource_name, resource_status,
-                                  self.assigned_ip, self.kernel_id))
-
-        return resource_status
-
-    def get_initial_states(self):
-        return {'SUBMITTED', 'RUNNING'}
-
-    def _determine_kernel_resource_name(self, **kwargs):
-        resource_name = kwargs['env'].get('KERNEL_RESOURCE_NAME',
-                                          KernelSessionManager.get_kernel_username(**kwargs) + '-' + self.kernel_id)
-
-        resource_name = re.sub('[^0-9a-z]+', '-', resource_name.lower())
-        while resource_name.startswith('-'):
-            resource_name = resource_name[1:]
-        while resource_name.endswith('-'):
-            resource_name = resource_name[:-1]
-        kwargs['env']['KERNEL_RESOURCE_NAME'] = resource_name
-
-        return resource_name
-
-    def _determine_kernel_namespace(self, **kwargs):
-        namespace = kwargs['env'].get('KERNEL_NAMESPACE')
-        if namespace is None:
-            kwargs['env']['KERNEL_NAMESPACE'] = enterprise_gateway_namespace
-        else:
-            self.log.info("KERNEL_NAMESPACE provided by client: {}".format(namespace))
-
-        return namespace
+        return pod_status

--- a/enterprise_gateway/services/processproxies/spark_operator.py
+++ b/enterprise_gateway/services/processproxies/spark_operator.py
@@ -1,0 +1,103 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+"""Code related to managing kernels running in Kubernetes clusters."""
+
+import os
+import re
+from kubernetes import client
+
+from .crd import CustomResourceProxy
+from ..sessions.kernelsessionmanager import KernelSessionManager
+
+enterprise_gateway_namespace = os.environ.get('EG_NAMESPACE', 'default')
+
+
+class SparkOperatorProcessProxy(CustomResourceProxy):
+    """
+    Kernel lifecycle management for Kubernetes kernels.
+    """
+
+    def __init__(self, kernel_manager, proxy_config):
+        super(SparkOperatorProcessProxy, self).__init__(kernel_manager, proxy_config)
+        self.kernel_namespace = None
+        self.group = 'sparkoperator.k8s.io'
+        self.version = 'v1beta2'
+        self.plural = 'sparkapplications'
+
+    async def launch_process(self, kernel_cmd, **kwargs):
+        """Launches the specified process within a Kubernetes environment."""
+        # Set env before superclass call so we see these in the debug output
+
+        # Kubernetes relies on many internal env variables.  Since EG is running in a k8s pod, we will
+        # transfer its env to each launched kernel.
+        kwargs['env'] = dict(os.environ, **kwargs['env'])  # FIXME: Should probably use process-whitelist in JKG #280
+        self.kernel_resource_name = self._determine_kernel_resource_name(**kwargs)
+        self.kernel_namespace = self._determine_kernel_namespace(**kwargs)  # will create namespace if not provided
+
+        await super(SparkOperatorProcessProxy, self).launch_process(kernel_cmd, **kwargs)
+        return self
+
+    def get_resource_status(self, iteration):
+        # Locates the kernel pod using the kernel_id selector.  If the phase indicates Running, the pod's IP
+        # is used for the assigned_ip.
+        resource_status = None
+
+        try:
+            custom_resource = client.CustomObjectsApi().get_namespaced_custom_object(self.group, self.version,
+                                                                                     self.kernel_namespace,
+                                                                                     self.plural,
+                                                                                     self.kernel_resource_name)
+
+            if custom_resource:
+                resource_status = custom_resource['status']['applicationState']['state']
+                pod_name = custom_resource['status']['driverInfo']['podName']
+                pod_info = client.CoreV1Api().read_namespaced_pod(pod_name, self.kernel_namespace)
+            else:
+                pod_info = None
+        except Exception:
+            pod_info = None
+
+        if pod_info and pod_info.status:
+            pod_status = pod_info.status.phase
+            if pod_status == 'Running' and self.assigned_host == '':
+                self.assigned_ip = pod_info.status.pod_ip
+                self.assigned_host = pod_info.metadata.name
+                self.assigned_node_ip = pod_info.status.host_ip
+
+        if iteration:
+            self.log.debug("{}: Waiting to connect to k8s custom resource in namespace '{}'. "
+                           "Name: '{}', Status: '{}', Pod IP: '{}', KernelID: '{}'".
+                           format(iteration, self.kernel_namespace, self.kernel_resource_name, resource_status,
+                                  self.assigned_ip, self.kernel_id))
+
+        return resource_status
+
+    def get_initial_states(self):
+        """Return list of states indicating container is starting (includes running)."""
+        return {'SUBMITTED', 'RUNNING'}
+
+    def _determine_kernel_resource_name(self, **kwargs):
+        resource_name = kwargs['env'].get('KERNEL_RESOURCE_NAME',
+                                          KernelSessionManager.get_kernel_username(**kwargs) + '-' + self.kernel_id)
+
+        # Rewrite resource_name to be compatible with DNS name convention
+        # And put back into env since kernel needs this
+        resource_name = re.sub('[^0-9a-z]+', '-', resource_name.lower())
+        while resource_name.startswith('-'):
+            resource_name = resource_name[1:]
+        while resource_name.endswith('-'):
+            resource_name = resource_name[:-1]
+        kwargs['env']['KERNEL_RESOURCE_NAME'] = resource_name
+
+        return resource_name
+
+    def _determine_kernel_namespace(self, **kwargs):
+        # If KERNEL_NAMESPACE was provided, then we assume it already exists.  If not provided, then we'll
+        # create the namespace and record that we'll want to delete it as well.
+        namespace = kwargs['env'].get('KERNEL_NAMESPACE')
+        if namespace is None:
+            kwargs['env']['KERNEL_NAMESPACE'] = enterprise_gateway_namespace  # record in env since kernel needs this
+        else:
+            self.log.info("KERNEL_NAMESPACE provided by client: {}".format(namespace))
+
+        return namespace

--- a/enterprise_gateway/services/processproxies/spark_operator.py
+++ b/enterprise_gateway/services/processproxies/spark_operator.py
@@ -2,12 +2,12 @@
 # Distributed under the terms of the Modified BSD License.
 
 import os
-from .crd import CustomResourceProxy, client
+from .crd import CustomResourceProcessProxy, client
 
 enterprise_gateway_namespace = os.environ.get('EG_NAMESPACE', 'default')
 
 
-class SparkOperatorProcessProxy(CustomResourceProxy):
+class SparkOperatorProcessProxy(CustomResourceProcessProxy):
     def __init__(self, kernel_manager, proxy_config):
         super(SparkOperatorProcessProxy, self).__init__(kernel_manager, proxy_config)
         self.group = 'sparkoperator.k8s.io'

--- a/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
@@ -1,0 +1,76 @@
+import os
+import yaml
+import argparse
+from kubernetes import client, config
+import urllib3
+
+from jinja2 import FileSystemLoader, Environment
+
+urllib3.disable_warnings()
+
+
+def generate_kernel_custom_resource_yaml(kernel_crd_template, keywords):
+    """Return the kubernetes pod spec as a yaml string.
+
+    - load jinja2 template from this file directory.
+    - substitute template variables with keywords items.
+    """
+    j_env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)), trim_blocks=True, lstrip_blocks=True)
+    # jinja2 template substitutes template variables with None though keywords doesn't contain corresponding item.
+    # Therfore, no need to check if any are left unsubstituted. Kubernetes API server will validate the pod spec instead.
+    k8s_yaml = j_env.get_template('/' + kernel_crd_template + '.yaml.j2').render(**keywords)
+
+    return k8s_yaml
+
+
+def launch_custom_resource_kernel(kernel_id, port_range, response_addr, public_key, spark_context_init_mode):
+    config.load_incluster_config()
+
+    keywords = dict()
+
+    keywords['eg_port_range'] = port_range
+    keywords['eg_public_key'] = public_key
+    keywords['eg_response_address'] = response_addr
+    keywords['kernel_id'] = kernel_id
+    keywords['kernel_name'] = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    keywords['kernel_spark_context_init_mode'] = spark_context_init_mode
+
+    for name, value in os.environ.items():
+        if name.startswith('KERNEL_'):
+            keywords[name.lower()] = yaml.safe_load(value)
+
+    kernel_crd_template = keywords['kernel_crd_group'] + '-' + keywords['kernel_crd_version']
+    custom_resource_yaml = generate_kernel_custom_resource_yaml(kernel_crd_template, keywords)
+
+    kernel_namespace = keywords['kernel_namespace']
+    group = keywords['kernel_crd_group']
+    version = keywords['kernel_crd_version']
+    plural = keywords['kernel_crd_plural']
+    custom_resource_object = yaml.safe_load(custom_resource_yaml)
+
+    client.CustomObjectsApi().create_namespaced_custom_object(group, version, kernel_namespace, plural,
+                                                              custom_resource_object)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--RemoteProcessProxy.kernel-id', dest='kernel_id', nargs='?',
+                        help='Indicates the id associated with the launched kernel.')
+    parser.add_argument('--RemoteProcessProxy.port-range', dest='port_range', nargs='?',
+                        metavar='<lowerPort>..<upperPort>', help='Port range to impose for kernel ports')
+    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
+                        metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
+    parser.add_argument('--RemoteProcessProxy.public-key', dest='public_key', nargs='?',
+                        help='Public key used to encrypt connection information')
+    parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
+                        nargs='?', help='Indicates whether or how a spark context should be created',
+                        default='none')
+
+    arguments = vars(parser.parse_args())
+    kernel_id = arguments['kernel_id']
+    port_range = arguments['port_range']
+    response_addr = arguments['response_address']
+    public_key = arguments['public_key']
+    spark_context_init_mode = arguments['spark_context_init_mode']
+
+    launch_custom_resource_kernel(kernel_id, port_range, response_addr, public_key, spark_context_init_mode)

--- a/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
@@ -10,14 +10,7 @@ urllib3.disable_warnings()
 
 
 def generate_kernel_custom_resource_yaml(kernel_crd_template, keywords):
-    """Return the kubernetes pod spec as a yaml string.
-
-    - load jinja2 template from this file directory.
-    - substitute template variables with keywords items.
-    """
     j_env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)), trim_blocks=True, lstrip_blocks=True)
-    # jinja2 template substitutes template variables with None though keywords doesn't contain corresponding item.
-    # Therfore, no need to check if any are left unsubstituted. Kubernetes API server will validate the pod spec instead.
     k8s_yaml = j_env.get_template('/' + kernel_crd_template + '.yaml.j2').render(**keywords)
 
     return k8s_yaml

--- a/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -1,0 +1,32 @@
+apiVersion: "sparkoperator.k8s.io/v1beta2"
+kind: SparkApplication
+metadata:
+  name: {{ kernel_resource_name }}
+spec:
+  type: Python
+  pythonVersion: "3"
+  sparkVersion: 2.4.5
+  image: {{ kernel_image }}
+  mainApplicationFile: "local:///tmp/launch_ipykernel.py"
+  arguments:
+    - "--RemoteProcessProxy.kernel-id"
+    - "{{ kernel_id }}"
+    - "--RemoteProcessProxy.spark-context-initialization-mode"
+    - "{{ init_mode }}"
+    - "--RemoteProcessProxy.response-address"
+    - "{{ eg_response_address }}"
+    - "--RemoteProcessProxy.port-range"
+    - "{{ eg_port_range }}"
+  driver:
+    labels:
+      kernel_id: "{{ kernel_id }}"
+      app: enterprise-gateway
+      component: kernel
+    cores: 1
+    coreLimit: 1000m
+    memory: 1g
+  executor:
+    instances: 2
+    cores: 1
+    coreLimit: 1000m
+    memory: 1g

--- a/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -7,7 +7,7 @@ spec:
   pythonVersion: "3"
   sparkVersion: 2.4.5
   image: {{ kernel_image }}
-  mainApplicationFile: "local:////usr/local/bin/kernel-launchers/scripts/launch_ipykernel.py"
+  mainApplicationFile: "local:///usr/local/bin/kernel-launchers/python/scripts/launch_ipykernel.py"
   arguments:
     - "--RemoteProcessProxy.kernel-id"
     - "{{ kernel_id }}"
@@ -18,6 +18,7 @@ spec:
     - "--RemoteProcessProxy.port-range"
     - "{{ eg_port_range }}"
   driver:
+    serviceAccount: "{{ kernel_service_account_name }}"
     labels:
       kernel_id: "{{ kernel_id }}"
       app: enterprise-gateway

--- a/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -7,7 +7,7 @@ spec:
   pythonVersion: "3"
   sparkVersion: 2.4.5
   image: {{ kernel_image }}
-  mainApplicationFile: "local:///tmp/launch_ipykernel.py"
+  mainApplicationFile: "local:////usr/local/bin/kernel-launchers/scripts/launch_ipykernel.py"
   arguments:
     - "--RemoteProcessProxy.kernel-id"
     - "{{ kernel_id }}"

--- a/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -26,6 +26,7 @@ spec:
     coreLimit: 1000m
     memory: 1g
   executor:
+    image: {{ kernel_executor_image }}
     instances: 2
     cores: 1
     coreLimit: 1000m

--- a/etc/kernelspecs/spark_python_operator/kernel.json
+++ b/etc/kernelspecs/spark_python_operator/kernel.json
@@ -1,13 +1,14 @@
 {
   "language": "python",
-  "display_name": "Spark Python Operator Mode",
+  "display_name": "Spark Operator (Python)",
   "metadata": {
     "process_proxy": {
-      "class_name": "enterprise_gateway.services.processproxies.spark_operator.SparkOperatorProcessProxy"
+      "class_name": "enterprise_gateway.services.processproxies.spark_operator.SparkOperatorProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-spark-py:VERSION",
+        "executor_image_name": "elyra/kernel-spark-py:VERSION"
+      }
     }
-  },
-  "env": {
-    "KERNEL_IMAGE": "elyra/kernel-spark-py:VERSION"
   },
   "argv": [
     "python",

--- a/etc/kernelspecs/spark_python_operator/kernel.json
+++ b/etc/kernelspecs/spark_python_operator/kernel.json
@@ -1,0 +1,24 @@
+{
+  "language": "python",
+  "display_name": "Spark Python Operator Mode",
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.spark_operator.SparkOperatorProcessProxy"
+    }
+  },
+  "env": {
+    "KERNEL_IMAGE": "elyra/kernel-spark-py:VERSION"
+  },
+  "argv": [
+    "python",
+    "/usr/local/share/jupyter/kernels/spark_python_operator/scripts/launch_custom_resource.py",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}",
+    "--RemoteProcessProxy.public-key",
+    "{public_key}"
+  ]
+}

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -30,6 +30,9 @@ rules:
   - apiGroups: ["rbac.authorization.k8s.io"]
     resources: ["rolebindings"]
     verbs: ["get", "list", "create", "delete"]
+  - apiGroups: ["sparkoperator.k8s.io"]
+    resources: ["sparkapplications"]
+    verbs: ["get", "list", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
eg now has supported raw pod based k8s process proxy but maybe not so appropriate i wanna use some integrated k8s operator including some custom resources.

this PR implement a new process proxy, which makes it easy to define some kernel based on a certain k8s custom resource, such as spark application inside gcp spark operator. 

Resolves #984 