### PR TITLE
KIP: Add support for containerd-based installations

### DIFF
--- a/docs/source/kernel-kubernetes.md
+++ b/docs/source/kernel-kubernetes.md
@@ -246,6 +246,10 @@ The Kernel Image Puller can be configured for the interval at which it checks fo
 
 If the Enterprise Gateway defines an authentication token (`EG_AUTH_TOKEN`) then that same token should be configured here as (`KIP_AUTH_TOKEN`) so that the puller can correctly authenticate its requests.
 
+The Kernel Image Puller also supports multiple container runtimes since Docker is no longer configured by default in Kubernetes.  KIP currently supports Docker and Containerd runtimes.  If another runtime is encountered, KIP will try to proceed using the Containerd client `crictl` against the configured socket.  As a result, it is import that the `criSocket` value be appropriately configured relative to the container runtime.  If the runtime is something other than Docker or Containerd and `crictl` isn't able to pull images, it may be necessary to manually pre-seed images or incur kernel start timeouts the first time a given node is asked to start a kernel associated with a non-resident image.
+
+KIP also supports the notion of a _default container registry_ whereby image names that do not specify a registry (e.g., `docker.io` or `quay.io`) KIP will apply the configured default.  Ideally, the image name should be fully qualified.
+
 Here's what the Kernel Image Puller looks like in the yaml...
 ```yaml
 apiVersion: apps/v1
@@ -267,23 +271,30 @@ spec:
       containers:
       - name: kernel-image-puller
         image: elyra/kernel-image-puller:VERSION
-        env:
-          - name: KIP_GATEWAY_HOST
-            value: "http://enterprise-gateway.enterprise-gateway:8888"
-          - name: KIP_INTERVAL
-            value: "300"
-          - name: KIP_PULL_POLICY
-            value: "IfNotPresent"
-          # Optional authorization token passed in all requests (should match EG_AUTH_TOKEN)
-          - name: KIP_AUTH_TOKEN
-            value:
+           - name: KIP_LOG_LEVEL
+             value: {{ .Values.logLevel }}
+           - name: KIP_GATEWAY_HOST
+             value: "http://enterprise-gateway.{{ .Release.Namespace }}:{{ .Values.port }}"
+           - name: KIP_INTERVAL
+             value: !!str {{ .Values.kip.interval }}
+           - name: KIP_PULL_POLICY
+             value: {{ .Values.kip.pullPolicy }}
+           - name: KIP_CRI_ENDPOINT
+             value: "unix://{{ .Values.kip.criSocket }}"
+           - name: KIP_DEFAULT_CONTAINER_REGISTRY
+             value: {{ .Values.kip.defaultContainerRegistry }}
+         # Optional authorization token passed in all requests (should match EG_AUTH_TOKEN)
+              {{- if .Values.authToken }}
+        - name: KIP_AUTH_TOKEN
+          value: {{ .Values.authToken }}
+              {{- end }}
         volumeMounts:
-          - name: dockersock
-            mountPath: "/var/run/docker.sock"
+           - name: cri-socket
+             mountPath: !!str {{ .Values.kip.criSocket }}  # see env KIP_CRI_ENDPOINT
       volumes:
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
+         - name: cri-socket
+           hostPath:
+              path: {{ .Values.kip.criSocket }}
 ```
 
 

--- a/etc/docker/kernel-image-puller/Dockerfile
+++ b/etc/docker/kernel-image-puller/Dockerfile
@@ -8,6 +8,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY kernel_image_puller.py ./
 
+# Install crictl for use by KIP when non-docker installations are encountered.
+ARG CRICTL_VERSION=v1.22.0
+RUN curl -sL https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz | tar zxv -C /usr/local/bin
+
+RUN echo $PATH
 # The following environment variables are supported - defaults provided.  Override as needed.
 ENV KIP_GATEWAY_HOST http://localhost:8888
 ENV KIP_INTERVAL 300

--- a/etc/docker/kernel-image-puller/kernel_image_puller.py
+++ b/etc/docker/kernel-image-puller/kernel_image_puller.py
@@ -16,7 +16,7 @@ gateway_host = os.getenv("KIP_GATEWAY_HOST", "http://localhost:8888")
 num_pullers = int(os.getenv("KIP_NUM_PULLERS", "2"))
 num_retries = int(os.getenv("KIP_NUM_RETRIES", "3"))
 interval = int(os.getenv("KIP_INTERVAL", "300"))
-log_level = os.getenv("KIP_LOG_LEVEL", "DEBUG")
+log_level = os.getenv("KIP_LOG_LEVEL", "INFO")
 
 # Add authentication token support to KIP
 auth_token = os.getenv("KIP_AUTH_TOKEN", None)

