### PR TITLE
Clarify client vs. server authentication in user docs

### DIFF
--- a/docs/source/users/connecting-to-eg.md
+++ b/docs/source/users/connecting-to-eg.md
@@ -1,4 +1,4 @@
-# Connecting the server to Enterprise Gateway
+# Connecting JupyterLab or Jupyter Notebook to Enterprise Gateway
 
 To leverage the benefits of Enterprise Gateway, it's helpful to redirect a Jupyter server's kernel management to the Gateway server. This allows better separation of the user's notebooks from the managed computer cluster (Kubernetes, Hadoop YARN, Docker Swarm, etc.) on which Enterprise Gateway resides. A Jupyter server can be configured to relay kernel requests to an Enterprise Gateway server in several ways.
 
@@ -7,7 +7,24 @@ To leverage the benefits of Enterprise Gateway, it's helpful to redirect a Jupyt
 To instruct the server to connect to an Enterprise Gateway instance running on host `<EG_HOST_IP>` on port `<EG_PORT>`, the following command line options can be used:
 
 ```bash
-jupyter lab --gateway-url=http://<EG_HOST_IP>:<EG_PORT> --GatewayClient.http_user=guest --GatewayClient.http_pwd=guest-password
+jupyter lab --gateway-url=http://<EG_HOST_IP>:<EG_PORT>
+```
+
+**With HTTP Basic authentication**
+
+```bash
+jupyter lab --gateway-url=http://<EG_HOST_IP>:<EG_PORT> --GatewayClient.http_user=<username> --GatewayClient.http_pwd=<password>
+```
+
+```{admonition} These are the *client's* credentials, not a Gateway account
+:class: important
+`<username>` and `<password>` are the HTTP Basic Auth credentials that **the Jupyter
+Server hosting your JupyterLab/Notebook sends to** Enterprise Gateway on each request.
+They are **not** a built-in Gateway account, and there are no default login credentials — both
+options default to `None` (no `Authorization` header is sent). A stock Enterprise
+Gateway server does **not** validate these values; whether they are enforced is an
+*operator* decision. See [Authenticating to Enterprise Gateway](#authenticating-to-enterprise-gateway)
+below and [Configuring security](../operators/config-security.md).
 ```
 
 ## Configuration file
@@ -18,8 +35,8 @@ In your `jupyter_server_config.py` file add the following for the equivalent opt
 
 ```python
 c.GatewayClient.url = "http://<EG_HOST_IP>:<EG_PORT>"
-c.GatewayClient.http_user = "guest"
-c.GatewayClient.http_pwd = "guest-password"
+c.GatewayClient.http_user = "<username>"
+c.GatewayClient.http_pwd = "<password>"
 ```
 
 ## Docker image
@@ -29,8 +46,8 @@ All GatewayClient options have corresponding environment variable support, so if
 ```bash
 docker run -t --rm \
   -e JUPYTER_GATEWAY_URL='http://<EG_HOST_IP>:<EG_PORT>' \
-  -e JUPYTER_GATEWAY_HTTP_USER=guest \
-  -e JUPYTER_GATEWAY_HTTP_PWD=guest-password \
+  -e JUPYTER_GATEWAY_HTTP_USER=<username> \
+  -e JUPYTER_GATEWAY_HTTP_PWD=<password> \
   -e LOG_LEVEL=DEBUG \
   -p 8888:8888 \
   -v ${HOME}/notebooks/:/tmp/notebooks \
@@ -39,6 +56,62 @@ docker run -t --rm \
 ```
 
 Notebook files residing in `${HOME}/notebooks` can then be accessed via `http://localhost:8888`.
