### PR TITLE
Add support for KERNEL_VOLUMES and KERNEL_VOLUME_MOUNTS to Spark Operator

### DIFF
--- a/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
+++ b/etc/kernel-launchers/operators/scripts/sparkoperator.k8s.io-v1beta2.yaml.j2
@@ -38,6 +38,18 @@ spec:
     cores: 1
     coreLimit: 1000m
     memory: 1g
+    volumeMounts:
+      {% if kernel_volume_mounts is defined %}
+        {% for mount in kernel_volume_mounts %}
+      - {{ mount }}
+        {% endfor %}
+      {% endif %}
+    volumes:
+      {% if kernel_volumes is defined %}
+        {% for volume in kernel_volumes %}
+      - {{ volume }}
+        {% endfor %}
+      {% endif %}
   executor:
     env:
 # Add any custom envs here that aren't already configured for the kernel's environment
@@ -54,6 +66,18 @@ spec:
     cores: 1
     coreLimit: 1000m
     memory: 1g
+    volumeMounts:
+      {% if kernel_volume_mounts is defined %}
+        {% for mount in kernel_volume_mounts %}
+      - {{ mount }}
+        {% endfor %}
+      {% endif %}
+    volumes:
+      {% if kernel_volumes is defined %}
+        {% for volume in kernel_volumes %}
+      - {{ volume }}
+        {% endfor %}
+      {% endif %}
 {% if kernel_sparkapp_config_map %}
   sparkConfigMap: {{ kernel_sparkapp_config_map }}
 {% endif %}


### PR DESCRIPTION
This patch adds support for injecting KERNEL_VOLUMES and KERNEL_VOLUME_MOUNTS into the Spark Operator kernel templates.
Previously, the Spark Operator kernelspec did not include any volumeMounts or volumes sections, so environment variables like KERNEL_VOLUMES and KERNEL_VOLUME_MOUNTS had no effect.

With this change, Enterprise Gateway now correctly propagates these variables into the generated SparkApplication manifest, allowing driver and executor pods to mount shared volumes (e.g. NFS or PVC) defined in the notebook environment.