### PR TITLE
Standardize Jupyter dependencies in kernel images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,18 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11"]
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           clean: true
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'
       - name: Display dependency info
         run: |
           python --version
@@ -84,7 +89,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
           ignore_links: |-
-            http://my-gateway-server\.com:8888|https://docs\.openshift\.com/.*|https://docs\.redhat\.com/.*
+            http://my-gateway-server\.com:8888|https://docs\.openshift\.com/.*|https://docs\.redhat\.com/.*|https://docs\.conda\.io/.*
 
   build_docs:
     runs-on: windows-latest

--- a/enterprise_gateway/itests/test_r_kernel.py
+++ b/enterprise_gateway/itests/test_r_kernel.py
@@ -34,7 +34,9 @@ class RKernelBaseTestCase(TestBase):
         self.assertTrue(self.kernel.restart())
 
         error_result, has_error = self.kernel.execute("y = x + 1")
-        self.assertRegex(error_result, "Error in eval")
+        # Match both legacy ("Error in eval(expr, envir, enclos): object 'x' not found")
+        # and modern ("Error: object 'x' not found") IRkernel error formats.
+        self.assertRegex(error_result, r"Error.*object 'x' not found")
         self.assertEqual(has_error, True)
 
     def test_interrupt(self):

--- a/etc/docker/demo-base/Dockerfile
+++ b/etc/docker/demo-base/Dockerfile
@@ -99,6 +99,12 @@ USER root
 
 RUN conda install mamba -n base -c conda-forge && \
     mamba install --yes --quiet -c conda-forge \
+    # # ipykernel 7 has asyncio rewrite affecting kernels to become idle
+    'ipykernel<7' \
+    # # cap kernel-side jupyter stack for fleet convergence
+    # 'jupyter_client<9' \
+    # 'jupyter_server<3' \
+    # 'pyzmq<28' \
     'jupyter' \
     'r-devtools' \
     'r-stringr' \

--- a/etc/docker/demo-base/README.md
+++ b/etc/docker/demo-base/README.md
@@ -1,15 +1,14 @@
 # What this image Gives You
 
-- Ubuntu base image : bionic
-- Hadoop 2.7.7
-- Apache Spark 2.4.6
-- Java 1.8 runtime
-- Mini-conda latest (python 3.11) with R packages
-- Toree 0.4.0-incubating
-- `jovyan` service user, with system users `elyra`, `bob`, and `alice`. The jovyan uid is `1000` to match other jupyter
-  images.
-- Password-less ssh for service user
-- Users have HDFS folder setup at startup
+- Debian-based miniconda image (`continuumio/miniconda3:24.1.2-0`)
+- Hadoop `3.3.1`
+- Apache Spark `3.2.1` — version controlled by `SPARK_VERSION` in the top-level `Makefile` (currently `3.2.1`);
+- OpenJDK 11 runtime (`openjdk-11-jdk-headless`)
+- miniconda 24.1.2 (Python 3.11) with R packages (`r-devtools`, `r-stringr`, `r-argparse`)
+- Apache Toree `0.5.0-incubating`
+- `jovyan` service user (UID `1000`, matching upstream Jupyter images), with system users `elyra`, `bob`, and `alice`
+- Password-less SSH for the `jovyan` service user
+- HDFS home directories created at container startup for each system user
 
 # Basic Use
 
