### PR TITLE
Spark operator k8s updates to enable it in gateway on k8s

### DIFF
--- a/etc/Makefile
+++ b/etc/Makefile
@@ -68,7 +68,7 @@ TOREE_LAUNCHER_FILES:=$(shell find kernel-launchers/scala/toree-launcher/src -ty
 PATTERN_kernelspecs_all := *
 PATTERN_kernelspecs_yarn := *_yarn_*
 PATTERN_kernelspecs_conductor := *_conductor_*
-PATTERN_kernelspecs_kubernetes := *_kubernetes
+PATTERN_kernelspecs_kubernetes := {*_kubernetes,*_operator}
 PATTERN_kernelspecs_docker := *_docker
 
 define BUILD_KERNELSPEC

--- a/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
@@ -1,3 +1,4 @@
+#!/opt/conda/bin/python
 import os
 import yaml
 import argparse

--- a/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_custom_resource.py
@@ -27,7 +27,7 @@ def launch_custom_resource_kernel(kernel_id, port_range, response_addr, public_k
     keywords['eg_response_address'] = response_addr
     keywords['kernel_id'] = kernel_id
     keywords['kernel_name'] = os.path.basename(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    keywords['kernel_spark_context_init_mode'] = spark_context_init_mode
+    keywords['spark_context_initialization_mode'] = spark_context_init_mode
 
     for name, value in os.environ.items():
         if name.startswith('KERNEL_'):
@@ -48,15 +48,15 @@ def launch_custom_resource_kernel(kernel_id, port_range, response_addr, public_k
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--RemoteProcessProxy.kernel-id', dest='kernel_id', nargs='?',
+    parser.add_argument('--kernel-id', '--RemoteProcessProxy.kernel-id', dest='kernel_id', nargs='?',
                         help='Indicates the id associated with the launched kernel.')
-    parser.add_argument('--RemoteProcessProxy.port-range', dest='port_range', nargs='?',
+    parser.add_argument('--port-range', '--RemoteProcessProxy.port-range',  dest='port_range', nargs='?',
                         metavar='<lowerPort>..<upperPort>', help='Port range to impose for kernel ports')
-    parser.add_argument('--RemoteProcessProxy.response-address', dest='response_address', nargs='?',
+    parser.add_argument('--response-address', '--RemoteProcessProxy.response-address',  dest='response_address', nargs='?',
                         metavar='<ip>:<port>', help='Connection address (<ip>:<port>) for returning connection file')
-    parser.add_argument('--RemoteProcessProxy.public-key', dest='public_key', nargs='?',
+    parser.add_argument('--public-key', '--RemoteProcessProxy.public-key', dest='public_key', nargs='?',
                         help='Public key used to encrypt connection information')
-    parser.add_argument('--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
+    parser.add_argument('--spark-context-initialization-mode', '--RemoteProcessProxy.spark-context-initialization-mode', dest='spark_context_init_mode',
                         nargs='?', help='Indicates whether or how a spark context should be created',
                         default='none')
 

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -1,3 +1,4 @@
+#!/opt/conda/bin/python
 import os
 import sys
 import yaml

--- a/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -9,13 +9,13 @@ spec:
   image: {{ kernel_image }}
   mainApplicationFile: "local:///usr/local/bin/kernel-launchers/python/scripts/launch_ipykernel.py"
   arguments:
-    - "--RemoteProcessProxy.kernel-id"
+    - "--kernel-id"
     - "{{ kernel_id }}"
-    - "--RemoteProcessProxy.spark-context-initialization-mode"
-    - "{{ init_mode }}"
-    - "--RemoteProcessProxy.response-address"
+    - "--spark-context-initialization-mode"
+    - "{{ spark_context_initialization_mode }}"
+    - "--response-address"
     - "{{ eg_response_address }}"
-    - "--RemoteProcessProxy.port-range"
+    - "--port-range"
     - "{{ eg_port_range }}"
   driver:
     serviceAccount: "{{ kernel_service_account_name }}"

--- a/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/kubernetes/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -17,6 +17,8 @@ spec:
     - "{{ eg_response_address }}"
     - "--port-range"
     - "{{ eg_port_range }}"
+    - "--public-key"
+    - "{{ eg_public_key }}"
   driver:
     serviceAccount: "{{ kernel_service_account_name }}"
     labels:

--- a/etc/kubernetes/enterprise-gateway.yaml
+++ b/etc/kubernetes/enterprise-gateway.yaml
@@ -31,8 +31,8 @@ rules:
     resources: ["rolebindings"]
     verbs: ["get", "list", "create", "delete"]
   - apiGroups: ["sparkoperator.k8s.io"]
-    resources: ["sparkapplications"]
-    verbs: ["get", "list", "create", "delete"]
+    resources: ["sparkapplications", "sparkapplications/status", "scheduledsparkapplications", "scheduledsparkapplications/status"]
+    verbs: ["get", "watch", "list", "create", "delete", "deletecollection", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This adds the Spark Operator to K8s kernespecs package, updates the spark operator parameters to follow the new EG/Jupyter Client pattern, and fixes in the proxy to be able to run and submit jobs via it