### PR TITLE
Build images during release, capture release build/dist dirs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -246,9 +246,9 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
 
     cd $SOURCE_DIR
     if [ -z "$DRY_RUN" ]; then
-        make clean dist release docs
+        make clean dist release docs docker-images push-images
     else
-        make clean dist docs
+        make clean dist docs docker-images
     fi
     mkdir -p $WORK_DIR/$RELEASE_TAG
     cp $SOURCE_DIR/dist/jupyter_enterprise_gateway* $WORK_DIR/$RELEASE_TAG
@@ -260,6 +260,8 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
     update_version_to_development
 
     cd $SOURCE_DIR
+    mv dist $WORK_DIR/$RELEASE_TAG
+    mv build $WORK_DIR/$RELEASE_TAG
     make clean dist docs
 
     # Build next development iteraction


### PR DESCRIPTION
It would be helpful to build the docker images during the release build.  These will be pushed if the release is not in "dryRun", otherwise they remain on the local system.  Previously, it was not sufficient to build the images from the release working directory because, after the release script has run, the dev versions are in place and extra care was required to get the proper kernelspecs included, etc.

The script also "captures" the `build` and `dist` trees to the version-specific directory.  This will more easily enable troubleshooting and "adjustments" to build artifacts (if necessary).