--- a/etc/docker/kernel-image-puller/kernel_image_puller.py
+++ b/etc/docker/kernel-image-puller/kernel_image_puller.py
@@ -4,17 +4,19 @@ import queue
 import requests
 import time
 
-from kubernetes import config, client
 from docker.client import DockerClient
-from docker.errors import APIError
 from docker.errors import NotFound
+from subprocess import run
+from subprocess import CalledProcessError
 from threading import Thread
+from typing import List
+from typing import Optional
 
 gateway_host = os.getenv("KIP_GATEWAY_HOST", "http://localhost:8888")
 num_pullers = int(os.getenv("KIP_NUM_PULLERS", "2"))
 num_retries = int(os.getenv("KIP_NUM_RETRIES", "3"))
 interval = int(os.getenv("KIP_INTERVAL", "300"))
-log_level = os.getenv("KIP_LOG_LEVEL", "INFO")
+log_level = os.getenv("KIP_LOG_LEVEL", "DEBUG")
 
 # Add authentication token support to KIP
 auth_token = os.getenv("KIP_AUTH_TOKEN", None)
@@ -25,18 +27,24 @@ policies = (POLICY_IF_NOT_PRESENT, POLICY_ALYWAYS)
 
 policy = os.getenv("KIP_PULL_POLICY", POLICY_IF_NOT_PRESENT)
 
+runtime_endpoint = os.getenv("KIP_CRI_ENDPOINT", "unix:///run/containerd/containerd.sock")
+default_container_registry = os.getenv("KIP_DEFAULT_CONTAINER_REGISTRY", "docker.io")
+DOCKER_CLIENT = "docker"
+CONTAINERD_CLIENT = "containerd"
+supported_container_runtimes = (DOCKER_CLIENT, CONTAINERD_CLIENT)
+
 logging.basicConfig(format='[%(levelname)1.1s %(asctime)s %(name)s.%(threadName)s] %(message)s')
 
 
 def get_kernelspecs():
     """Fetches the set of kernelspecs from the gateway, returning a dict of configured kernel specs"""
-    end_point = '{}/api/kernelspecs'.format(gateway_host)
-    logger.info("Fetching kernelspecs from '{}' ...".format(end_point))
+    end_point = f"{gateway_host}/api/kernelspecs"
+    logger.info(f"Fetching kernelspecs from '{end_point}' ...")
     if auth_token:
-        end_point += '?token={}'.format(auth_token)
+        end_point += f"?token={auth_token}"
     resp = requests.get(end_point)
     if not resp.ok:
-        raise requests.exceptions.HTTPError('Gateway server response: {}'.format(resp.status_code))
+        raise requests.exceptions.HTTPError(f"Gateway server response: {resp.status_code}")
     return resp.json()
 
 
@@ -52,7 +60,7 @@ def fetch_image_names():
         kspecs_response = get_kernelspecs()
         kspecs = kspecs_response.get('kernelspecs')
     except Exception as ex:
-        logger.error("Got exception attempting to retrieve kernelspecs - retrying. Exception was: {}".format(ex))
+        logger.error(f"Got exception attempting to retrieve kernelspecs - retrying. Exception was: {ex}")
     finally:
         if kspecs is None:
             return False
@@ -73,21 +81,13 @@ def fetch_image_names():
                     if executor_image_name is not None:
                         images.add(executor_image_name)
 
-    # Add the image names to the name queue
-    if docker_client is None:
-        logger.warning(
-            """
-            KernelInfoPuller only operates on Docker-based K8s systems and is unable to pull kernel images at this time.  
-            Please pre-seed your nodes with the necessary kernel images prior to their use.
-            Images below cannot be pulled: 
-                {}
-            """.format(','.join(images)))
+    if not images:
         return False
-    else:
-        for image_name in images:
-            name_queue.put_nowait(image_name)
 
-        return True
+    # Add the image names to the name queue to be pulled
+    for image_name in images:
+        name_queue.put_nowait(image_name)
+    return True
 
 
 def pull_image(image_name):
@@ -96,35 +96,94 @@ def pull_image(image_name):
     If the policy is `IfNotPresent` the set of pulled image names is
     checked and, if present, the method returns.  Otherwise, the pull attempt is made
     and the set of pulled images is updated, when successful.