@@ -17,3 +16,7 @@ As of the 0.9.0 release of [Jupyter Enterprise Gateway](https://github.com/jupyt
 this image can be started as a separate YARN cluster to better demonstrate remote kernel capabilities. See section
 [Dual Mode](https://hub.docker.com/r/elyra/enterprise-gateway/#dual_mode) on the enterprise-gateway page for command
 usage.
+
+# Pinned dependencies
+
+This image's conda/mamba environment pins `ipykernel<7` to keep kernel idle/busy transitions working under the Enterprise Gateway process-proxy model.

--- a/etc/docker/enterprise-gateway-demo/Dockerfile
+++ b/etc/docker/enterprise-gateway-demo/Dockerfile
@@ -1,7 +1,7 @@
 ARG HUB_ORG
 ARG SPARK_VERSION
 
-ARG BASE_CONTAINER=${HUB_ORG}/demo-base:${SPARK_VERSION}
+ARG BASE_CONTAINER=${HUB_ORG}/demo-base@sha256:080d9e9411b722f1afb333c767c9f28bb831f7055a37da7a11b12170a158e6d9
 FROM $BASE_CONTAINER
 
 # An ARG declared before a FROM is outside of a build stage,
@@ -17,7 +17,9 @@ USER $NB_USER
 
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp/
-RUN pip install /tmp/jupyter_enterprise_gateway*.whl
+# ipykernel 7 has asyncio rewrite affecting kernels to become idle
+RUN pip install --upgrade "ipykernel<7" && \
+    pip install /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway_kernelspecs*.tar.gz /usr/local/share/jupyter/kernels/
 

--- a/etc/docker/enterprise-gateway-demo/README.md
+++ b/etc/docker/enterprise-gateway-demo/README.md
@@ -1,10 +1,13 @@
 Built on [elyra/demo-base](https://hub.docker.com/r/elyra/demo-base/), this image adds support for [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) to better demonstrate running Python, R and Scala kernels in YARN-cluster mode.
 
+The base image is referenced by digest (`elyra/demo-base@sha256:080d9e94…`) rather than by the mutable `:3.2.1` tag, so this image's contents stay reproducible even if the upstream tag is rebuilt. To pick up an updated `demo-base`, bump the digest in `etc/docker/enterprise-gateway-demo/Dockerfile` deliberately and re-run the integration suite (`make itest-yarn-debug`) before merging.
+
 # What it Gives You
 
 - [elyra/demo-base](https://hub.docker.com/r/elyra/demo-base/) base functionality
-- [Jupyter Enterprise Gateway](https://github.com/jupyter-incubator/enterprise_gateway)
+- [Jupyter Enterprise Gateway](https://github.com/jupyter-server/enterprise_gateway)
 - Python/R/Toree kernels that target YARN-cluster mode
+- `ipykernel<7` is pinned ahead of the wheel install to prevent ipykernel 7.x's asyncio rewrite from breaking kernel idle-state transitions
 
 # Basic Use
 

--- a/etc/docker/enterprise-gateway/Dockerfile
+++ b/etc/docker/enterprise-gateway/Dockerfile
@@ -34,7 +34,9 @@ RUN curl -s https://archive.apache.org/dist/spark/spark-${SPARK_VER}/spark-${SPA
 
 # Install Enterprise Gateway wheel and kernelspecs
 COPY jupyter_enterprise_gateway*.whl /tmp/
-RUN pip install /tmp/jupyter_enterprise_gateway*.whl && \
+# ipykernel 7 has asyncio rewrite affecting kernels to become idle
+RUN pip install --upgrade "ipykernel<7" && \
+    pip install /tmp/jupyter_enterprise_gateway*.whl && \
 	rm -f /tmp/jupyter_enterprise_gateway*.whl
 
 ADD jupyter_enterprise_gateway_kernelspecs*.tar.gz /usr/local/share/jupyter/kernels/

--- a/etc/docker/enterprise-gateway/README.md
+++ b/etc/docker/enterprise-gateway/README.md
@@ -1,4 +1,4 @@
-This image adds support for [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster. It is currently built on jupyter/minimal-notebook as a base with Apache Spark 2.4.6 installed on top.
+This image adds support for [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster. It is built on `jupyter/minimal-notebook:2023-03-13` and installs Apache Spark `3.2.1`.
 
 **Note: If you're looking for the YARN-based image of this name, it has been moved to [elyra/enterprise-gateway-demo](https://hub.docker.com/r/elyra/enterprise-gateway-demo/).**
 
@@ -6,6 +6,7 @@ This image adds support for [Jupyter Enterprise Gateway](https://jupyter-enterpr
 
 - [Jupyter Enterprise Gateway](https://github.com/jupyter-server/enterprise_gateway)
 - Python/R/Toree kernels that can be launched and distributed across a managed cluster.
+- `ipykernel<7` is pinned before the Enterprise Gateway wheel install to keep kernel idle/busy transitions working under the process-proxy model
 
 # Basic Use
 

--- a/etc/docker/kernel-image-puller/README.md
+++ b/etc/docker/kernel-image-puller/README.md
@@ -19,6 +19,8 @@ There are a few points of configuration listed below - all of which are environm
 - `KIP_NUM_PULLERS` (`2`)
 - `KIP_NUM_RETRIES` (`3`)
 - `KIP_PULL_POLICY` (`IfNotPresent`)
-- `KIP_IMAGE_FETCHER` (`KernelSpecsFetcher`)
+- `KIP_IMAGE_FETCHER` (`KernelSpecsFetcher`) — default applied by `kernel_image_puller.py` via `os.getenv()`; not set as a Dockerfile `ENV`, so override at runtime with `-e KIP_IMAGE_FETCHER=…`.
+
+The image bundles `crictl` from the Kubic repositories so it can pull kernel images on Kubernetes nodes that use containerd or CRI-O instead of Docker.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).

--- a/etc/docker/kernel-py/Dockerfile
+++ b/etc/docker/kernel-py/Dockerfile
@@ -5,7 +5,13 @@ FROM $BASE_CONTAINER
 ENV PATH=$PATH:$CONDA_DIR/bin
 
 # Add debugger support
-RUN pip install --upgrade ipykernel
+# ipykernel 7 has asyncio rewrite affecting kernels to become idle
+# jupyter_client/server/pyzmq capped to converge with the rest of the fleet
+RUN pip install --upgrade \
+    "ipykernel<7" \
+    "jupyter_client<9" \
+    "jupyter_server<3" \
+    "pyzmq<28"
 
 RUN conda install --quiet --yes \
     cffi \

--- a/etc/docker/kernel-py/README.md
+++ b/etc/docker/kernel-py/README.md
@@ -12,3 +12,12 @@ Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) 
 Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).
+
+# Pinned dependencies
+
+This image installs the IPython kernel with the following upper bounds, applied to keep kernel runtime behavior consistent across the kernel image fleet:
+
+- `ipykernel<7` — ipykernel 7.x rewrote the asyncio integration in a way that prevents kernels from transitioning to the `idle` state under Enterprise Gateway's process-proxy model.
+- `jupyter_client<9`, `jupyter_server<3`, `pyzmq<28` — held in lockstep with `ipykernel<7` so the Jupyter messaging layer stays on a known-compatible API surface across all kernel images.
+
+Bumping any of these caps requires re-running `make itest-yarn-debug` against the integration suite to confirm `test_interrupt`, `test_restart`, and the kernel idle/busy transitions still behave correctly.

--- a/etc/docker/kernel-r/Dockerfile
+++ b/etc/docker/kernel-r/Dockerfile
@@ -3,6 +3,12 @@ ARG BASE_CONTAINER=quay.io/jupyter/r-notebook:r-4.5.2
 FROM $BASE_CONTAINER
 
 RUN conda install --quiet --yes \
+    # ipykernel 7 has asyncio rewrite affecting kernels to become idle
+    'ipykernel<7' \
+    # cap kernel-side jupyter stack for fleet convergence
+    'jupyter_client<9' \
+    'jupyter_server<3' \
+    'pyzmq<28' \
     'r-argparse' \
     pycryptodomex && \
     conda clean --all && \

--- a/etc/docker/kernel-r/README.md
+++ b/etc/docker/kernel-r/README.md
@@ -11,3 +11,12 @@ Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) 
 Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).
+
+# Pinned dependencies
+
+This image installs IRKernel and the supporting Jupyter messaging stack with the following upper bounds, applied to keep kernel runtime behavior consistent across the kernel image fleet:
+
+- `ipykernel<7` — ipykernel 7.x rewrote the asyncio integration in a way that prevents kernels from transitioning to the `idle` state under Enterprise Gateway's process-proxy model.
+- `jupyter_client<9`, `jupyter_server<3`, `pyzmq<28` — held in lockstep with `ipykernel<7` so the Jupyter messaging layer stays on a known-compatible API surface across all kernel images.
+
+Bumping any of these caps requires re-running `make itest-yarn-debug` against the integration suite to confirm `test_interrupt`, `test_restart`, and the kernel idle/busy transitions still behave correctly.

--- a/etc/docker/kernel-scala/README.md
+++ b/etc/docker/kernel-scala/README.md
@@ -1,4 +1,4 @@
-This image enables the use of a Scala ([Apache Toree](https://toree.apache.org/)) kernel launched from [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster. It is built on [elyra/spark:v2.4.6](https://hub.docker.com/r/elyra/spark/) deriving from the [Apache Spark 2.4.6 release](https://spark.apache.org/docs/2.4.6/). Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
+This image enables the use of a Scala ([Apache Toree](https://toree.apache.org/)) kernel launched from [Jupyter Enterprise Gateway](http://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster. It is built on `elyra/spark` — the Spark version is controlled by `SPARK_VERSION` in the top-level `Makefile` (currently `3.2.1`). Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
 
 # What it Gives You
 

--- a/etc/docker/kernel-spark-py/README.md
+++ b/etc/docker/kernel-spark-py/README.md
@@ -1,10 +1,11 @@
-This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster. It is built on the base image [elyra/kernel-py](https://hub.docker.com/r/elyra/kernel-py/), and adds [Apache Spark 2.4.6](https://spark.apache.org/docs/2.4.6/). Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster. It is built on the base image [elyra/kernel-py](https://hub.docker.com/r/elyra/kernel-py/) and adds Apache Spark — the Spark version is controlled by `SPARK_VERSION` in the top-level `Makefile` (currently `3.2.1`). Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
 
 # What it Gives You
 
 - IPython kernel support (with debugger)
 - [Data science libraries](https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook)
 - Spark on kubernetes support from within a Jupyter Notebook
+- OpenJDK 8 runtime (`openjdk-8-jdk`), required by the bundled Apache Spark distribution
 
 # Basic Use
 

--- a/etc/docker/kernel-spark-r/README.md
+++ b/etc/docker/kernel-spark-r/README.md
@@ -1,9 +1,10 @@
-This image enables the use of an IRKernel kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster. It is built on the base image [elyra/kernel-r](https://hub.docker.com/r/elyra/kernel-r/), and adds [Apache Spark 2.4.6](https://spark.apache.org/docs/2.4.6/). Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
+This image enables the use of an IRKernel kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes cluster. It is built on the base image [elyra/kernel-r](https://hub.docker.com/r/elyra/kernel-r/) and adds Apache Spark — the Spark version is controlled by `SPARK_VERSION` in the top-level `Makefile` (currently `3.2.1`). Note: The ability to use the kernel within Spark within a Docker Swarm configuration probably won't yield the expected results.
 
 # What it Gives You
 
 - IRkernel kernel support
 - Spark on kubernetes support from within a Jupyter Notebook
+- OpenJDK 8 runtime (`openjdk-8-jdk`), required by the bundled Apache Spark distribution
 
 # Basic Use
 

--- a/etc/docker/kernel-tf-gpu-py/Dockerfile
+++ b/etc/docker/kernel-tf-gpu-py/Dockerfile
@@ -1,5 +1,5 @@
-# Ubuntu:xenial
-ARG BASE_CONTAINER=tensorflow/tensorflow:2.9.1-gpu
+# Ubuntu 22.04, Python 3.10, CUDA 12.3
+ARG BASE_CONTAINER=tensorflow/tensorflow:2.20.0-gpu
 FROM $BASE_CONTAINER
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -9,12 +9,21 @@ RUN apt-get update && apt-get install -yq \
     libsm6 \
     libxext-dev \
     libxrender1 \
-    netcat \
     python3-dev \
+    python3-pip \
     tzdata \
     unzip && \
     rm -rf /var/lib/apt/lists/* && \
-    pip install --upgrade future pycryptodomex ipykernel
+    # apt's python3.10 upgrade wipes the TF-bundled pip; python3-pip above
+    # provides Ubuntu's pip compatible with the upgraded interpreter
+    # ipykernel 7 has asyncio rewrite affecting kernels to become idle
+    # jupyter_client/server/pyzmq capped to converge with the rest of the fleet
+    python3 -m pip install --upgrade \
+        future pycryptodomex \
+        "ipykernel<7" \
+        "jupyter_client<9" \
+        "jupyter_server<3" \
+        "pyzmq<28"
 
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 

--- a/etc/docker/kernel-tf-gpu-py/README.md
+++ b/etc/docker/kernel-tf-gpu-py/README.md
@@ -1,4 +1,15 @@
-This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations. It is currently built on [tensorflow/tensorflow:2.7.0-gpu-jupyter](https://hub.docker.com/r/tensorflow/tensorflow/) deriving from the [tensorflow](https://github.com/tensorflow/tensorflow) project.
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations. It is currently built on [tensorflow/tensorflow:2.20.0-gpu](https://hub.docker.com/r/tensorflow/tensorflow/) deriving from the [tensorflow](https://github.com/tensorflow/tensorflow) project.
+
+# Base image
+
+Built on `tensorflow/tensorflow:2.20.0-gpu`, which provides:
+
+- Ubuntu 22.04
+- Python 3.10
+- CUDA 12.3
+- TensorFlow 2.20 with GPU support
+
+The image installs `python3-pip` from Ubuntu's apt repositories because `apt-get install python3-dev` shadows the `pip` shipped inside the TensorFlow base image; `python3 -m pip` is then used for all subsequent Python installs in the Dockerfile.
 
 # What it Gives You
 
@@ -11,3 +22,12 @@ Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) 
 Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).
+
+# Pinned dependencies
+
+This image installs the IPython kernel with the following upper bounds, applied to keep kernel runtime behavior consistent across the kernel image fleet:
+
+- `ipykernel<7` — ipykernel 7.x rewrote the asyncio integration in a way that prevents kernels from transitioning to the `idle` state under Enterprise Gateway's process-proxy model.
+- `jupyter_client<9`, `jupyter_server<3`, `pyzmq<28` — held in lockstep with `ipykernel<7` so the Jupyter messaging layer stays on a known-compatible API surface across all kernel images.
+
+Bumping any of these caps requires re-running `make itest-yarn-debug` against the integration suite to confirm `test_interrupt`, `test_restart`, and the kernel idle/busy transitions still behave correctly.

--- a/etc/docker/kernel-tf-py/Dockerfile
+++ b/etc/docker/kernel-tf-py/Dockerfile
@@ -6,6 +6,14 @@ FROM $BASE_CONTAINER
 
 ENV KERNEL_LANGUAGE=python
 
+# ipykernel 7 has asyncio rewrite affecting kernels to become idle
+# jupyter_client/server/pyzmq capped to converge with the rest of the fleet
+RUN pip install --upgrade \
+    "ipykernel<7" \
+    "jupyter_client<9" \
+    "jupyter_server<3" \
+    "pyzmq<28"
+
 ADD jupyter_enterprise_gateway_kernel_image_files*.tar.gz /usr/local/bin/
 
 RUN conda install --quiet --yes \

--- a/etc/docker/kernel-tf-py/README.md
+++ b/etc/docker/kernel-tf-py/README.md
@@ -1,4 +1,4 @@
-This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations. It is currently built on the [jupyter/tensorflow-notebook](https://hub.docker.com/r/jupyter/tensorflow-notebook) image deriving from the [jupyter/tensorflow-notebook](https://github.com/jupyter/docker-stacks/tree/main/images/tensorflow-notebook) project.
+This image enables the use of an IPython kernel launched from [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/) within a Kubernetes or Docker Swarm cluster that can perform Tensorflow operations. It is built on `jupyter/tensorflow-notebook:2023-10-20` (from the [jupyter/docker-stacks](https://github.com/jupyter/docker-stacks/tree/main/images/tensorflow-notebook) project); refer to that image's release notes for the bundled TensorFlow version.
 
 # What it Gives You
 
@@ -11,3 +11,12 @@ Deploy [enterprise-gateway](https://hub.docker.com/r/elyra/enterprise-gateway/) 
 Launch a gateway-enabled Jupyter Notebook application against the Enterprise Gateway instance and pick the desired kernel to use in your notebook.
 
 For more information, check our [repo](https://github.com/jupyter-server/enterprise_gateway) and [docs](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/).
+
+# Pinned dependencies
+
+This image installs the IPython kernel with the following upper bounds, applied to keep kernel runtime behavior consistent across the kernel image fleet:
+
+- `ipykernel<7` — ipykernel 7.x rewrote the asyncio integration in a way that prevents kernels from transitioning to the `idle` state under Enterprise Gateway's process-proxy model.
+- `jupyter_client<9`, `jupyter_server<3`, `pyzmq<28` — held in lockstep with `ipykernel<7` so the Jupyter messaging layer stays on a known-compatible API surface across all kernel images.
+
+Bumping any of these caps requires re-running `make itest-yarn-debug` against the integration suite to confirm `test_interrupt`, `test_restart`, and the kernel idle/busy transitions still behave correctly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "pycryptodomex>=3.9.7",
   "pyzmq>=20.0,<25.0",  # Pyzmq 25 removes deprecated code that jupyter_client 6 uses, remove if v6 gets updated
   "requests>=2.14.2",
-  "tornado>=6.1",
+  "tornado>=6.1,<7.0",
   "traitlets>=5.3.0",
   "watchdog>=2.1.3",
   "yarn-api-client>=1.0"
@@ -57,7 +57,7 @@ test = [
   "coverage",
   "pytest<8.1.0",
   "pytest-tornasync",
-  "ipykernel",
+  "ipykernel>=6.29,<7",  # ipykernel 7 has asyncio rewrite affecting kernels to become idle
   "pre-commit",
   "websocket-client"
 ]

--- a/requirements.yml
+++ b/requirements.yml
@@ -16,14 +16,14 @@ dependencies:
   - python-kubernetes>=18.20.0
   - pyzmq>=20.0.0,<25 # Pyzmq 25 removes deprecated code that jupyter_client 6 uses, remove if v6 gets updated
   - requests>=2.14.2
-  - tornado>=6.1
+  - tornado>=6.1,<7
   - traitlets>=5.3.0
   - watchdog>=2.1.3
   - yarn-api-client>=1.0
 
   # Test Requirements
   - coverage
-  - ipykernel
+  - ipykernel>=6.29,<7  # ipykernel 7 has asyncio rewrite affecting kernels to become idle
   - mock
   - pytest<8.1.0
   - pytest-tornasync


### PR DESCRIPTION
Fix kernel-not-becoming-idle bug caused by ipykernel 7.x's asyncio rewrite silently dropping shell messages signed by EG's jupyter_client 6.1.12 sessions. Symptom: kernels accept the connection, emit iopub_welcome, then never reply to kernel_info_request from EG.

Pin ipykernel<7 in every kernel and demo image. Add convergence caps for jupyter_client<9, jupyter_server<3, and pyzmq<28 so all kernel images align on jupyter_client 8.8.0 / jupyter_server 2.18.2 / pyzmq 27.1.0 instead of inheriting whatever each base image's snapshot happens to ship.

Bump kernel-tf-gpu-py base from tensorflow/tensorflow:2.9.1-gpu (Python 3.8, EOL Oct 2024) to 2.20.0-gpu (Python 3.11, CUDA 12.x). Drop unused netcat; add python3-pip to survive Ubuntu 22.04's libpython3.10 upgrade wiping TF's bundled pip.

Tighten EG-runtime caps in pyproject.toml / requirements.yml: add tornado<7 and ipykernel>=6.29,<7 (test extra) to match what kernel images install at runtime.

enterprise-gateway and enterprise-gateway-demo retain wheel-imposed caps (jupyter_client 6.1.12, jupyter_server 1.24.0, pyzmq 24.0.1) and stay unchanged on those packages.