### PR TITLE
Prometheus http and kernel startup/shutdown metrics

### DIFF
--- a/enterprise_gateway/base/handlers.py
+++ b/enterprise_gateway/base/handlers.py
@@ -8,6 +8,7 @@ import json
 from typing import List
 
 import jupyter_server._version
+import prometheus_client
 from jupyter_server.base.handlers import APIHandler
 from tornado import web
 
@@ -31,6 +32,17 @@ class APIVersionHandler(TokenAuthorizationMixin, CORSMixin, JSONErrorsMixin, API
         )
 
 
+class PrometheusMetricsHandler(CORSMixin, web.RequestHandler):
+    """
+    Return prometheus metrics from this enterprise gateway
+    """
+
+    def get(self):
+        """Get the latest state of the Prometheus' metrics."""
+        self.set_header("Content-Type", prometheus_client.CONTENT_TYPE_LATEST)
+        self.write(prometheus_client.generate_latest(prometheus_client.REGISTRY))
+
+
 class NotFoundHandler(JSONErrorsMixin, web.RequestHandler):
     """
     Catches all requests and responds with 404 JSON messages.
@@ -48,4 +60,8 @@ class NotFoundHandler(JSONErrorsMixin, web.RequestHandler):
         raise web.HTTPError(404)
 
 
-default_handlers: List[tuple] = [(r"/api", APIVersionHandler), (r"/(.*)", NotFoundHandler)]
+default_handlers: List[tuple] = [
+    (r"/api", APIVersionHandler),
+    (r"/metrics", PrometheusMetricsHandler),
+    (r"/(.*)", NotFoundHandler),
+]

--- a/enterprise_gateway/enterprisegatewayapp.py
+++ b/enterprise_gateway/enterprisegatewayapp.py
@@ -37,6 +37,7 @@ from .services.sessions.kernelsessionmanager import (
     WebhookKernelSessionManager,
 )
 from .services.sessions.sessionmanager import SessionManager
+from .webapp import EnterpriseGatewayWebApp
 
 try:
     from jupyter_server.auth.authorizer import AllowAllAuthorizer
@@ -219,7 +220,7 @@ class EnterpriseGatewayApp(EnterpriseGatewayConfigMixin, JupyterApp):
 
         handlers = self._create_request_handlers()
 
-        self.web_app = web.Application(
+        self.web_app = EnterpriseGatewayWebApp(
             handlers=handlers,
             kernel_manager=self.kernel_manager,
             session_manager=self.session_manager,

--- a/enterprise_gateway/metrics.py
+++ b/enterprise_gateway/metrics.py
@@ -1,0 +1,30 @@
+"""Collection of all the metrics used by the Enterprise Gateway"""
+
+import os
+
+from prometheus_client import Histogram
+
+metrics_prefix = os.environ.get("EG_METRICS_PREFIX", "enterprise_gateway")
+
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    'http_request_duration_seconds',
+    'Request duration for all HTTP requests',
+    ['method', 'handler', 'status_code'],
+    namespace=metrics_prefix,
+)
+
+KERNEL_START_DURATION_SECONDS = Histogram(
+    'kernel_start_duration_seconds',
+    'Kernel startup duration',
+    ['kernel_name', 'process_proxy'],
+    buckets=[0.1, 0.25, 0.5, 1, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0],
+    namespace=metrics_prefix,
+)
+
+KERNEL_SHUTDOWN_DURATION_SECONDS = Histogram(
+    'kernel_shutdown_duration_seconds',
+    'Kernel startup duration for all HTTP requests',
+    ['kernel_name', 'process_proxy'],
+    buckets=[0.1, 0.25, 0.5, 1, 2.5, 5.0, 10.0, 15.0, 20.0, 30.0],
+    namespace=metrics_prefix,
+)

--- a/enterprise_gateway/tests/test_handlers.py
+++ b/enterprise_gateway/tests/test_handlers.py
@@ -557,6 +557,12 @@ class TestDefaults(TestHandlers):
             if ws:
                 ws.close()
 
+    @gen_test
+    def test_get_metrics(self):
+        """Getting the swagger.json spec should be ok"""
+        response = yield self.http_client.fetch(self.get_url("/metrics"))
+        self.assertEqual(response.code, 200)
+
 
 class TestCustomDefaultKernel(TestHandlers):
     """Tests gateway behavior when setting a custom default kernelspec."""

--- a/enterprise_gateway/webapp.py
+++ b/enterprise_gateway/webapp.py
@@ -1,0 +1,36 @@
+"""Tornado web app for enterprise_gateway."""
+
+from tornado import web
+from tornado.web import RequestHandler
+
+from enterprise_gateway.metrics import HTTP_REQUEST_DURATION_SECONDS
+
+
+class EnterpriseGatewayWebApp(web.Application):
+    """
+    Custom Tornado web application that handles all HTTP traffic for the Enterprise Gateway.
+    """
+
+    def log_request(self, handler: RequestHandler) -> None:
+        """
+        Tornado log handler for recording RED metrics.
+
+        We record the following metrics:
+           Rate: the number of requests, per second, your services are serving.
+           Errors: the number of failed requests per second.
+           Duration: the amount of time each request takes expressed as a time interval.
+
+        We use a fully qualified name of the handler as a label,
+        rather than every url path to reduce cardinality.
+
+        This function should be either the value of or called from a function
+        that is the 'log_function' tornado setting. This makes it get called
+        at the end of every request, allowing us to record the metrics we need.
+        """
+        super().log_request(handler)
+
+        HTTP_REQUEST_DURATION_SECONDS.labels(
+            method=handler.request.method,
+            handler=f'{handler.__class__.__module__}.{type(handler).__name__}',
+            status_code=handler.get_status(),
+        ).observe(handler.request.request_time())


### PR DESCRIPTION
This MR is taking on #731.

The `jupyter_server` already ships with a `PrometheusMetricsHandler`, however, that handler inherits from `JupyterHandler`, which requires authentication. The enterprise gateway project doesn't integrate with that method of authentication, therefore I added separate handler to serve the metrics.

I've included 3 metrics in the initial implementation:
- All HTTP response timings per handler, status_code and method
- Kernel startup duration in seconds
- Kernel shutdown duration in seconds

In terms of configuration, I've included the `EG_METRICS_PREFIX` environment variable for now, similar to how other configurations for the process proxies are set.

<details>
<summary> Sample responses from the /metrics endpoint</summary>
<pre>
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.005",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.01",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.025",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.05",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.075",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.1",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.25",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.5",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="0.75",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="1.0",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="2.5",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="5.0",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="7.5",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="10.0",method="POST",status_code="200"} 0.0
enterprise_gateway_http_request_duration_seconds_bucket{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",le="+Inf",method="POST",status_code="200"} 1.0
enterprise_gateway_http_request_duration_seconds_count{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",method="POST",status_code="200"} 1.0
enterprise_gateway_http_request_duration_seconds_sum{handler="enterprise_gateway.services.kernels.handlers.KernelActionHandler",method="POST",status_code="200"} 19.83746862411499
</pre>
</details>