### PR TITLE
Validate images relative to python, spark, and debugger

### DIFF
--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -1,8 +1,11 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/scipy-notebook:2022-01-24
+ARG BASE_CONTAINER=jupyter/scipy-notebook:04f7f60d34a6
 FROM $BASE_CONTAINER
 
 ENV PATH=$PATH:$CONDA_DIR/bin
+
+# Add debugger support
+RUN pip install --upgrade ipykernel
 
 RUN conda install --quiet --yes \
     cffi \

--- a/etc/docker/kernel-py/README.md
+++ b/etc/docker/kernel-py/README.md
@@ -1,7 +1,7 @@
 This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster.  It is built on [jupyter/scipy-notebook](https://hub.docker.com/r/jupyter/scipy-notebook/).
 
 # What it Gives You
-* IPython kernel support 
+* IPython kernel support (with debugger)
 * [Data science libraries](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook)
 
 # Basic Use

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/r-notebook:2022-01-24
+ARG BASE_CONTAINER=jupyter/r-notebook:04f7f60d34a6
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \

--- a/etc/docker/kernel-spark-py/README.md
+++ b/etc/docker/kernel-spark-py/README.md
@@ -1,7 +1,7 @@
 This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster.  It is built on the base image [elyra/kernel-py](https://hub.docker.com/r/elyra/kernel-py/), and adds [Apache Spark 2.4.6](https://spark.apache.org/docs/2.4.6/).  Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
 
 # What it Gives You
-* IPython kernel support 
+* IPython kernel support (with debugger)
 * [Data science libraries](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook)
 * Spark on kubernetes support from within a Jupyter Notebook
 

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu:xenial
-ARG BASE_CONTAINER=tensorflow/tensorflow:2.4.0-gpu-jupyter
+ARG BASE_CONTAINER=tensorflow/tensorflow:2.7.0-gpu-jupyter
 FROM $BASE_CONTAINER
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -yq \
     tzdata \
     unzip && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --upgrade future pycryptodomex ipykernel>=6.0
+    pip install --upgrade future pycryptodomex ipykernel
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 

--- a/etc/docker/kernel-tf-gpu-py/README.md
+++ b/etc/docker/kernel-tf-gpu-py/README.md
@@ -1,7 +1,7 @@
-This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations.  It is currently built on [tensorflow/tensorflow:1.12.0-gpu-py3](https://hub.docker.com/r/tensorflow/tensorflow/) deriving from the [tensorflow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/README.md) project.
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations.  It is currently built on [tensorflow/tensorflow:2.7.0-gpu-jupyter](https://hub.docker.com/r/tensorflow/tensorflow/) deriving from the [tensorflow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/docker/README.md) project.
 
 # What it Gives You
-* IPython kernel support supplemented with Tensorflow functionality
+* IPython kernel support supplemented with Tensorflow functionality (and deubugger)
 
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.

--- a/etc/docker/kernel-tf-py/README.md
+++ b/etc/docker/kernel-tf-py/README.md
@@ -1,7 +1,7 @@
 This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations.  It is currently built on the [jupyter/tensorflow-notebook](https://hub.docker.com/r/jupyter/tensorflow-notebook) image deriving from the [jupyter/tensorflow-notebook](https://github.com/jupyter/docker-stacks/tree/master/tensorflow-notebook) project.
 
 # What it Gives You
-* IPython kernel support supplemented with Tensorflow functionality
+* IPython kernel support supplemented with Tensorflow functionality (and debugger)
 
 # Basic Use
 Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) per its instructions and configured to the appropriate environment.


### PR DESCRIPTION
After creating and running images with the #986 and (then) #1029 PRs while preparing for the EG 2.6.0 release, several issues were discovered, mostly related to python, spark, and R versions.  In addition, the tensorflow-gpu image was also using an older version of `ipykernel`.

This PR essentially reverts the jupyter docker-stack base images for kernel-py and kernel-r, upon which their corresponding spark-based images are derived.  It also updates the version of tensorflow for the GPU image from 2.4.0 to 2.7.0.  Note that the version of tensorflow for the regular image (derived from jupyter/tensorflow-notebook) is using tensorflow 2.6.2.

Some of the README files that are posted on dockerhub have also been updated where appropriate.

One thing learned from this exercise is that PySpark on Spark 2.4.6 only supports Python 3.7 (or lower).  We will need to revisit these base images when moving to Spark 3.2 (in EG 3.0), but I suspect things will be a bit more straightforward and I'm hoping we can use synchronized tag values at that time.