### PR TITLE
Upgrade the base docker image of kernel-r

### DIFF
--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,8 +1,5 @@
-# quay.io/jupyter
-ARG HUB_ORG
-
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=$HUB_ORG/r-notebook:r-4.5.2
+ARG BASE_CONTAINER=quay.io/jupyter/r-notebook:r-4.5.2
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -1,5 +1,8 @@
+# quay.io/jupyter
+ARG HUB_ORG
+
 # Ubuntu 18.04.1 LTS Bionic
-ARG BASE_CONTAINER=jupyter/r-notebook:2023-03-13
+ARG BASE_CONTAINER=$HUB_ORG/r-notebook:r-4.5.2
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \


### PR DESCRIPTION
The base image (BASE_CONTAINER) of the `elyra/kernel-r` docker image is old and the version of R used in there is `4.2.2`. More recent version of R is available that users would prefer to use. With the change the underlying Debian OS is also getting upgraded to `trixie` with latest security fixes. 