### PR TITLE
Fix `make dev` to set `PYTHONPATH`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ build:
 env: ## Make a dev environment
 	-conda env create --file requirements.yml --name $(ENV)
 
-activate: ## Activate the virtualenv (default: enterprise-gateway-dev)
-	@echo "$(SA) $(ENV)"
+activate: ## Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
+	@echo "Run \`$(SA) $(ENV)\` to activate the environment."
 
 clean: ## Make a clean source tree
 	-rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ help:
 build:
 env: ## Make a dev environment
 	-conda env create --file requirements.yml --name $(ENV)
+	-conda env config vars set PYTHONPATH=$(PWD) --name $(ENV)
 
 activate: ## Print instructions to activate the virtualenv (default: enterprise-gateway-dev)
 	@echo "Run \`$(SA) $(ENV)\` to activate the environment."


### PR DESCRIPTION
Without this, the `PYTHONPATH` environment variable is unset which leads to the error below.

```
(base) bgerrity@bgerrity-mbp enterprise_gateway % make dev
source activate enterprise-gateway-dev && python enterprise_gateway
Traceback (most recent call last):
  File "/opt/miniconda3/envs/enterprise-gateway-dev/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/miniconda3/envs/enterprise-gateway-dev/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/bgerrity/enterprise_gateway/enterprise_gateway/__main__.py", line 7, in <module>
    import enterprise_gateway.enterprisegatewayapp as app
ModuleNotFoundError: No module named 'enterprise_gateway'
make: *** [dev] Error 1
(base) bgerrity@bgerrity-mbp enterprise_gateway %
```

Also aligned the description and message of the `activate` message.

Not sure if this is the best way to address this problem, but having to do a manual `export PYTHONPATH=...` after `make env` seems wrong.