### PR TITLE
Cap jupyter_server < 2 until kernel provisioners are supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "docker>=3.5.0",
   "future",
   "jinja2>=3.1",
-  "jupyter_client>=6.1.5,<7",  # Remove cap once EG supports kernel provisioners
+  "jupyter_client>=6.1.12,<7",  # Remove cap once EG supports kernel provisioners
   "jupyter_core>=4.7.0",
   "kubernetes>=18.20.0",
   "jupyter_server>=1.3,<2.0",  # Remove cap (increase floor) once EG suport kernel provisioners


### PR DESCRIPTION
We need to cap the Jupyter Server dependency until EG supports kernel provisioners, at which time we'll raise the floor to >= 2.0.

Resolves #1185