### PR TITLE
Revert the RTD python version to 3.8

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,6 +5,6 @@ channels:
   - free
 dependencies:
   - pip
-  - python=3.9
+  - python=3.8
   - pip:
       - -r doc-requirements.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,7 @@ sphinx:
 conda:
     environment: docs/environment.yml
 python:
-    version: 3.9
+    version: "3.8"
     install:
         # install itself with pip install .
         - method: pip


### PR DESCRIPTION
The RTD builds were breaking with the merge of https://github.com/jupyter/enterprise_gateway/pull/1034 due to the Python 3.9 reference: https://readthedocs.org/projects/jupyter-enterprise-gateway/builds/15945185/

This PR reverts the Python version to 3.8 for the time being.  We can revisit later (when the docs are reformatted).