-
-    Since NotFound exceptions are tolerated, we trap for only that exception and let
-    the caller handle others.
     """
     if policy == POLICY_IF_NOT_PRESENT:
         if image_name in pulled_images:
             # Image has been pulled, but make sure it still exists.  If it doesn't exist
             # let this drop through to actual pull
-            logger.info("Image '{}' already pulled and policy is '{}'.  Checking existence.".
-                        format(image_name, policy))
-            try:
-                t1 = time.time()
-                docker_client.images.get(image_name)
-                t2 = time.time()
-                logger.debug("Checked existence of image '{}' in {:.3f} secs.".format(image_name, t2 - t1))
+            logger.info(f"Image '{image_name}' already pulled and policy is '{policy}'.  Checking existence.")
+            if image_exists(image_name):
                 return
-            except NotFound:
-                pulled_images.remove(image_name)
-                logger.warning("Previously pulled image '{}' was not found - attempting pull...".format(image_name))
+            pulled_images.remove(image_name)
+            logger.warning(f"Previously pulled image '{image_name}' was not found - attempting pull...")
 
-    logger.debug("Pulling image '{}'...".format(image_name))
-    try:
-        t1 = time.time()
-        docker_client.images.pull(image_name)
-        t2 = time.time()
+    logger.info(f"Pulling image '{image_name}'...")
+    if download_image(image_name):
         pulled_images.add(image_name)
-        logger.info("Pulled image '{}' in {:.3f} secs.".format(image_name, t2 - t1))
-    except NotFound:
-        logger.warning("Image '{}' was not found!".format(image_name))
+    else:
+        logger.warning(f"Image '{image_name}' was not downloaded!")
+
+
+def get_absolute_image_name(image_name: str) -> str:
+    """Ensures the image name is prefixed with a "registry". """
+    # We will check for the form 'registry/repo/image:tag' if the 'registry/' prefix
+    # is missing (based on the absence of two slashes), then we'll prefix the image
+    # name with the KIP_DEFAULT_CONTAINER_REGISTRY env value.
+    image_pieces = image_name.split('/')
+    if len(image_pieces) < 3:  # we're missing a registry specifier, use env
+        return f"{default_container_registry}/{image_name}"
+    return image_name  # take our chances
+
+
+def image_exists(image_name: str) -> bool:
+    """Checks for the existence of the named image using the configured container runtime."""
+    result = True
+    absolute_image_name = get_absolute_image_name(image_name)
+    t0 = time.time()
+    if container_runtime == DOCKER_CLIENT:
+        try:
+            DockerClient.from_env().images.get(absolute_image_name)
+        except NotFound:
+            result = False
+    elif container_runtime == CONTAINERD_CLIENT:
+        argv = ['crictl', '-r', runtime_endpoint, 'inspecti', '-q', absolute_image_name]
+        result = execute_cmd(argv)
+    else:  # invalid container runtime
+        logger.error(f"Invalid container runtime detected: '{container_runtime}'!")
+        result = False
+    t1 = time.time()
+    logger.debug(f"Checked existence of image '{image_name}' in {(t1 - t0):.3f} secs.  exists = {result}")
+    return result
+
+
+def download_image(image_name: str) -> bool:
+    """Downloads (pulls) the named image using the configured container runtime."""
+    result = True
+    absolute_image_name = get_absolute_image_name(image_name)
+    t0 = time.time()
+    if container_runtime == DOCKER_CLIENT:
+        try:
+            DockerClient.from_env().images.pull(absolute_image_name)
+        except NotFound:
+            result = False
+    elif container_runtime == CONTAINERD_CLIENT:
+        argv = ['crictl', '-r', runtime_endpoint, 'pull', absolute_image_name]
+        result = execute_cmd(argv)
+    else:  # invalid container runtime
+        logger.error(f"Invalid container runtime detected: '{container_runtime}'!")
+        result = False
+    t1 = time.time()
+    if result is True:
+        logger.info(f"Pulled image '{image_name}' in {(t1 - t0):.3f} secs.")
+    return result
+
+
+def execute_cmd(argv: List[str]) -> bool:
+    """Execute the given command expressed in 'argv'.  If expected_output is provided it
+
+    will be checked against the command's stdout after stripping off the '\n' character.
+    """
+    result = True
+    try:
+        run(argv, capture_output=True, text=True, check=True)
+    except CalledProcessError as cpe:
+        error_msg = cpe.stderr[:-1]  # strip off trailing newline
+        logger.error(f"Error executing {' '.join(argv)}: {error_msg}")
+        result = False
+    except Exception as ex:
+        logger.error(f"Error executing {' '.join(argv)}: {ex}")
+        result = False
+    return result
 
 
 def puller():
@@ -134,7 +193,6 @@ def puller():
     for NotFound, are retried up to num_retries times. Once the image has been pulled, it's not found or the
     retries have been exceeded, the queue task is marked as done.
     """
