### PR TITLE
Fix ruff lint violations in handlers, container, and tests

### DIFF
--- a/enterprise_gateway/services/kernels/handlers.py
+++ b/enterprise_gateway/services/kernels/handlers.py
@@ -36,6 +36,46 @@ class MainKernelHandler(
     def inherited_envs(self):
         return self.settings["eg_inherited_envs"]
 
+    def _build_kernel_env(self, model_env: dict[str, Any]) -> dict[str, str]:
+        """Build the kernel environment from the request model and server settings."""
+        env = {key: value for key, value in os.environ.items() if key in self.inherited_envs}
+
+        allowed_envs: list[str]
+        allowed_envs = list(model_env.keys()) if self.client_envs == ["*"] else self.client_envs
+        for key, value in model_env.items():
+            if key.startswith("KERNEL_") or key in allowed_envs:
+                if not isinstance(value, str):
+                    raise tornado.web.HTTPError(
+                        400, f"Environment variable '{key}' value must be a string"
+                    )
+                if len(value) > MAX_ENV_VALUE_LENGTH:
+                    raise tornado.web.HTTPError(
+                        400, f"Environment variable '{key}' exceeds maximum length"
+                    )
+                env[key] = value
+        return env
+
+    def _build_kernel_headers(self) -> dict[str, str]:
+        """Build kernel headers from the request based on server settings."""
+        kernel_headers = {}
+        missing_headers = []
+        kernel_header_names = self.settings["eg_kernel_headers"]
+        for name in kernel_header_names:
+            if name:
+                value = self.request.headers.get(name)
+                if value:
+                    kernel_headers[name] = value
+                else:
+                    missing_headers.append(name)
+
+        if missing_headers:
+            self.log.warning(
+                "The following headers specified in 'kernel-headers' were not found: {}".format(
+                    missing_headers
+                )
+            )
+        return kernel_headers
+
     async def post(self):
         """Overrides the super class method to manage env in the request body.
 
@@ -53,51 +93,13 @@ class MainKernelHandler(
             if len(kernels) >= max_kernels:
                 raise tornado.web.HTTPError(403, "Resource Limit")
 
-        # Try to get env vars from the request body
         model = self.get_json_body()
         if model is not None and "env" in model:
             if not isinstance(model["env"], dict):
                 raise tornado.web.HTTPError(400)
 
-            # Transfer inherited environment variables from current process
-            env = {key: value for key, value in os.environ.items() if key in self.inherited_envs}
-
-            # Allow all KERNEL_* envs and those specified in client_envs and set from client.  If this EG
-            # instance is configured to accept all envs in the payload (i.e., client_envs == '*'), go ahead
-            # and add those keys to the "working" allowed_envs list, otherwise, just transfer the configured envs.
-            allowed_envs: list[str]
-            allowed_envs = model["env"].keys() if self.client_envs == ["*"] else self.client_envs
-            # Allow KERNEL_* args and those allowed by configuration.
-            for key, value in model["env"].items():
-                if key.startswith("KERNEL_") or key in allowed_envs:
-                    if not isinstance(value, str):
-                        raise tornado.web.HTTPError(
-                            400, f"Environment variable '{key}' value must be a string"
-                        )
-                    if len(value) > MAX_ENV_VALUE_LENGTH:
-                        raise tornado.web.HTTPError(
-                            400, f"Environment variable '{key}' exceeds maximum length"
-                        )
-                    env[key] = value
-
-            # If kernel_headers are configured, fetch each of those and include in start request
-            kernel_headers = {}
-            missing_headers = []
-            kernel_header_names = self.settings["eg_kernel_headers"]
-            for name in kernel_header_names:
-                if name:  # Ignore things like empty strings
-                    value = self.request.headers.get(name)
-                    if value:
-                        kernel_headers[name] = value
-                    else:
-                        missing_headers.append(name)
-
-            if len(missing_headers):
-                self.log.warning(
-                    "The following headers specified in 'kernel-headers' were not found: {}".format(
-                        missing_headers
-                    )
-                )
+            env = self._build_kernel_env(model["env"])
+            kernel_headers = self._build_kernel_headers()
 
             # No way to override the call to start_kernel on the kernel manager
             # so do a temporary partial (ugh)

--- a/enterprise_gateway/services/processproxies/container.py
+++ b/enterprise_gateway/services/processproxies/container.py
@@ -39,18 +39,18 @@ def _parse_prohibited_ids(env_var: str, default: str) -> list[int]:
     result: list[int] = []
     raw_value = os.getenv(env_var, default)
     for item in raw_value.split(","):
-        item = item.strip()
-        if item:
+        stripped = item.strip()
+        if stripped:
             try:
-                result.append(int(item))
+                result.append(int(stripped))
             except ValueError:
                 msg = (
-                    f"Invalid entry '{item}' in {env_var}='{raw_value}'. "
+                    f"Invalid entry '{stripped}' in {env_var}='{raw_value}'. "
                     f"All entries must be numeric IDs, not usernames or group names. "
                     f"Example: {env_var}=0,1000"
                 )
                 log.critical(msg)
-                raise ValueError(msg)
+                raise ValueError(msg) from None
     return result
 
 

--- a/enterprise_gateway/tests/test_yaml_injection.py
+++ b/enterprise_gateway/tests/test_yaml_injection.py
@@ -273,7 +273,7 @@ class TestSecurityContextInjection(unittest.TestCase):
         sc = docs[0]["spec"]["securityContext"]
         self.assertEqual(sc["runAsUser"], 1000)
         env["KERNEL_WORKING_DIR"] = (
-            '/tmp\n...\n---\napiVersion: v1\nkind: Pod\nmetadata:\n'
+            '/tmp\n...\n---\napiVersion: v1\nkind: Pod\nmetadata:\n'  # noqa: S108
             '  name: injected-pod\nspec:\n  containers:\n'
             '  - name: evil\n    image: nginx\n    securityContext:\n'
             '      privileged: true\n...\n'
@@ -402,9 +402,7 @@ class TestSparkOperatorTemplate(unittest.TestCase):
             ),
         )
         j_env.filters["yaml_safe"] = yaml_safe_str
-        return j_env.get_template(
-            "/sparkoperator.k8s.io-v1beta2.yaml.j2"
-        ).render(**keywords)
+        return j_env.get_template("/sparkoperator.k8s.io-v1beta2.yaml.j2").render(**keywords)
 
     def test_injection_via_kernel_image_blocked(self):
         keywords = {

--- a/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
+++ b/etc/kernel-launchers/kubernetes/scripts/launch_kubernetes.py
@@ -15,7 +15,14 @@ urllib3.disable_warnings()
 
 KERNEL_POD_TEMPLATE_PATH = "/kernel-pod.yaml.j2"
 
-ALLOWED_K8S_KINDS = {"Pod", "Secret", "PersistentVolumeClaim", "PersistentVolume", "Service", "ConfigMap"}
+ALLOWED_K8S_KINDS = {
+    "Pod",
+    "Secret",
+    "PersistentVolumeClaim",
+    "PersistentVolume",
+    "Service",
+    "ConfigMap",
+}
 MAX_DOCUMENTS_PER_KIND = 1
 YAML_PARSED_KERNEL_VARS = {"KERNEL_VOLUME_MOUNTS", "KERNEL_VOLUMES"}
 
@@ -153,7 +160,9 @@ def launch_kubernetes_kernel(
         if name.startswith("KERNEL_"):
             if name in YAML_PARSED_KERNEL_VARS:
                 parsed = yaml.safe_load(value)
-                if not isinstance(parsed, list) or not all(isinstance(item, dict) for item in parsed):
+                if not isinstance(parsed, list) or not all(
+                    isinstance(item, dict) for item in parsed
+                ):
                     sys.exit(
                         f"ERROR - {name} must be a YAML list of mappings - "
                         f"kernel launch terminating!"

--- a/etc/kernel-launchers/operators/scripts/launch_custom_resource.py
+++ b/etc/kernel-launchers/operators/scripts/launch_custom_resource.py
@@ -97,7 +97,9 @@ def launch_custom_resource_kernel(
         if name.startswith("KERNEL_"):
             if name in YAML_PARSED_KERNEL_VARS:
                 parsed = yaml.safe_load(value)
-                if not isinstance(parsed, list) or not all(isinstance(item, dict) for item in parsed):
+                if not isinstance(parsed, list) or not all(
+                    isinstance(item, dict) for item in parsed
+                ):
                     sys.exit(
                         f"ERROR - {name} must be a YAML list of mappings - "
                         f"kernel launch terminating!"
@@ -108,7 +110,9 @@ def launch_custom_resource_kernel(
 
     kernel_crd_template = keywords["kernel_crd_group"] + "-" + keywords["kernel_crd_version"]
     if not re.match(r'^[a-z0-9][a-z0-9.\-]*-v[a-z0-9]+$', kernel_crd_template):
-        sys.exit(f"ERROR - Invalid CRD template name: {kernel_crd_template} - kernel launch terminating!")
+        sys.exit(
+            f"ERROR - Invalid CRD template name: {kernel_crd_template} - kernel launch terminating!"
+        )
 
     custom_resource_yaml = generate_kernel_custom_resource_yaml(kernel_crd_template, keywords)
 
@@ -118,7 +122,9 @@ def launch_custom_resource_kernel(
     plural = keywords["kernel_crd_plural"]
     custom_resource_object = yaml.safe_load(custom_resource_yaml)
     if not isinstance(custom_resource_object, dict) or "kind" not in custom_resource_object:
-        sys.exit("ERROR - Rendered CRD manifest is not a valid single-document YAML - kernel launch terminating!")
+        sys.exit(
+            "ERROR - Rendered CRD manifest is not a valid single-document YAML - kernel launch terminating!"
+        )
     if group == "sparkoperator.k8s.io":
         extend_operator_env(custom_resource_object, "driver")
         extend_operator_env(custom_resource_object, "executor")


### PR DESCRIPTION
- Reduce cyclomatic complexity in MainKernelHandler.post by extracting _build_kernel_env and _build_kernel_headers helpers
- Avoid overwriting loop variable in _parse_prohibited_ids (PLW2901)
- Use raise-from-none pattern for re-raised ValueError (B904)
- Suppress false-positive S108 on injection test fixture string