### PR TITLE
Update base jupyter images, use their jupyter packages

### DIFF
--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_CONTAINER=jupyter/minimal-notebook:8e693aad7dcc
+ARG BASE_CONTAINER=jupyter/minimal-notebook:2022-01-24
 
 FROM $BASE_CONTAINER
 

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,14 +1,11 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/scipy-notebook:8e693aad7dcc
+ARG BASE_CONTAINER=jupyter/scipy-notebook:2022-01-24
 FROM $BASE_CONTAINER
 
 ENV PATH=$PATH:$CONDA_DIR/bin
 
 RUN conda install --quiet --yes \
     cffi \
-    ipykernel \
-    ipython \
-    jupyter_client \
     future \
     pycryptodomex && \
     conda clean -tipsy && \

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,10 +1,9 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/r-notebook:8e693aad7dcc
+ARG BASE_CONTAINER=jupyter/r-notebook:2022-01-24
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \
     'r-argparse' \
-    jupyter_client \
     pycryptodomex && \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -1,6 +1,6 @@
 # Ubuntu:Bionic
 # TensorFlow 2.4.0
-ARG BASE_CONTAINER=jupyter/tensorflow-notebook:8e693aad7dcc
+ARG BASE_CONTAINER=jupyter/tensorflow-notebook:2022-01-24
 
 FROM $BASE_CONTAINER
 
@@ -9,7 +9,6 @@ ENV KERNEL_LANGUAGE python
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 RUN conda install --quiet --yes \
-    ipykernel \
     pillow \
     future \
     pycryptodomex && \


### PR DESCRIPTION
After building new images in preparation for a 2.6.0, it was found that the ipykernel installed in python-kernel images did not include debugger support as it was installed from the conda defaults channel.  This caused the work done in #986 to appear as though debug was not available, when, in reality, the issue was with the docker image.

Instead, we should update the base jupyter images and NOT install jupyter packages over those, but use the packages in the base container.

I have confirmed that python debugger support is enabled with these changes and these will be part of the 2.6.0 release.

I've also found that the base images support date-based tags and all jupyter-derived images have been updated to use the builds tagged `2022-01-24`.  This will make it easier to locate the relative time a base image was built.