-
     while True:
         image_name = name_queue.get()
         if image_name is None:
@@ -145,55 +203,64 @@ def puller():
             try:
                 pull_image(image_name)
                 break
-            except APIError as ex:
+            except Exception as ex:
                 i += 1
                 if i < num_retries:
-                    logger.warning("Attempt {} to pull image '{}' encountered exception - retrying.  Exception was: {}".
-                                   format(i, image_name, ex))
+                    logger.warning(f"Attempt {i} to pull image '{image_name}' encountered exception - retrying.  "
+                                   f"Exception was: {ex}.")
                 else:
-                    logger.error("Attempt {} to pull image '{}' failed with exception: {}".
-                                 format(i, image_name, ex))
+                    logger.error(f"Attempt {i} to pull image '{image_name}' failed with exception: {ex}")
         name_queue.task_done()
 
 
-def _is_docker_runtime():
-    config.load_incluster_config()
-    first_node_name = client.CoreV1Api(client.ApiClient()).list_node().items[0].metadata.name
-    node_info = client.CoreV1Api(client.ApiClient()).read_node(name=first_node_name)
-    container_runtime = node_info.status.node_info.container_runtime_version
+def is_runtime_endpoint_recognized() -> bool:
+    return DOCKER_CLIENT in runtime_endpoint or CONTAINERD_CLIENT in runtime_endpoint
 
-    return 'docker://' in container_runtime
+
+def get_container_runtime() -> Optional[str]:
+    """Determine the container runtime from the KIP_CRI_ENDPOINT env."""
+
+    if DOCKER_CLIENT in runtime_endpoint:
+        return DOCKER_CLIENT
+
+    # This will essentially be the default to use in case we don't recognized the endpoint.
+    return CONTAINERD_CLIENT
 
 
 if __name__ == "__main__":
     logger = logging.getLogger('kernel_image_puller')
     logger.setLevel(log_level)
 
-    is_docker_runtime = _is_docker_runtime()
+    container_runtime = get_container_runtime()
 
     # Determine pull policy.
     pulled_images = set()
     if policy not in policies:
-        logger.warning("Invalid pull policy detected in KIP_PULL_POLICY: '{}'.  Using policy '{}'.".
-                       format(policy, POLICY_IF_NOT_PRESENT))
+        logger.warning(f"Invalid pull policy detected in KIP_PULL_POLICY: '{policy}'.  "
+                       f"Using policy '{POLICY_IF_NOT_PRESENT}'.")
         policy = POLICY_IF_NOT_PRESENT
 
     logger.info("Starting Kernel Image Puller with the following parameters:")
-    logger.info("KIP_GATEWAY_HOST: {}".format(gateway_host))
-    logger.info("KIP_INTERVAL: {} secs".format(interval))
-    logger.info("KIP_NUM_PULLERS: {}".format(num_pullers))
-    logger.info("KIP_NUM_RETRIES: {}".format(num_retries))
-    logger.info("KIP_PULL_POLICY: {}".format(policy))
-    logger.info("KIP_LOG_LEVEL: {}".format(log_level))
-    logger.info("KIP_AUTH_TOKEN: {}".format(auth_token))
-
-    docker_client = DockerClient.from_env() if is_docker_runtime else None
+    logger.info(f"KIP_GATEWAY_HOST: {gateway_host}")
+    logger.info(f"KIP_INTERVAL: {interval} secs")
+    logger.info(f"KIP_NUM_PULLERS: {num_pullers}")
+    logger.info(f"KIP_NUM_RETRIES: {num_retries}")
+    logger.info(f"KIP_PULL_POLICY: {policy}")
+    logger.info(f"KIP_LOG_LEVEL: {log_level}")
+    logger.info(f"KIP_AUTH_TOKEN: {auth_token}")
+    logger.info(f"KIP_DEFAULT_CONTAINER_REGISTRY: {default_container_registry}")
+    logger.info(f"KIP_CRI_ENDPOINT: {runtime_endpoint}")
+    if is_runtime_endpoint_recognized():
+        logger.info(f"Detected container runtime: {container_runtime}")
+    else:
+        logger.warning(f"This node's container runtime interface could not be detected from "
+                       f"endpoint: {runtime_endpoint}, proceeding with {container_runtime} client...")
 
     # Create an empty queue and start the puller threads.  The number of puller threads is configurable.
     name_queue = queue.Queue()
     threads = []
     for i in range(num_pullers):
-        t = Thread(target=puller, name="t{}".format(i + 1))
+        t = Thread(target=puller, name=f"t{(i + 1)}")
         t.start()
         threads.append(t)
 
