### PR TITLE
Add origin restriction config

### DIFF
--- a/docs/source/config-options.md
+++ b/docs/source/config-options.md
@@ -114,6 +114,12 @@ EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp) options
     carefully as it can dramatically limit who can launch kernels.
     (EG_AUTHORIZED_USERS env var - non-bracketed, just comma-separated)
     Default: set()
+--EnterpriseGatewayApp.authorized_origin=<Unicode>
+    Hostname (e.g. 'localhost', 'reverse.proxy.net') which the handler will
+    match against the request's SSL certificate.  An HTTP 403 (Forbidden) error
+    will be raised on a failed match.  This option requires TLS to be enabled.
+    It does not support IP addresses. (EG_AUTHORIZED_ORIGIN env var)
+    Default: ''
 --EnterpriseGatewayApp.base_url=<Unicode>
     The base path for mounting all API resources (EG_BASE_URL env var)
     Default: '/'

--- a/enterprise_gateway/mixins.py
+++ b/enterprise_gateway/mixins.py
@@ -447,6 +447,14 @@ class EnterpriseGatewayConfigMixin(Configurable):
         au_env = os.getenv(self.authorized_users_env)
         return au_env.split(',') if au_env is not None else []
 
+    # Authorized origin
+    authorized_origin_env = 'EG_AUTHORIZED_ORIGIN'
+    authorized_origin = Unicode(config=True,
+                                help="""Hostname (e.g. 'localhost', 'reverse.proxy.net') which the handler will match
+                                against the request's SSL certificate.  An HTTP 403 (Forbidden) error will be raised on
+                                a failed match.  This option requires TLS to be enabled.  It does not support IP
+                                addresses. (EG_AUTHORIZED_ORIGIN env var)""")
+
     # Port range
     port_range_env = 'EG_PORT_RANGE'
     port_range_default_value = "0..0"

--- a/enterprise_gateway/tests/test_gatewayapp.py
+++ b/enterprise_gateway/tests/test_gatewayapp.py
@@ -13,6 +13,7 @@ RESOURCES = os.path.join(os.path.dirname(__file__), 'resources')
 
 class TestGatewayAppConfig(unittest.TestCase):
     """Tests configuration of the gateway app."""
+
     def setUp(self):
         """Saves a copy of the environment."""
         self.environ = dict(os.environ)
@@ -89,14 +90,10 @@ class TestGatewayAppConfig(unittest.TestCase):
 
         self._assert_envs_to_traitlets()
 
-    def test_ssl_options(self):
+    def test_ssl_options_no_config(self):
         app = EnterpriseGatewayApp()
         ssl_options = app._build_ssl_options()
         self.assertIsNone(ssl_options)
-        app = EnterpriseGatewayApp()
-        os.environ['EG_CERTFILE'] = '/test/fake.crt'
-        ssl_options = app._build_ssl_options()
-        self.assertEqual(ssl_options['ssl_version'], 5)
 
 
 class TestGatewayAppBase(AsyncHTTPTestCase, ExpectLog):
@@ -108,6 +105,7 @@ class TestGatewayAppBase(AsyncHTTPTestCase, ExpectLog):
     app : KernelGatewayApp
         Instance of the app
     """
+
     def tearDown(self):
         """Shuts down the app after test run."""
         if self.app:


### PR DESCRIPTION
Addressing #989: It's a fairly simple SSL check and doesn't offer any support for running without authentication. Not sure if this is the best approach; open to any feedback or alternative implementations.