+
+## Authenticating to Enterprise Gateway
+
+A common point of confusion is _which side_ owns the credentials shown above.
+Enterprise Gateway itself performs **no user authentication by default** — it assumes
+requests have already been authenticated upstream (for example, by
+[Apache Knox](https://knox.apache.org/) or
+[JupyterHub](https://jupyterhub.readthedocs.io/en/latest/)). The `GatewayClient`
+options simply control what credentials the Jupyter server _presents_ on each request;
+whether those credentials are enforced is entirely an operator decision.
+
+The diagram below shows where each option applies:
+
+```{mermaid}
+flowchart LR
+    subgraph client["Jupyter Server (client)"]
+        lab["JupyterLab / Notebook<br/>(frontend)"]
+        GC["GatewayClient<br/>http_user / http_pwd<br/>auth_token / auth_scheme"]
+    end
+    subgraph proxy["Optional proxy"]
+        P["Validates<br/>Basic Auth"]
+    end
+    subgraph eg["Enterprise Gateway (server)"]
+        subgraph server["Jupyter Server (server)"]
+            T["EG_AUTH_TOKEN gate"]
+            K["Kernel launch<br/>KERNEL_USERNAME → authorization"]
+        end
+    end
+    lab --> GC
+    GC -- "Authorization header" --> P
+    P --> T
+    T --> K
+```
+
+The Gateway client can attach the following to each request:
+
+- **HTTP Basic Auth** — `http_user` / `http_pwd` (env: `JUPYTER_GATEWAY_HTTP_USER` /
+  `JUPYTER_GATEWAY_HTTP_PWD`). Both default to `None`. Enterprise Gateway does **not**
+  validate these itself; they are only meaningful when a proxy in front of the Gateway
+  (such as Knox) checks them. There is no built-in `guest` / `guest-password` account.
+- **Bearer / token auth** — `auth_token` and optional `auth_scheme` (env:
+  `JUPYTER_GATEWAY_AUTH_TOKEN` / `JUPYTER_GATEWAY_AUTH_SCHEME`) send an
+  `Authorization: {auth_scheme} {auth_token}` header. To have the Gateway server
+  _enforce_ a token, the operator sets `EG_AUTH_TOKEN` (or
+  `c.EnterpriseGatewayApp.auth_token`) on the server; requests then require a matching
+  `Authorization: token <value>` header (or `?token=<value>`) and are rejected with
+  HTTP 401 otherwise.
+- **KERNEL_USERNAME** — conveys the already-authenticated user's identity for
+  _authorization_ (allowed/blocked users) and _impersonation_ at kernel launch. This is
+  an identity, not a secret.
+
+```{seealso}
+Operators configuring what the Gateway server actually enforces should refer to
+[Configuring security](../operators/config-security.md), which covers `EG_AUTH_TOKEN`,
+`KERNEL_USERNAME`-based authorization, impersonation, and SSL/TLS.
+```
 
 ## Connection Timeouts
 

--- a/docs/source/users/index.rst
+++ b/docs/source/users/index.rst
@@ -12,7 +12,7 @@ Because Enterprise Gateway is a headless web server, it is typically accessed fr
 The following assumes an Enterprise Gateway server has been configured and deployed.  Please consult the `operators <../operators/index.html>`_ documentation to deploy and configure the Enterprise Gateway server.
 
 .. note::
-  There are two primary client applications that can use Enterprise Gateway, JupyterLab running on Jupyter Server and Jupyter Notebook.  When a reference to a *Jupyter server* (lowercase 'server') or *the server* is made, the reference applies to both Jupyter Server and Jupyter Notebook.  Generally speaking, the client-side behaviors are identical between the two, although references to Jupyter Server are preferred since it's more current.  If anything is different, that difference will be noted, otherwise, please assume discussion of the two are interchangeable.
+  There are two primary client applications that can use Enterprise Gateway, JupyterLab and Jupyter Notebook where both are running on top of Jupyter Server.  Generally speaking, the client-side behaviors are identical between the two, although references to Jupyter Server are preferred since it's more current.  If anything is different, that difference will be noted, otherwise, please assume discussion of the two are interchangeable.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/users/installation.md
+++ b/docs/source/users/installation.md
@@ -1,7 +1,7 @@
 # Installing the client
 
 In terms of Enterprise Gateway, the client application is typically JupyterLab or Jupyter Notebook which has an embedded Jupyter Server.
-These applications are then configured to connect to Enterprise Gateway and delegate the kernel management operations to the Gateway server [See Connecting to EG for more details](connecting-to-eg.html).
+These applications are then configured to connect to Enterprise Gateway and delegate the kernel management operations to the Gateway server ([see Connecting to EG for more details](connecting-to-eg.md)).
 
 To install Jupyter Server via `pip`:
 

--- a/docs/source/users/installation.md
+++ b/docs/source/users/installation.md
@@ -1,7 +1,7 @@
 # Installing the client
 
-In terms of Enterprise Gateway, the client application is typically JupyterLab or Jupyter Notebook which has an embedded Jupyter Server. 
-These applications are then configured to connect to Enterprise Gateway and delegate the kernel management operations to the Gateway server [See Connecting to EG for more details](connecting-to-eg.html). 
+In terms of Enterprise Gateway, the client application is typically JupyterLab or Jupyter Notebook which has an embedded Jupyter Server.
+These applications are then configured to connect to Enterprise Gateway and delegate the kernel management operations to the Gateway server [See Connecting to EG for more details](connecting-to-eg.html).
 
 To install Jupyter Server via `pip`:
 

--- a/docs/source/users/installation.md
+++ b/docs/source/users/installation.md
@@ -1,17 +1,18 @@
 # Installing the client
 
-In terms of Enterprise Gateway, the client application is typically Jupyter Server (hosting JupyterLab) or Jupyter Notebook. These applications are then configured to connect to Enterprise Gateway.
+In terms of Enterprise Gateway, the client application is typically JupyterLab or Jupyter Notebook which has an embedded Jupyter Server. 
+These applications are then configured to connect to Enterprise Gateway and delegate the kernel management operations to the Gateway server [See Connecting to EG for more details](connecting-to-eg.html). 
 
 To install Jupyter Server via `pip`:
 
 ```bash
-pip install jupyter_server
+pip install jupyterlab
 ```
 
 or via `conda`:
 
 ```bash
-conda install -c conda-forge jupyter_server
+conda install -c conda-forge jupyterlab
 ```
 
 Likewise, for Jupyter Notebook via `pip`:
@@ -26,4 +27,4 @@ or via `conda`:
 conda install -c conda-forge notebook
 ```
 
-For additional information regarding the installation of [Jupyter Server](https://jupyter-server.readthedocs.io/en/latest/index.html) or [Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/latest/), please refer to their respective documentation (see embedded links).
+For additional information regarding the installation of [JupyterLab](https://jupyterlab.readthedocs.io/en/latest/getting_started/overview.html) or [Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/latest/), please refer to their respective documentation (see embedded links).


### PR DESCRIPTION
Users frequently assume Enterprise Gateway ships with a default "guest" / "guest-password" account and look for a server-side way to change it. In reality, http_user/http_pwd are the *client's* HTTP Basic Auth credentials, both default to None, and a stock Gateway server does not validate them at all.

Reduce this confusion in the Users Guide:

- Replace the literal guest/guest-password example values with <username>/<password> placeholders so they no longer read as defaults.
- Add an "Authenticating to Enterprise Gateway" section explaining that the Gateway performs no user authentication by default, and describing the three request-auth mechanisms (Basic Auth, bearer/auth_token gated by EG_AUTH_TOKEN, and KERNEL_USERNAME identity), with a Mermaid diagram showing where each option applies.
- Split the connect example into an unauthenticated form and an explicit HTTP Basic authentication form to show credentials are optional.
- Clarify in the Users Guide index and client installation pages that JupyterLab and Jupyter Notebook both run on top of Jupyter Server.

Fixes #1444