@@ -207,7 +274,8 @@ if __name__ == "__main__":
         if fetched:
             wait_interval = interval  # Once we have fetched kernelspecs, update wait_interval
             name_queue.join()
-            logger.info("Images pulled.  Sleeping {} seconds...\n".format(wait_interval))
-        else:
-            logger.info("Sleeping {} seconds to fetch image names...\n".format(wait_interval))
+        elif not is_runtime_endpoint_recognized():
+            wait_interval = interval  # Increase the interval since we shouldn't pound the service for kernelspecs
+
+        logger.info(f"Sleeping {wait_interval} seconds to fetch image names...\n")
         time.sleep(wait_interval)

--- a/etc/kubernetes/helm/enterprise-gateway/Chart.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 name: enterprise-gateway
 description: A helm chart to deploy Jupyter Enterprise Gateway
-version: 3.0.0.dev0
+version: 3.0.0
 apiVersion: v1
 icon: https://avatars1.githubusercontent.com/u/7388996?s=200&v=4
 home: https://jupyter.org/enterprise_gateway

--- a/etc/kubernetes/helm/enterprise-gateway/templates/daemonset.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/templates/daemonset.yaml
@@ -18,27 +18,34 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      serviceAccountName: enterprise-gateway-sa
       containers:
       - name: kernel-image-puller
         image: {{ .Values.kip.image }}
         imagePullPolicy: {{ .Values.kip.imagePullPolicy }}
         env:
+        - name: KIP_LOG_LEVEL
+          value: {{ .Values.logLevel }}
         - name: KIP_GATEWAY_HOST
           value: "http://enterprise-gateway.{{ .Release.Namespace }}:{{ .Values.port }}"
         - name: KIP_INTERVAL
           value: !!str {{ .Values.kip.interval }}
         - name: KIP_PULL_POLICY
           value: {{ .Values.kip.pullPolicy }}
+        - name: KIP_CRI_ENDPOINT
+          value: "unix://{{ .Values.kip.criSocket }}"
+        - name: KIP_DEFAULT_CONTAINER_REGISTRY
+          value: {{ .Values.kip.defaultContainerRegistry }}
         # Optional authorization token passed in all requests (should match EG_AUTH_TOKEN)
         {{- if .Values.authToken }}
         - name: KIP_AUTH_TOKEN   
           value: {{ .Values.authToken }}
         {{- end }}
         volumeMounts:
-        - name: dockersock
-          mountPath: "/var/run/docker.sock"
+        - name: cri-socket
+          mountPath: !!str {{ .Values.kip.criSocket }}  # see env KIP_CRI_ENDPOINT
       volumes:
-      - name: dockersock
+      - name: cri-socket
         hostPath:
-          path: /var/run/docker.sock
+          path: {{ .Values.kip.criSocket }}
 {{- end }}

--- a/etc/kubernetes/helm/enterprise-gateway/values.yaml
+++ b/etc/kubernetes/helm/enterprise-gateway/values.yaml
@@ -84,5 +84,9 @@ kip:
   pullPolicy: IfNotPresent
   # The interval (in seconds) at which the Kernel Image Puller fetches kernelspecs to pull kernel images.
   interval: 300
+  # The container runtime interface socket, use /run/containerd/containerd.sock for containerd installations
+  criSocket: /var/run/docker.sock
+  # Prefix to use if a registry is not already specified on image name (e.g., quay.io/elyra/kernel-py:2.5.0)
+  defaultContainerRegistry: docker.io
 
 


### PR DESCRIPTION
PR #995 was introduced to better tolerate installations configured with a non-docker container runtime.  This PR introduces the use of `crictl` (Containerd's CLI tool) to check image existence and pull images when a docker runtime is not configured.

Since `crictl` needs to mount the container runtime socket (to accomplish docker-in-docker, or rather, container-in-container) this change makes that socket reference a configurable value in the helm chart.

If a CRI socket is configured that is not detected as Docker or Containerd, KIP will proceed with attempting image management using `crictl` since it can take a _runtime endpoint_ that is composable from the mounted socket value.  That said, there's a good chance that another runtime may introduce issues, but I'm hoping this PR introduces an appropriate framework to add support beyond `critctl`.

This PR also introduces a _default container registry_ configurable that allows any non-qualified images to be pulled from alternate registries (e.g., quay.io).

This was tested against Kubernetes clusters configured with Docker and Containerd runtimes.

I also converted statements using `.format` to `f-strings` - which introduces some noise on the changes. (sorry)

@abzymeinsjtu - I'm hoping you might have a chance to review this as well. 🙏 