### PR TITLE
Fix RTD - remove IPython highlighting reference

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
-    "IPython.sphinxext.ipython_console_highlighting",
     "sphinxcontrib_github_alt",
     "sphinxcontrib.openapi",
     "sphinxemoji.sphinxemoji",

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -9,3 +9,4 @@ python:
         # install itself with pip install .
         - method: pip
           path: .
+


### PR DESCRIPTION
An additional (and hopefully last) PR to fix the RTD build.  We got further with #1035, but this PR removes the reference to IPython highlighting extension. This reference was "inherited" from the jupyter_server config, but EG doesn't use it (that I know of).